### PR TITLE
[#10] Do not use VM during packaging

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -39,32 +39,18 @@ let
     gitRevision = babylonnet.rev;
   };
 
-  buildDeb = import ./packageDeb.nix { inherit stdenv writeTextFile; };
+  buildDeb = import ./packageDeb.nix { inherit stdenv writeTextFile dpkg; };
   buildRpm = packageDesc:
-    import ./packageRpm.nix { inherit stdenv writeTextFile; }
-    (packageDesc // { arch = "x86_64"; });
+    import ./packageRpm.nix { inherit stdenv writeTextFile rpm buildFHSUserEnv; }
+      (packageDesc // { arch = "x86_64"; });
 
-  inherit (vmTools)
-    makeImageFromDebDist makeImageFromRPMDist debDistros rpmDistros
-    runInLinuxImage;
-  ubuntuImage = makeImageFromDebDist debDistros.ubuntu1804x86_64;
-  fedoraImage = makeImageFromRPMDist rpmDistros.fedora27x86_64;
+  mainnet-rpm-package = buildRpm packageDesc-mainnet;
 
-  mainnet-rpm-package = runInLinuxImage
-    ((buildRpm packageDesc-mainnet).packageRpm // { diskImage = fedoraImage; });
+  mainnet-deb-package = buildDeb packageDesc-mainnet;
 
-  mainnet-deb-package = runInLinuxImage
-    ((buildDeb packageDesc-mainnet).packageDeb // { diskImage = ubuntuImage; });
+  babylonnet-rpm-package = buildRpm packageDesc-babylonnet;
 
-  babylonnet-rpm-package = runInLinuxImage
-    ((buildRpm packageDesc-babylonnet).packageRpm // {
-      diskImage = fedoraImage;
-    });
-
-  babylonnet-deb-package = runInLinuxImage
-    ((buildDeb packageDesc-babylonnet).packageDeb // {
-      diskImage = ubuntuImage;
-    });
+  babylonnet-deb-package = buildDeb packageDesc-babylonnet;
 
   tezos-client-mainnet = stdenv.mkDerivation rec {
     name = "tezos-client-mainnet-${mainnet.rev}";

--- a/packageDeb.nix
+++ b/packageDeb.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ stdenv, writeTextFile }:
+{ stdenv, writeTextFile, dpkg }:
 pkgDesc:
 
 let
@@ -26,23 +26,23 @@ let
     '';
   };
 
-in rec {
-  packageDeb =
-    stdenv.mkDerivation {
-      name = "${pkgName}.deb";
+in stdenv.mkDerivation rec {
+  name = "${pkgName}.deb";
 
-      phases = "packagePhase";
+  nativeBuildInputs = [ dpkg ];
 
-      packagePhase = ''
-        mkdir ${pkgName}
-        mkdir -p ${pkgName}/usr/local/bin
-        cp ${bin} ${pkgName}/usr/local/bin/${project}
+  phases = "packagePhase";
 
-        mkdir ${pkgName}/DEBIAN
-        cp ${writeControlFile} ${pkgName}/DEBIAN/control
+  packagePhase = ''
+    mkdir ${pkgName}
+    mkdir -p ${pkgName}/usr/local/bin
+    cp ${bin} ${pkgName}/usr/local/bin/${project}
 
-        dpkg-deb --build ${pkgName}
-        cp ${pkgName}.deb $out
-      '';
-    };
+    mkdir ${pkgName}/DEBIAN
+    cp ${writeControlFile} ${pkgName}/DEBIAN/control
+
+    dpkg-deb --build ${pkgName}
+    mkdir -p $out
+    cp ${name} $out/
+  '';
 }


### PR DESCRIPTION
## Description
Problem: Currently we run linux VM in order to generate .deb or .rpm
package. However, this is slow and consumes a lot of resoures.

Solution: Run `dpkg-deb` and `rpmbuild` directly in nix.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Maybe _resolves_ #10 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
