### PR TITLE
[#14] Rename repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Reporting Issues
 
-Please [open an issue](https://github.com/serokell/tezos-client/issues/new/choose)
+Please [open an issue](https://github.com/serokell/tezos-packaging/issues/new/choose)
 if you find a bug or have a feature request.
 Before submitting a bug report or feature request, check to make sure it hasn't already been submitted
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
    - SPDX-License-Identifier: MPL-2.0
    -->
 
-# `tezos-client`
+# Tezos packaging
 
-[![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg)](https://buildkite.com/serokell/tezos-client)
+[![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg)](https://buildkite.com/serokell/tezos-packaging?branch=master)
+
+This repo provides various form of distribution for tezos-related executables
+(unfortunately, only `tezos-client` for now, see [this issue](https://github.com/serokell/tezos-packaging/issues/14)).
 
 `tezos-client` is CLI tool used for interaction with Tezos blockchain.
 This repo contains nix expression for building staticically linked
@@ -68,7 +71,7 @@ such package the command `tezos-client-mainnet` or `tezos-client-babylonnet` wil
 ## Obtain binary or packages from CI
 
 If you don't want to build these files from scratch, you can download artifacts
-produced by the CI. Go to the [latest master build](https://buildkite.com/serokell/tezos-client-packaging/builds/latest?branch=master),
+produced by the CI. Go to the [latest master build](https://buildkite.com/serokell/tezos-packaging/builds/latest?branch=master),
 click on `build and package` stage, choose `Artifacts` section and download files by clcking on the filenames.
 
 ## Ubuntu (Debian based distros) usage


### PR DESCRIPTION
## Description
Problem: We are going to package other tezos-related binaries as well,
thus `tezos-client-packaging` is not the best name for repo.

Solution: Rename it once again, now to `tezos-packaging`

Also pipeline on buildkite was renamed
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

~Resolves~ Relates #14
https://issues.serokell.io/issue/OPS-901
#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
