### PR TITLE
[#14] Package more tezos binaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,10 +17,8 @@ steps:
  - commands:
    - nix-build -A mainnet-binaries -o mainnet-binaries
    - nix-build -A babylonnet-binaries -o babylonnet-binaries
-   - nix-build -A mainnet-rpm-package -o mainnet-rpm-package --arg timestamp ${cur_date}
-   - nix-build -A mainnet-deb-package -o mainnet-deb-package --arg timestamp ${cur_date}
-   - nix-build -A babylonnet-rpm-package -o babylonnet-rpm-package --arg timestamp ${cur_date}
-   - nix-build -A babylonnet-deb-package -o babylonnet-deb-package --arg timestamp ${cur_date}
+   - nix-build -A deb-packages -o deb-packages --arg timestamp ${cur_date}
+   - nix-build -A rpm-packages -o rpm-packages --arg timestamp ${cur_date}
    label: build and package
    artifact_paths:
      - ./mainnet-binaries/*
@@ -29,6 +27,8 @@ steps:
      - ./mainnet-deb-package/*
      - ./babylonnet-rpm-package/*
      - ./babylonnet-deb-package/*
+     - ./deb-packages/*
+     - ./rpm-packages/*
    branches: !master
  - commands:
    - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,16 +15,16 @@ steps:
    label: crossref-verify
    soft_fail: true
  - commands:
-   - nix-build -A tezos-client-mainnet -o tezos-client-mainnet
-   - nix-build -A tezos-client-babylonnet -o tezos-client-babylonnet
+   - nix-build -A mainnet-binaries -o mainnet-binaries
+   - nix-build -A babylonnet-binaries -o babylonnet-binaries
    - nix-build -A mainnet-rpm-package -o mainnet-rpm-package --arg timestamp ${cur_date}
    - nix-build -A mainnet-deb-package -o mainnet-deb-package --arg timestamp ${cur_date}
    - nix-build -A babylonnet-rpm-package -o babylonnet-rpm-package --arg timestamp ${cur_date}
    - nix-build -A babylonnet-deb-package -o babylonnet-deb-package --arg timestamp ${cur_date}
    label: build and package
    artifact_paths:
-     - ./tezos-client-mainnet/*
-     - ./tezos-client-babylonnet/*
+     - ./mainnet-binaries/*
+     - ./babylonnet-binaries/*
      - ./mainnet-rpm-package/*
      - ./mainnet-deb-package/*
      - ./babylonnet-rpm-package/*

--- a/Makefile
+++ b/Makefile
@@ -3,33 +3,16 @@
 # SPDX-License-Identifier: MPL-2.0
 ts := $(shell date +"%Y%m%d%H%M")
 
-binary:
-		nix-build -A tezos-client-babylonnet -o tezos-client
-		cp tezos-client/tezos-client-babylonnet-* tezos-client-babylonnet
-		rm tezos-client
+.PHONY: binaries binaries-mainnet rpm-packages deb-packages
 
-binary-mainnet:
-		nix-build -A tezos-client-mainnet -o tezos-client
-		cp tezos-client/tezos-client-mainnet-* ./tezos-client-mainnet
-		rm tezos-client
+binaries:
+		cp $(shell nix-build -A babylonnet-binaries --no-out-link)/* ./
 
-rpm:
-		nix-build -A babylonnet-rpm-package -o tezos-client-package --arg timestamp $(ts)
-		cp -a tezos-client-package/*.rpm .
-		rm tezos-client-package
+binaries-mainnet:
+		cp $(shell nix-build -A mainnet-binaries --no-out-link)/* ./
 
-rpm-mainnet:
-		nix-build -A mainnet-rpm-package -o tezos-client-package --arg timestamp $(ts)
-		cp -a tezos-client-package/*.rpm .
-		rm tezos-client-package
+rpm-packages:
+		nix-build -A rpm-packages -o rpm-packages --arg timestamp $(ts)
 
-deb:
-		nix-build -A babylonnet-deb-package -o tezos-client-package --arg timestamp $(ts)
-		cp -a tezos-client-package/*.deb .
-		rm tezos-client-package
-
-deb-mainnet:
-		nix-build -A mainnet-deb-package -o tezos-client-package --arg timestamp $(ts)
-		cp -a tezos-client-package/*.deb .
-		rm tezos-client-package
-
+deb-packages:
+		nix-build -A deb-packages -o deb-packages --arg timestamp $(ts)

--- a/README.md
+++ b/README.md
@@ -9,103 +9,43 @@
 [![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg?branch=master)](https://buildkite.com/serokell/tezos-packaging)
 
 This repo provides various form of distribution for tezos-related executables
-(unfortunately, only `tezos-client` for now, see [this issue](https://github.com/serokell/tezos-packaging/issues/14)).
+(`tezos-client`, `tezos-client-admin`, `tezos-node`, `tezos-baker`,
+`tezos-accuser`, `tezos-endorser`, `tezos-signer` and `tezos-protocol-compiler`).
 
-`tezos-client` is CLI tool used for interaction with Tezos blockchain.
-This repo contains nix expression for building staticically linked
-tezos-client binaries that can be used with remote tezos nodes without
-using `babylonnet.sh` or `mainnet.sh` scripts.
+## Obtain binaries or packages from github release
 
-## Build Instructions
-
-### Statically built binary
-
-Run one of the following commands:
-```
-nix-build -A tezos-client-mainnet -o tezos-client
-nix-build -A tezos-client-babylonnet -o tezos-client
-```
-
-Or use Makefile:
-```bash
-make binary #build tezos-client-babylonnet
-make binary-mainnet #build tezos-client-mainnet
-```
-
-To build `mainnet` or `babylonnet` versions of `tezos-client` executable
-
-### Ubuntu `.deb` package
-
-Run one of the following commands:
-```
-nix-build -A mainnet-deb-package -o tezos-client-package --arg timestamp $(date +"%Y%m%d%H%M")
-nix-build -A babylonnet-deb-package -o tezos-client-package --arg timestamp $(date +"%Y%m%d%H%M")
-```
-
-Or use Makefile:
-```bash
-make deb #build deb package with tezos-client-babylonnet
-make deb-mainnet #build deb package with tezos-client-mainnet
-```
-
-To build `.deb` package with `mainnet` or `babylonnet` `tezos-client` executable. Once you install
-such package the command `tezos-client-mainnet` or `tezos-client-babylonnet` will be available.
-
-### Fedora `.rpm` package
-
-Run one of the following commands:
-```
-nix-build -A mainnet-rpm-package -o tezos-client-package --arg timestamp $(date +"%Y%m%d%H%M")
-nix-build -A babylonnet-rpm-package -o tezos-client-package --arg timestamp $(date +"%Y%m%d%H%M")
-```
-
-Or use Makefile:
-```bash
-make rpm #build rpm package with tezos-client-babylonnet
-make rpm-mainnet #build rpm package with tezos-client-mainnet
-```
-
-To build `.rpm` package with `mainnet` or `babylonnet` `tezos-client` executable. Once you install
-such package the command `tezos-client-mainnet` or `tezos-client-babylonnet` will be available.
-
-## Obtain binary or packages from github release
-
-If you don't want to build these files from scratch, you can download assets from github release.
+Recomended way to get these binaries is to download them from assets from github release.
 Go to the [latest release](https://github.com/serokell/tezos-packaging/releases/latest)
 and download desired assets.
 
 ## Ubuntu (Debian based distros) usage
 
-### Install `.deb` package
+### Use PPA with `tezos-*` binaries
 
-Build or download `.deb` file from the CI and double-click on it or run:
-```
-sudo apt install <path to deb file>
-```
-
-### Use PPA with `tezos-client`
-
-Also if you are using Ubuntu you can use PPA in order to install `tezos-client`.
-In order to do that run the following commands:
+If you are using Ubuntu you can use PPA in order to install `tezos-*` executables.
+E.g, in order to do install `tezos-client` run the following commands:
 ```
 sudo add-apt-repository ppa:serokell/tezos && sudo apt-get update
 sudo apt-get install tezos-client-mainnet
 sudo apt-get install tezos-client-babylonnet
 ```
+Once you install such packages the commands `tezos-*` will be available.
+
+### Install `.deb` package locally
+
+As an alternative, you can download `.deb` file from release assets
+(they are located in `deb-packages.tar.gz` archive) and double-click on it or run:
+```
+sudo apt install <path to deb file>
+```
 
 ## Fedora (Red Hat) usage
 
+### Use copr package with `tezos-*` binaries
 
-### Install `.rpm` package
-
-Build or download `.rpm` file from the CI and double-click on it or run:
-```
-sudo yum localinstall <path to the rpm file>
-```
-### Use copr package with `tezos-client`
-
-Also if you are using Fedora you can use Copr in order to install `tezos-client`.
-In order to do that run the following commands:
+If you are using Fedora you can use Copr in order to install `tezos-*`
+executables.
+E.g. in order to install `tezos-client` run the following commands:
 ```
 # use dnf
 sudo dnf copr enable @Serokell/Tezos
@@ -117,10 +57,22 @@ sudo yum copr enable @Serokell/Tezos
 sudo yum install tezos-client-mainnet
 sudo yum install tezos-client-babylonnet
 ```
+Once you install such packages the commands `tezos-*` will be available.
+
+### Install `.rpm` package
+
+As an alternative, you can download `.rpm` file from release assets
+(they are located in `rpm-packages.tar.gz` archive) and double-click on it or run:
+```
+sudo yum localinstall <path to the rpm file>
+```
 
 ## Other Linux distros usage
 
-Build static `tezos-client` binary or download it from the CI.
+Download binaries from release assets.
+
+### `tezos-client` example
+
 Make it executable:
 ```
 chmod +x tezos-client
@@ -128,11 +80,56 @@ chmod +x tezos-client
 
 Run `./tezos-client` or add it to your PATH to be able to run it anywhere.
 
-## `tezos-client` usage
+## Build Instructions
 
-Run `tezos-client [global options] command [command options]`.
+Also, you can build all these binaries and packages from scratch using nix.
 
-Run `tezos-client man` to get more information.
+### Statically built binaries
+
+Run one of the following commands:
+```
+nix-build -A babylonnet-binaries -o babylonnet-binaries
+nix-build -A mainnet-binaries -o mainnet-binaries
+```
+
+Or use Makefile:
+```bash
+make binaries #build babylonnet version of binaries
+make binaries-mainnet #build mainnet version of binaries
+```
+
+To produce `tar.gz` archive with `babylonnet` or `mainnet` version of tezos
+binaries.
+
+### Ubuntu `.deb` packages
+
+Run the following command:
+```
+nix-build -A deb-packages -o deb-packages --arg timestamp $(date +"%Y%m%d%H%M")
+```
+
+Or use Makefile:
+```bash
+make deb-packages #build deb package
+```
+
+To build `.deb` packages with `mainnet` or `babylonnet` version of tezos
+binaries.
+
+### Fedora `.rpm` packages
+
+Run one of the following commands:
+```
+nix-build -A rpm-packages -o rpm-packages --arg timestamp $(date +"%Y%m%d%H%M")
+```
+
+Or use Makefile:
+```bash
+make rpm-packages #build rpm packages
+```
+
+To build `.rpm` packages with `mainnet` or `babylonnet` version of tezos
+binaries.
 
 ## For Contributors
 

--- a/default.nix
+++ b/default.nix
@@ -10,18 +10,19 @@ let
     rev = "94f779a7";
     sha256 = "16lxilng5q8fr2ll6h4hf7wlvac6nmw4cx10cbgzj5ks090bl97r";
     patchFile = ./nix/fix-mainnet.patch;
+    protoName = "proto_005_PsBabyM1";
   };
   babylonnet = {
     rev = "b8731913";
     sha256 = "1pakf1s6bg76fq42mb8fj1immz9g9wwimd522cpx8k28zf0hkl5i";
     patchFile = ./nix/fix-babylonnet.patch;
+    protoName = "proto_005_PsBabyM1";
   };
-  tezos-client-static-mainnet = import ./nix/static.nix mainnet;
-  tezos-client-static-babylonnet = import ./nix/static.nix babylonnet;
-  binary-mainnet = "${tezos-client-static-mainnet}/bin/tezos-client";
-  binary-babylonnet = "${tezos-client-static-babylonnet}/bin/tezos-client";
-  # Hopefully, there will always be a single LICENSE for all binaries and branches
-  licenseFile = "${tezos-client-static-mainnet}/LICENSE";
+  static-nix = import ./nix/static.nix;
+  tezos-static-mainnet = static-nix mainnet;
+  tezos-static-babylonnet = static-nix babylonnet;
+  binary-mainnet = "${tezos-static-mainnet}/bin/tezos-client";
+  binary-babylonnet = "${tezos-static-babylonnet}/bin/tezos-client";
   packageDesc-mainnet = {
     inherit licenseFile;
     project = "tezos-client-mainnet";
@@ -82,6 +83,7 @@ let
   };
 
 in rec {
-  inherit tezos-client-mainnet tezos-client-babylonnet mainnet-deb-package
-    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package tezos-license;
+  inherit
+    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package tezos-license
+    tezos-static-mainnet tezos-static-babylonnet;
 }

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,23 @@ let
   static-nix = import ./nix/static.nix;
   tezos-static-mainnet = static-nix mainnet;
   tezos-static-babylonnet = static-nix babylonnet;
+
+  packDirectory = archiveName: pathToPack:
+    stdenv.mkDerivation rec {
+      name = "${archiveName}.tar.gz";
+      phases = "archivePhase";
+      nativeBuildInputs = [ gnutar ];
+      archivePhase = ''
+        mkdir -p $out
+        tar -cvzf $out/${name} --mode='u+rwX' -C ${pathToPack} $(ls ${pathToPack})
+      '';
+    };
+  mainnet-binaries = packDirectory "mainnet-binaries-${mainnet.rev}"
+    "${tezos-static-mainnet}/bin";
+  babylonnet-binaries =
+    packDirectory "babylonnet-binaries-${babylonnet.rev}"
+    "${tezos-static-babylonnet}/bin";
+
   binary-mainnet = "${tezos-static-mainnet}/bin/tezos-client";
   binary-babylonnet = "${tezos-static-babylonnet}/bin/tezos-client";
   packageDesc-mainnet = {
@@ -86,6 +103,6 @@ let
 
 in rec {
   inherit
-    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package tezos-license
-    tezos-static-mainnet tezos-static-babylonnet;
+    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package
+    mainnet-binaries babylonnet-binaries;
 }

--- a/default.nix
+++ b/default.nix
@@ -36,10 +36,10 @@ let
         tar -cvzf $out/${name} --mode='u+rwX' -C ${pathToPack} $(ls ${pathToPack})
       '';
     };
-  mainnet-binaries = packDirectory "mainnet-binaries-${mainnet.rev}"
+  mainnet-binaries = packDirectory "binaries-mainnet-${mainnet.rev}"
     "${tezos-static-mainnet}/bin";
   babylonnet-binaries =
-    packDirectory "babylonnet-binaries-${babylonnet.rev}"
+    packDirectory "binaries-babylonnet-${babylonnet.rev}"
     "${tezos-static-babylonnet}/bin";
   licenseFile = "${tezos-static-mainnet}/LICENSE";
 

--- a/default.nix
+++ b/default.nix
@@ -6,17 +6,19 @@ with pkgs;
 
 let
   root = ./.;
-  mainnet = {
+  mainnet = rec {
     rev = "94f779a7";
     sha256 = "16lxilng5q8fr2ll6h4hf7wlvac6nmw4cx10cbgzj5ks090bl97r";
     patchFile = ./nix/fix-mainnet.patch;
-    protoName = "proto_005_PsBabyM1";
+    protoName = "005_PsBabyM1";
+    binarySuffix = builtins.replaceStrings ["_"] ["-"] protoName;
   };
-  babylonnet = {
+  babylonnet = rec {
     rev = "b8731913";
     sha256 = "1pakf1s6bg76fq42mb8fj1immz9g9wwimd522cpx8k28zf0hkl5i";
     patchFile = ./nix/fix-babylonnet.patch;
-    protoName = "proto_005_PsBabyM1";
+    protoName = "005_PsBabyM1";
+    binarySuffix = builtins.replaceStrings ["_"] ["-"] protoName;
   };
   static-nix = import ./nix/static.nix;
   tezos-static-mainnet = static-nix mainnet;

--- a/default.nix
+++ b/default.nix
@@ -6,19 +6,21 @@ with pkgs;
 
 let
   root = ./.;
-  mainnet = rec {
+  protocol005 = rec {
+    protocolName = "005_PsBabyM1";
+    binarySuffix = builtins.replaceStrings [ "_" ] [ "-" ] protocolName;
+  };
+  mainnet = {
     rev = "94f779a7";
     sha256 = "16lxilng5q8fr2ll6h4hf7wlvac6nmw4cx10cbgzj5ks090bl97r";
     patchFile = ./nix/fix-mainnet.patch;
-    protoName = "005_PsBabyM1";
-    binarySuffix = builtins.replaceStrings ["_"] ["-"] protoName;
+    protocol = protocol005;
   };
-  babylonnet = rec {
+  babylonnet = {
     rev = "b8731913";
     sha256 = "1pakf1s6bg76fq42mb8fj1immz9g9wwimd522cpx8k28zf0hkl5i";
     patchFile = ./nix/fix-babylonnet.patch;
-    protoName = "005_PsBabyM1";
-    binarySuffix = builtins.replaceStrings ["_"] ["-"] protoName;
+    protocol = protocol005;
   };
   static-nix = import ./nix/static.nix;
   tezos-static-mainnet = static-nix mainnet;
@@ -39,59 +41,70 @@ let
   babylonnet-binaries =
     packDirectory "babylonnet-binaries-${babylonnet.rev}"
     "${tezos-static-babylonnet}/bin";
+  licenseFile = "${tezos-static-mainnet}/LICENSE";
 
-  binary-mainnet = "${tezos-static-mainnet}/bin/tezos-client";
-  binary-babylonnet = "${tezos-static-babylonnet}/bin/tezos-client";
-  packageDesc-mainnet = {
-    inherit licenseFile;
-    project = "tezos-client-mainnet";
-    version = toString timestamp;
-    bin = binary-mainnet;
-    arch = "amd64";
-    license = "MIT";
-    dependencies = "";
-    maintainer = "Serokell https://serokell.io";
-    description = "CLI client for interacting with tezos blockchain";
-    gitRevision = mainnet.rev;
-    branchName = "mainnet";
-  };
+  mkPackageDescs = { executableName, binPath, description }@executableDesc:
+    let
+      mainnetDesc = {
+        inherit description;
+        bin = "${tezos-static-mainnet}/${binPath}";
+        gitRevision = mainnet.rev;
+        project = "${executableName}-mainnet";
+        version = toString timestamp;
+        arch = "amd64";
+        license = "MPL-2.0";
+        dependencies = "";
+        maintainer = "Serokell https://serokell.io";
+        licenseFile = "${tezos-static-mainnet}/LICENSE";
+        branchName = "mainnet";
+      };
+      babylonnetDesc = mainnetDesc // {
+        bin = "${tezos-static-babylonnet}/${binPath}";
+        project = "${executableName}-babylonnet";
+        gitRevision = babylonnet.rev;
+        branchName = "babylonnet";
+      };
+    in [ mainnetDesc babylonnetDesc ];
 
-  packageDesc-babylonnet = packageDesc-mainnet // {
-    project = "tezos-client-babylonnet";
-    bin = binary-babylonnet;
-    gitRevision = babylonnet.rev;
-    branchName = "babylonnet";
-  };
+  tezos-executables = [
+    {
+      executableName = "tezos-client";
+      binPath = "/bin/tezos-client";
+      description = "CLI client for interacting with tezos blockchain";
+    }
+    {
+      executableName = "tezos-admin-client";
+      binPath = "/bin/tezos-admin-client";
+      description = "Administration tool for the node";
+    }
+    {
+      executableName = "tezos-node";
+      binPath = "/bin/tezos-node";
+      description =
+        "Entry point for initializing, configuring and running a Tezos node";
+    }
+    {
+      executableName = "tezos-baker";
+      binPath = "/bin/tezos-baker-${protocol005.binarySuffix}";
+      description = "Daemon for baking";
+    }
+    {
+      executableName = "tezos-accuser";
+      binPath = "/bin/tezos-accuser-${protocol005.binarySuffix}";
+      description = "Daemon for accusing";
+    }
+    {
+      executableName = "tezos-endorser";
+      binPath = "/bin/tezos-endorser-${protocol005.binarySuffix}";
+      description = "Daemon for endorsing";
+    }
+    {
+      executableName = "tezos-signer";
+      binPath = "/bin/tezos-signer";
+      description = "A client to remotely sign operations or blocks";
+    }
+  ];
 
-  buildDeb = import ./packageDeb.nix { inherit stdenv writeTextFile dpkg; };
-  buildRpm = packageDesc:
-  import ./packageRpm.nix { inherit stdenv writeTextFile gnutar rpm buildFHSUserEnv; }
-    (packageDesc // { arch = "x86_64"; });
-
-  mainnet-rpm-package = buildRpm packageDesc-mainnet;
-
-  mainnet-deb-package = buildDeb packageDesc-mainnet;
-
-  babylonnet-rpm-package = buildRpm packageDesc-babylonnet;
-
-  babylonnet-deb-package = buildDeb packageDesc-babylonnet;
-
-  tezos-client-mainnet = stdenv.mkDerivation rec {
-    name = "tezos-client-mainnet-${mainnet.rev}";
-    phases = "copyPhase";
-    copyPhase = ''
-      mkdir -p $out
-      cp ${binary-mainnet} $out/${name}
-    '';
-  };
-  tezos-client-babylonnet = stdenv.mkDerivation rec {
-    name = "tezos-client-babylonnet-${babylonnet.rev}";
-    phases = "copyPhase";
-    copyPhase = ''
-      mkdir -p $out
-      cp ${binary-babylonnet} $out/${name}
-    '';
-  };
   tezos-license = stdenv.mkDerivation rec {
     name = "LICENSE";
     phases = "copyPhase";
@@ -101,8 +114,29 @@ let
     '';
   };
 
+  packageDescs = lib.flatten (map mkPackageDescs tezos-executables);
+
+  buildDeb = import ./packageDeb.nix { inherit stdenv writeTextFile dpkg; };
+  buildRpm = packageDesc:
+    import ./packageRpm.nix {
+      inherit stdenv writeTextFile gnutar rpm buildFHSUserEnv;
+    } (packageDesc // { arch = "x86_64"; });
+
+  moveDerivations = name: drvs:
+    stdenv.mkDerivation rec {
+      inherit name drvs;
+
+      buildCommand = ''
+        mkdir -p $out
+        for drv in $drvs; do
+          cp $drv/* $out
+        done
+      '';
+    };
+
+  deb-packages = moveDerivations "deb-packages" (map buildDeb packageDescs);
+  rpm-packages = moveDerivations "rpm-packages" (map buildRpm packageDescs);
+
 in rec {
-  inherit
-    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package
-    mainnet-binaries babylonnet-binaries;
+  inherit deb-packages rpm-packages mainnet-binaries babylonnet-binaries tezos-license;
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -336,6 +336,7 @@ let
           dune build src/proto_${branchInfo.protoName}/bin_baker/tezos-baker-${branchInfo.binarySuffix}.install
           dune build src/proto_${branchInfo.protoName}/bin_accuser/tezos-accuser-${branchInfo.binarySuffix}.install
           dune build src/proto_${branchInfo.protoName}/bin_endorser/tezos-endorser-${branchInfo.binarySuffix}.install
+          dune build src/bin_signer/tezos-signer.install
         '';
         installPhase = ''
           mkdir -p $out/bin
@@ -353,6 +354,8 @@ let
           # tezos-endorser
           cp _build/default/src/proto_${branchInfo.protoName}/bin_endorser/main_endorser_${branchInfo.protoName}.exe \
           $out/bin/tezos-endorser-${branchInfo.binarySuffix}
+          # tezos-signer
+          cp _build/default/src/bin_signer/main_signer.exe $out/bin/tezos-signer
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -343,7 +343,7 @@ let
           mkdir -p $out/bin
           # tezos-client and tezos-admin
           cp _build/default/src/bin_client/main_client.exe $out/bin/tezos-client
-          cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-client-admin
+          cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-admin-client
           # tezos-node
           cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
           # tezos-baker

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -333,7 +333,7 @@ let
           PATH=$PATH:${ocp-ocamlres}/lib/ocaml/4.07.1/bin
           dune build src/bin_client/tezos-client.install
           dune build src/bin_node/tezos-node.install
-          # dune build src/${branchInfo.protoName}/bin_baker/tezos-baker.install
+          dune build src/proto_${branchInfo.protoName}/bin_baker/tezos-baker-${branchInfo.binarySuffix}.install
         '';
         installPhase = ''
           mkdir -p $out/bin
@@ -343,7 +343,7 @@ let
           # tezos-node
           cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
           # tezos-baker
-          # cp _build/default/src/${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe $out/bin/tezos-baker
+          cp _build/default/src/proto_${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe $out/bin/tezos-baker-${branchInfo.binarySuffix}
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -335,6 +335,7 @@ let
           dune build src/bin_node/tezos-node.install
           dune build src/proto_${branchInfo.protoName}/bin_baker/tezos-baker-${branchInfo.binarySuffix}.install
           dune build src/proto_${branchInfo.protoName}/bin_accuser/tezos-accuser-${branchInfo.binarySuffix}.install
+          dune build src/proto_${branchInfo.protoName}/bin_endorser/tezos-endorser-${branchInfo.binarySuffix}.install
         '';
         installPhase = ''
           mkdir -p $out/bin
@@ -344,9 +345,14 @@ let
           # tezos-node
           cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
           # tezos-baker
-          cp _build/default/src/proto_${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe $out/bin/tezos-baker-${branchInfo.binarySuffix}
+          cp _build/default/src/proto_${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe \
+          $out/bin/tezos-baker-${branchInfo.binarySuffix}
           # tezos-accuser
-          cp _build/default/src/proto_${branchInfo.protoName}/bin_accuser/main_accuser_${branchInfo.protoName}.exe $out/bin/tezos-accuser-${branchInfo.binarySuffix}
+          cp _build/default/src/proto_${branchInfo.protoName}/bin_accuser/main_accuser_${branchInfo.protoName}.exe \
+          $out/bin/tezos-accuser-${branchInfo.binarySuffix}
+          # tezos-endorser
+          cp _build/default/src/proto_${branchInfo.protoName}/bin_endorser/main_endorser_${branchInfo.protoName}.exe \
+          $out/bin/tezos-endorser-${branchInfo.binarySuffix}
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -229,13 +229,56 @@ let
           };
           propagatedBuildInputs = [ fmt astring ];
         }) { };
+    pprint = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, ocamlbuild }:
+        buildDunePackage rec {
+          pname = "pprint";
+          version = "20180528";
+
+          minimumOCamlVersion = "4.03";
+          src = fetchFromGitHub {
+            owner = "fpottier";
+            repo = "${pname}";
+            rev = "${version}";
+            sha256 = "1jhmmd7ik1lx9y5niqv5rknhq02pkwmyxc5c0wndp5cyp8hsj0py";
+          };
+          buildInputs = [ ocamlbuild ];
+          buildPhase = "";
+          installPhase = ''
+            mkdir -p $out/lib/ocaml/4.07.1/site-lib
+            make install
+          '';
+          doCheck = false;
+        }) { };
+    ocp-ocamlres = self.callPackage
+      ({ stdenv, fetchFromGitHub, buildDunePackage, pprint, astring, base }:
+        buildDunePackage rec {
+          pname = "ocp-ocamlres";
+          version = "0.4";
+
+          minimumOCamlVersion = "4.03";
+          src = fetchFromGitHub {
+            owner = "OCamlPro";
+            repo = "${pname}";
+            rev = "v${version}";
+            sha256 = "0smfwrj8qhzknhzawygxi0vgl2af4vyi652fkma59rzjpvscqrnn";
+          };
+          buildInputs = [ pprint astring base ];
+          buildPhase = "";
+          installPhase = ''
+            mkdir -p $out/lib/ocaml/4.07.1/site-lib
+            mkdir -p $out/lib/ocaml/4.07.1/bin
+            make install
+          '';
+          doCheck = false;
+        }) { };
 
     tezos = self.callPackage ({ stdenv, fetchgit, buildDunePackage, base
       , bigstring, cohttp-lwt, cohttp-lwt-unix, cstruct, ezjsonm, hex, ipaddr
-      , js_of_ocaml, cmdliner, easy-format, ocp-ocamlres, tls, lwt4, lwt_log
+      , js_of_ocaml, cmdliner, easy-format, tls, lwt4, lwt_log
       , mtime, ocplib-endian, ptime, re, rresult, stdio, uri, uutf, zarith
-      , libusb1, hidapi, gmp, irmin, alcotest, dum, genspio, pprint, ocamlgraph
-      , findlib, digestif, upx }:
+      , libusb1, hidapi, gmp, irmin, alcotest, dum, genspio, ocamlgraph, findlib
+      , digestif, ocp-ocamlres, pprint, upx }:
       buildDunePackage rec {
         pname = "tezos";
         version = "0.0.1";
@@ -274,18 +317,33 @@ let
           stdio
           uri
           uutf
-          zarith # cmdliner easy-format js_of_ocaml ocp-ocamlres tls
+          zarith
+          cmdliner
+          # easy-format js_of_ocaml ocp-ocamlres tls
           # alcotest dum pprint
+          ocp-ocamlres
+          pprint
           ocamlgraph
           findlib
           genspio
         ] ++ [ libusb1 libusb1.out (gmp.override { withStatic = true; }) upx ];
         doCheck = false;
-        buildPhase = "dune build src/bin_client/tezos-client.install";
+        buildPhase = ''
+          # tezos-node build requires ocp-ocamlres binary in PATH
+          PATH=$PATH:${ocp-ocamlres}/lib/ocaml/4.07.1/bin
+          dune build src/bin_client/tezos-client.install
+          dune build src/bin_node/tezos-node.install
+          # dune build src/${branchInfo.protoName}/bin_baker/tezos-baker.install
+        '';
         installPhase = ''
           mkdir -p $out/bin
+          # tezos-client and tezos-admin
           cp _build/default/src/bin_client/main_client.exe $out/bin/tezos-client
-          cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-admin
+          cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-client-admin
+          # tezos-node
+          cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
+          # tezos-baker
+          # cp _build/default/src/${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe $out/bin/tezos-baker
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -333,9 +333,9 @@ let
           PATH=$PATH:${ocp-ocamlres}/lib/ocaml/4.07.1/bin
           dune build src/bin_client/tezos-client.install
           dune build src/bin_node/tezos-node.install
-          dune build src/proto_${branchInfo.protoName}/bin_baker/tezos-baker-${branchInfo.binarySuffix}.install
-          dune build src/proto_${branchInfo.protoName}/bin_accuser/tezos-accuser-${branchInfo.binarySuffix}.install
-          dune build src/proto_${branchInfo.protoName}/bin_endorser/tezos-endorser-${branchInfo.binarySuffix}.install
+          dune build src/proto_${branchInfo.protocol.protocolName}/bin_baker/tezos-baker-${branchInfo.protocol.binarySuffix}.install
+          dune build src/proto_${branchInfo.protocol.protocolName}/bin_accuser/tezos-accuser-${branchInfo.protocol.binarySuffix}.install
+          dune build src/proto_${branchInfo.protocol.protocolName}/bin_endorser/tezos-endorser-${branchInfo.protocol.binarySuffix}.install
           dune build src/bin_signer/tezos-signer.install
           dune build src/lib_protocol_compiler/tezos-protocol-compiler.install
         '';
@@ -347,14 +347,14 @@ let
           # tezos-node
           cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
           # tezos-baker
-          cp _build/default/src/proto_${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe \
-          $out/bin/tezos-baker-${branchInfo.binarySuffix}
+          cp _build/default/src/proto_${branchInfo.protocol.protocolName}/bin_baker/main_baker_${branchInfo.protocol.protocolName}.exe \
+          $out/bin/tezos-baker-${branchInfo.protocol.binarySuffix}
           # tezos-accuser
-          cp _build/default/src/proto_${branchInfo.protoName}/bin_accuser/main_accuser_${branchInfo.protoName}.exe \
-          $out/bin/tezos-accuser-${branchInfo.binarySuffix}
+          cp _build/default/src/proto_${branchInfo.protocol.protocolName}/bin_accuser/main_accuser_${branchInfo.protocol.protocolName}.exe \
+          $out/bin/tezos-accuser-${branchInfo.protocol.binarySuffix}
           # tezos-endorser
-          cp _build/default/src/proto_${branchInfo.protoName}/bin_endorser/main_endorser_${branchInfo.protoName}.exe \
-          $out/bin/tezos-endorser-${branchInfo.binarySuffix}
+          cp _build/default/src/proto_${branchInfo.protocol.protocolName}/bin_endorser/main_endorser_${branchInfo.protocol.protocolName}.exe \
+          $out/bin/tezos-endorser-${branchInfo.protocol.binarySuffix}
           # tezos-signer
           cp _build/default/src/bin_signer/main_signer.exe $out/bin/tezos-signer
           # tezos-protocol-compiler

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -334,6 +334,7 @@ let
           dune build src/bin_client/tezos-client.install
           dune build src/bin_node/tezos-node.install
           dune build src/proto_${branchInfo.protoName}/bin_baker/tezos-baker-${branchInfo.binarySuffix}.install
+          dune build src/proto_${branchInfo.protoName}/bin_accuser/tezos-accuser-${branchInfo.binarySuffix}.install
         '';
         installPhase = ''
           mkdir -p $out/bin
@@ -344,6 +345,8 @@ let
           cp _build/default/src/bin_node/main.exe $out/bin/tezos-node
           # tezos-baker
           cp _build/default/src/proto_${branchInfo.protoName}/bin_baker/main_baker_${branchInfo.protoName}.exe $out/bin/tezos-baker-${branchInfo.binarySuffix}
+          # tezos-accuser
+          cp _build/default/src/proto_${branchInfo.protoName}/bin_accuser/main_accuser_${branchInfo.protoName}.exe $out/bin/tezos-accuser-${branchInfo.binarySuffix}
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -337,6 +337,7 @@ let
           dune build src/proto_${branchInfo.protoName}/bin_accuser/tezos-accuser-${branchInfo.binarySuffix}.install
           dune build src/proto_${branchInfo.protoName}/bin_endorser/tezos-endorser-${branchInfo.binarySuffix}.install
           dune build src/bin_signer/tezos-signer.install
+          dune build src/lib_protocol_compiler/tezos-protocol-compiler.install
         '';
         installPhase = ''
           mkdir -p $out/bin
@@ -356,6 +357,8 @@ let
           $out/bin/tezos-endorser-${branchInfo.binarySuffix}
           # tezos-signer
           cp _build/default/src/bin_signer/main_signer.exe $out/bin/tezos-signer
+          # tezos-protocol-compiler
+          cp _build/default/src/lib_protocol_compiler/main_native.exe $out/bin/tezos-protocol-compiler
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
           # Compress binaries with upx

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -32,3 +32,19 @@ index 54920a2..8bd54be 100644
  
  (install
   (section bin)
+diff --git a/src/proto_005_PsBabyM1/bin_baker/dune b/src/proto_005_PsBabyM1/bin_baker/dune
+index 1414a08..12dba95 100644
+--- a/src/proto_005_PsBabyM1/bin_baker/dune
++++ b/src/proto_005_PsBabyM1/bin_baker/dune
+@@ -10,7 +10,10 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -80,4 +80,19 @@ index d1b60c7..a738ef2 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/bin_signer/dune b/src/bin_signer/dune
+index e4c9a7c..2a5f941 100644
+--- a/src/bin_signer/dune
++++ b/src/bin_signer/dune
+@@ -19,7 +19,10 @@
+                    -open Tezos_rpc_http_server
+                    -open Tezos_rpc_http_client_unix
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_stdlib)))
++                   -open Tezos_stdlib
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
   (name runtest_lint)

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -96,3 +96,16 @@ index e4c9a7c..2a5f941 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/lib_protocol_compiler/dune b/src/lib_protocol_compiler/dune
+index 1142419..d8086b4 100644
+--- a/src/lib_protocol_compiler/dune
++++ b/src/lib_protocol_compiler/dune
+@@ -65,7 +65,7 @@
+  (public_name tezos-protocol-compiler)
+  (modes native)
+  (libraries tezos_protocol_compiler_native)
+- (flags (:standard -linkall))
++ (flags (:standard -linkall -ccopt -static))
+  (modules Main_native))
+ 
+ (executable

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -48,3 +48,19 @@ index 1414a08..12dba95 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/proto_005_PsBabyM1/bin_accuser/dune b/src/proto_005_PsBabyM1/bin_accuser/dune
+index 2f2a6fd..fd9773b 100644
+--- a/src/proto_005_PsBabyM1/bin_accuser/dune
++++ b/src/proto_005_PsBabyM1/bin_accuser/dune
+@@ -10,7 +10,10 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -17,3 +17,18 @@ index 6bee8e98..53006632 100644
  
  (install
   (section bin)
+diff --git a/src/bin_node/dune b/src/bin_node/dune
+index 54920a2..8bd54be 100644
+--- a/src/bin_node/dune
++++ b/src/bin_node/dune
+@@ -28,7 +28,9 @@
+                    -open Tezos_validator
+                    -open Tezos_shell_context
+                    -open Tezos_protocol_updater
+-                   -linkall)))
++                   -linkall
++                   -ccopt -static
++                   )))
+ 
+ (install
+  (section bin)

--- a/nix/fix-babylonnet.patch
+++ b/nix/fix-babylonnet.patch
@@ -64,3 +64,20 @@ index 2f2a6fd..fd9773b 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/proto_005_PsBabyM1/bin_endorser/dune b/src/proto_005_PsBabyM1/bin_endorser/dune
+index d1b60c7..a738ef2 100644
+--- a/src/proto_005_PsBabyM1/bin_endorser/dune
++++ b/src/proto_005_PsBabyM1/bin_endorser/dune
+@@ -10,7 +10,10 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
+  (name runtest_lint)

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -64,6 +64,22 @@ index 173ab99..eae42b2 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/proto_005_PsBabyM1/bin_endorser/dune b/src/proto_005_PsBabyM1/bin_endorser/dune
+index 9df7abf..e8402b8 100644
+--- a/src/proto_005_PsBabyM1/bin_endorser/dune
++++ b/src/proto_005_PsBabyM1/bin_endorser/dune
+@@ -9,7 +9,10 @@
+                    -open Tezos_client_005_PsBabyM1
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -48,6 +48,22 @@ index 755e8d4..aeb8f2d 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/proto_005_PsBabyM1/bin_accuser/dune b/src/proto_005_PsBabyM1/bin_accuser/dune
+index 173ab99..eae42b2 100644
+--- a/src/proto_005_PsBabyM1/bin_accuser/dune
++++ b/src/proto_005_PsBabyM1/bin_accuser/dune
+@@ -9,7 +9,10 @@
+                    -open Tezos_client_005_PsBabyM1
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -32,6 +32,22 @@ index 54920a2..8bd54be 100644
  
  (install
   (section bin)
+diff --git a/src/proto_005_PsBabyM1/bin_baker/dune b/src/proto_005_PsBabyM1/bin_baker/dune
+index 755e8d4..aeb8f2d 100644
+--- a/src/proto_005_PsBabyM1/bin_baker/dune
++++ b/src/proto_005_PsBabyM1/bin_baker/dune
+@@ -9,7 +9,10 @@
+                    -open Tezos_client_005_PsBabyM1
+                    -open Tezos_client_commands
+                    -open Tezos_baking_005_PsBabyM1_commands
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -80,6 +80,22 @@ index 9df7abf..e8402b8 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/bin_signer/dune b/src/bin_signer/dune
+index c06413b..a81e206 100644
+--- a/src/bin_signer/dune
++++ b/src/bin_signer/dune
+@@ -18,7 +18,10 @@
+                    -open Tezos_rpc_http
+                    -open Tezos_rpc_http_server
+                    -open Tezos_rpc_http_client_unix
+-                   -open Tezos_stdlib_unix)))
++                   -open Tezos_stdlib_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -17,6 +17,21 @@ index f42b53e6..7e47c074 100644
  
  (install
   (section bin)
+diff --git a/src/bin_node/dune b/src/bin_node/dune
+index 54920a2..8bd54be 100644
+--- a/src/bin_node/dune
++++ b/src/bin_node/dune
+@@ -28,7 +28,9 @@
+                    -open Tezos_validator
+                    -open Tezos_shell_context
+                    -open Tezos_protocol_updater
+-                   -linkall)))
++                   -linkall
++                   -ccopt -static
++                   )))
+ 
+ (install
+  (section bin)
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/nix/fix-mainnet.patch
+++ b/nix/fix-mainnet.patch
@@ -96,6 +96,19 @@ index c06413b..a81e206 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/lib_protocol_compiler/dune b/src/lib_protocol_compiler/dune
+index 7d70857..9fbe9cc 100644
+--- a/src/lib_protocol_compiler/dune
++++ b/src/lib_protocol_compiler/dune
+@@ -64,7 +64,7 @@
+  (public_name tezos-protocol-compiler)
+  (modes native)
+  (libraries tezos_protocol_compiler_native)
+- (flags (:standard -linkall))
++ (flags (:standard -linkall -ccopt -static))
+  (modules Main_native))
+ 
+ (executable
 diff --git a/src/lib_base/p2p_addr.ml b/src/lib_base/p2p_addr.ml
 index d9139c4b..a3af815c 100644
 --- a/src/lib_base/p2p_addr.ml

--- a/packageRpm.nix
+++ b/packageRpm.nix
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ stdenv, writeTextFile, gnutar, rpm, buildFHSUserEnv }:
+{ stdenv, writeTextFile, gnutar, rpm, buildFHSUserEnv
+, buildSourcePackage ? false }:
 pkgDesc:
 
 let
@@ -62,6 +63,7 @@ let
   };
 
 in stdenv.mkDerivation rec {
+  rpmBuildFlag = if buildSourcePackage then "-ba" else "-bb";
   name = "${pkgName}.rpm";
 
   phases = "packagePhase";
@@ -78,9 +80,9 @@ in stdenv.mkDerivation rec {
     cp ${sourceArchive} SOURCES/${sourceArchive.name}
     mkdir -p BUILD/${project}
     cp ${licenseFile} BUILD/${project}/LICENSE
-    rpmbuild-env -ba SPECS/${project}.spec --define '_bindir /usr/bin' --define '_datadir /usr/share'
+    rpmbuild-env ${rpmBuildFlag} SPECS/${project}.spec --define '_bindir /usr/bin' --define '_datadir /usr/share'
     mkdir -p $out
-    cp SRPMS/*.src.rpm $out/
+    ${if buildSourcePackage then "cp SRPMS/*.src.rpm $out/" else ""}
     cp RPMS/*/*.rpm $out/
   '';
 

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p gitAndTools.hub git -i bash
+#!nix-shell -p gitAndTools.hub git rename -i bash
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
@@ -9,9 +9,27 @@ project=$(basename $(pwd))
 
 # The directory in which artifacts will be created
 TEMPDIR=`mktemp -d`
+assets_dir=$TEMPDIR/assets
 
 # Build release.nix
 nix-build release.nix -o $TEMPDIR/$project --arg timestamp $(date +\"%Y%m%d%H%M\")
+mkdir -p $assets_dir
+# Create archives with deb and rpm packages
+tar -cvzf $assets_dir/packages-deb.tar.gz --mode='u+rwX' -C $TEMPDIR/$project $(cd $TEMPDIR/$project && ls *.deb)
+tar -cvzf $assets_dir/packages-rpm.tar.gz --mode='u+rwX' -C $TEMPDIR/$project $(cd $TEMPDIR/$project && ls *.rpm)
+# Move these archives to assets
+cp $TEMPDIR/$project/*.tar.gz $assets_dir
+cp $TEMPDIR/$project/LICENSE $assets_dir
+# Unpack binaries
+mkdir -p $assets_dir/binaries-babylonnet $assets_dir/binaries-mainnet
+tar -C $assets_dir/binaries-mainnet -xvzf $TEMPDIR/$project/binaries-mainnet-*.tar.gz
+tar -C $assets_dir/binaries-babylonnet -xvzf $TEMPDIR/$project/binaries-babylonnet-*.tar.gz
+# Add corresponding babylonnet or mainnet suffixes
+rename 's/(.*)$/$1-babylonnet/' $assets_dir/binaries-babylonnet/*
+rename 's/(.*)$/$1-mainnet/' $assets_dir/binaries-mainnet/*
+# Move renamed binaries to assets
+mv $assets_dir/binaries-*/* $assets_dir/
+rm -r $assets_dir/*/
 
 # Delete release
 hub release delete auto-release
@@ -23,7 +41,7 @@ git push --force --tags
 
 # Combine all assets
 assets=""
-for file in $TEMPDIR/$project/*; do
+for file in $assets_dir/*; do
     assets+="-a $file "
 done
 


### PR DESCRIPTION
## Description
Tezos software includes more executables than just `tezos-client`. We want to package them as well.
For now, in this PR we only build static binaries for them 
(specifically `tezos-client`, `tezos-admin-client`, `tezos-node`, `tezos-baker`, `tezos-accuser`, `tezos-endorser`, `tezos-signer`, and `tezos-protocol-compiler`).

TODO:
~* Package them into `.deb` and `.rpm` as well as `tezos-client`.~
~* Update usage instructions.~
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Resolves #14

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
