### PR TITLE
[#19] Generate source packages using nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,13 @@ you can do this by running the following commands:
 ```
 nix-build -A deb-source-packages -o deb-source-packages \
 --arg builderInfo "\"Roman Melnikov <roman.melnikov@serokell.io>\"" \
---arg timestamp "$(date +\"%Y%m%d%H%M\")" --arg date "\"$(date -R)\""
+--arg timestamp "$(date +\"%Y%m%d%H%M\")" --arg date "\"$(date -R)\"" \
+--arg ubuntuVersion "\"bionic\""
 # Note that buildInfo should contain information about user how is capable
 # in publishing packages on PPA
+# Also you can specify ubuntu version you're building packages for.
+# "bionic" (18.04 LTS) is default version. Consider building packages
+# for "eoan" and "xenial" as well.
 
 # Copy files from /nix/store
 mkdir -p source-packages

--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ To build `.deb` packages with tezos binaries.
 Once you built them, you can install `.deb` packages using the following command:
 ```
 sudo apt install <path to deb file>
+
+### Publish packages on Launchpad PPA
+
+In order to publish packages on PPA you will have to build source packages,
+you can do this by running the following commands:
+```
+nix-build -A deb-source-packages -o deb-source-packages \
+--arg builderInfo "\"Roman Melnikov <roman.melnikov@serokell.io>\"" \
+--arg timestamp "$(date +\"%Y%m%d%H%M\")" --arg date "\"$(date -R)\""
+# Note that buildInfo should contain information about user how is capable
+# in publishing packages on PPA
+
+# Copy files from /nix/store
+mkdir -p source-packages
+cp deb-source-packages/* source-packages
+# Sign *.changes files with your gpg key, which should be known
+# for Launchpad
+debsign source-packages/*.changes
+# dput all packages to PPA repository
+dput ppa:serokell/tezos source-package/*.changes
 ```
 
 ### Fedora `.rpm` packages
@@ -139,6 +159,20 @@ Once you built them, you can install `.rpm` packages using the following command
 ```
 sudo yum localinstall <path to the rpm file>
 ```
+
+### Publish packages on Fedora Copr
+
+In order to publish packages on Copr you will have to build source packages,
+you can do this by running the following command:
+```
+nix-build -A rpm-source-packages -o rpm-source-packages \
+--arg timestamp "$(date +\"%Y%m%d%H%M\")"
+# Copy files from /nix/store
+mkdir -p source-packages
+cp rpm-source-packages/* source-packages
+```
+After this `source-packages` directory will contain `.src.rpm` packages which
+can be uploaded to Copr repository.
 
 ## For Contributors
 

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101"
-, date ? "Thu, 1 Jan 1970 10:00:00 +0300", builderInfo ? "", patches ? [] }:
+{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101", patches ? []
+, date ? "Thu, 1 Jan 1970 10:00:00 +0300", builderInfo ? ""
+, ubuntuVersion ? "bionic"}:
 with pkgs;
 
 let
@@ -115,7 +116,7 @@ let
     import ./packageSourceDeb.nix {
       inherit stdenv writeTextFile writeScript runCommand;
       inherit (lib) toLower;
-    } packageDesc { inherit date builderInfo; };
+    } packageDesc { inherit date builderInfo ubuntuVersion; };
   buildSourceRpm = packageDesc:
     import ./packageRpm.nix {
       inherit stdenv writeTextFile gnutar rpm buildFHSUserEnv;
@@ -142,11 +143,9 @@ let
   buildSourceDebInVM = pkgDesc:
     runInLinuxImage ((buildSourceDeb pkgDesc) // { diskImage = ubuntuImage; });
 
-  deb-source-packages =
-    moveDerivations (map buildSourceDebInVM packageDescs);
+  deb-source-packages = moveDerivations (map buildSourceDebInVM packageDescs);
 
-  rpm-source-packages =
-    moveDerivations (map buildSourceRpm packageDescs);
+  rpm-source-packages = moveDerivations (map buildSourceRpm packageDescs);
 
   releaseFile = writeTextFile {
     name = "release-notes.md";

--- a/packageRpm.nix
+++ b/packageRpm.nix
@@ -63,7 +63,7 @@ let
   };
 
 in stdenv.mkDerivation rec {
-  rpmBuildFlag = if buildSourcePackage then "-ba" else "-bb";
+  rpmBuildFlag = if buildSourcePackage then "-bs" else "-bb";
   name = "${pkgName}.rpm";
 
   phases = "packagePhase";
@@ -82,8 +82,7 @@ in stdenv.mkDerivation rec {
     cp ${licenseFile} BUILD/${project}/LICENSE
     rpmbuild-env ${rpmBuildFlag} SPECS/${project}.spec --define '_bindir /usr/bin' --define '_datadir /usr/share'
     mkdir -p $out
-    ${if buildSourcePackage then "cp SRPMS/*.src.rpm $out/" else ""}
-    cp RPMS/*/*.rpm $out/
+    ${if buildSourcePackage then "cp SRPMS/*.src.rpm $out/" else "cp RPMS/*/*.rpm $out/"}
   '';
 
 }

--- a/packageSourceDeb.nix
+++ b/packageSourceDeb.nix
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 { stdenv, writeTextFile, writeScript, runCommand, toLower }:
 pkgDesc:
-{ date, builderInfo }:
+{ date, builderInfo, ubuntuVersion }:
 
 let
   project = toLower pkgDesc.project;
@@ -37,7 +37,7 @@ let
   writeChangelogFile = writeTextFile {
     name = "changelog";
     text = ''
-      ${project} (0ubuntu${version}-${revision}) xenial; urgency=medium
+      ${project} (0ubuntu${version}-${revision}) ${ubuntuVersion}; urgency=medium
 
         * Publish ${revision} revision of ${project}.
 

--- a/packageSourceDeb.nix
+++ b/packageSourceDeb.nix
@@ -62,6 +62,7 @@ let
     #!/usr/bin/make -f
     %:
     	dh $@
+    override_dh_strip:
   '';
 
 in runCommand "build_source_deb" { SOURCE_DATE_EPOCH = 1576846270; } ''

--- a/packageSourceDeb.nix
+++ b/packageSourceDeb.nix
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ stdenv, writeTextFile, writeScript, runCommand, toLower }:
+pkgDesc:
+{ date, builderInfo }:
+
+let
+  project = toLower pkgDesc.project;
+  version = pkgDesc.version;
+  revision = pkgDesc.gitRevision;
+  pkgArch = pkgDesc.arch;
+  bin = pkgDesc.bin;
+  pkgName = "${project}_0ubuntu${version}-${revision}_${pkgArch}";
+
+  writeControlFile = writeTextFile {
+    name = "control";
+    text = ''
+      Source: ${project}
+      Section: utils
+      Priority: optional
+      Maintainer: Serokell <hi@serokell.io>
+      Build-Depends: debhelper (>=9)
+      Standards-Version: 3.9.7
+      Homepage: https://gitlab.com/tezos/tezos/
+      #Vcs-Git: git@gitlab.com:tezos/tezos.git
+      #Vcs-Browser: https://gitlab.com/tezos/tezos.git
+
+      Package: ${project}
+      Architecture: ${pkgDesc.arch}
+      Depends: ${pkgDesc.dependencies}
+      Description: ${project}
+       ${pkgDesc.description}
+    '';
+  };
+
+  writeChangelogFile = writeTextFile {
+    name = "changelog";
+    text = ''
+      ${project} (0ubuntu${version}-${revision}) xenial; urgency=medium
+
+        * Publish ${revision} revision of ${project}.
+
+       -- ${builderInfo} ${date}
+    '';
+  };
+
+  root = ./.;
+  writeMakefile = writeTextFile {
+    name = "Makefile";
+    text = ''
+      BINDIR=/usr/bin
+      all:
+
+      install:
+      	mkdir -p $(DESTDIR)$(BINDIR)
+      	cp ${project} $(DESTDIR)$(BINDIR)
+    '';
+  };
+
+  writeRulesFile = writeScript "rules" ''
+    #!/usr/bin/make -f
+    %:
+    	dh $@
+  '';
+
+in runCommand "build_source_deb" { SOURCE_DATE_EPOCH = 1576846270; } ''
+    mkdir -p ${project}/debian/source
+    cd ${project}
+    cp ${writeMakefile} Makefile
+    cp ${bin} ${project}
+    cp ${writeControlFile} debian/control
+    cp ${writeChangelogFile} debian/changelog
+    cp ${pkgDesc.licenseFile} debian/copyright
+    echo 9 > debian/compat
+    echo "The Debian Package tezos-client-mainnet" > debian/README
+    echo "3.0 (native)" > debian/source/format
+    cp ${writeRulesFile} debian/rules
+    dpkg-buildpackage -S -us -uc | tee ../${project}_0ubuntu${version}-${revision}_source.buildinfo 2>&1
+    mkdir -p $out
+    cp ../*.* $out/
+  ''

--- a/release.nix
+++ b/release.nix
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: MPL-2.0
 { pkgs ? import <nixpkgs> { }, timestamp ? "19700101" }:
 let
-  ignored_closures = [ "deb-packages" "rpm-packages" ];
+  ignored_closures = [
+    "deb-packages"
+    "rpm-packages"
+    "deb-source-packages"
+    "rpm-source-packages"
+  ];
   closures = builtins.attrValues
     (pkgs.lib.filterAttrs (n: v: !(builtins.elem n ignored_closures))
       (import ./. { inherit pkgs timestamp; }));


### PR DESCRIPTION
## Description
Problem: Currently, source package generation for ubuntu is performed
manually, soon (after #14 is resolved) we will have much more stuff to package 
and publish on launchpad.

Solution: Automate deb source packages generation using nix.
At this point, we are going back to the package generation inside Ubuntu VM.
Unfortunately, `dpkg-buildpackage` uses some hardcoded filepaths and
also require some dependencies, which are specific only for debian-based
repositories, achieving this without VM will be extremely painful.
Since launchpad and copr repo updates will not happen very often, we
can generate ubuntu stuff using VM. Also, we are not going to generate
it in CI, because source packages are not really useful for end-users.

Source packages generation for Fedora and rpm was also slightly updated.

Note that this PR is currently based on #18.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #19 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
