### PR TITLE
Update CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Tezos packaging
 
-[![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg)](https://buildkite.com/serokell/tezos-packaging?branch=master)
+[![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg?branch=master)](https://buildkite.com/serokell/tezos-packaging)
 
 This repo provides various form of distribution for tezos-related executables
 (unfortunately, only `tezos-client` for now, see [this issue](https://github.com/serokell/tezos-packaging/issues/14)).


### PR DESCRIPTION
## Description

Problem: CI badge shows status for latest build which is quite useless
information because last build can be in some WIP PR where it is even
not supposed to pass.

Solution: Add `?branch=master` to `.svg` link, it should show status
of the latest `master` build which is more useful.
Also remove `?branch=master` from the link that will be open on click
because it seems to have no effect there.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
