### PR TITLE
[#16] Update license in packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,10 +25,10 @@ let
     version = toString timestamp;
     bin = binary-mainnet;
     arch = "amd64";
-    license = "MPL-2.0";
+    license = "MIT";
     dependencies = "";
     maintainer = "Serokell https://serokell.io";
-    licenseFile = "${root}/LICENSES/MPL-2.0.txt";
+    licenseFile = "${tezos-client-static-mainnet}/LICENSE";
     description = "CLI client for interacting with tezos blockchain";
     gitRevision = mainnet.rev;
     branchName = "mainnet";
@@ -38,6 +38,7 @@ let
     project = "tezos-client-babylonnet";
     bin = binary-babylonnet;
     gitRevision = babylonnet.rev;
+    licenseFile = "${tezos-client-static-babylonnet}/LICENSE";
     branchName = "babylonnet";
   };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -286,6 +286,8 @@ let
           mkdir -p $out/bin
           cp _build/default/src/bin_client/main_client.exe $out/bin/tezos-client
           cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-admin
+          # Reuse license from tezos repo in packaging
+          cp LICENSE $out/LICENSE
         '';
       }) { };
   });


### PR DESCRIPTION
Problem: All packages have MPL-2.0 license, however, it is a bit
incorrect.

Solution: Use license from tezos repo instead.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #16 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
