### PR TITLE
[#11] Add autorelease script

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,5 +33,4 @@ steps:
  - commands:
    - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh
    label: create auto pre-release
-   # TODO: uncomment me before merging
-   # branches: master
+   branches: master

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,3 +29,9 @@ steps:
      - ./mainnet-deb-package/*
      - ./babylonnet-rpm-package/*
      - ./babylonnet-deb-package/*
+   branches: !master
+ - commands:
+   - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh
+   label: create auto pre-release
+   # TODO: uncomment me before merging
+   # branches: master

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ make rpm-mainnet #build rpm package with tezos-client-mainnet
 To build `.rpm` package with `mainnet` or `babylonnet` `tezos-client` executable. Once you install
 such package the command `tezos-client-mainnet` or `tezos-client-babylonnet` will be available.
 
-## Obtain binary or packages from CI
+## Obtain binary or packages from github release
 
-If you don't want to build these files from scratch, you can download artifacts
-produced by the CI. Go to the [latest master build](https://buildkite.com/serokell/tezos-packaging/builds/latest?branch=master),
-click on `build and package` stage, choose `Artifacts` section and download files by clcking on the filenames.
+If you don't want to build these files from scratch, you can download assets from github release.
+Go to the [latest release](https://github.com/serokell/tezos-packaging/releases/latest)
+and download desired assets.
 
 ## Ubuntu (Debian based distros) usage
 

--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
   tezos-client-static-babylonnet = import ./nix/static.nix babylonnet;
   binary-mainnet = "${tezos-client-static-mainnet}/bin/tezos-client";
   binary-babylonnet = "${tezos-client-static-babylonnet}/bin/tezos-client";
-  # Hopefully, there is always will be single LICENSE for all binaries and branches
+  # Hopefully, there will always be a single LICENSE for all binaries and branches
   licenseFile = "${tezos-client-static-mainnet}/LICENSE";
   packageDesc-mainnet = {
     inherit licenseFile;

--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,10 @@ let
   tezos-client-static-babylonnet = import ./nix/static.nix babylonnet;
   binary-mainnet = "${tezos-client-static-mainnet}/bin/tezos-client";
   binary-babylonnet = "${tezos-client-static-babylonnet}/bin/tezos-client";
+  # Hopefully, there is always will be single LICENSE for all binaries and branches
+  licenseFile = "${tezos-client-static-mainnet}/LICENSE";
   packageDesc-mainnet = {
+    inherit licenseFile;
     project = "tezos-client-mainnet";
     version = toString timestamp;
     bin = binary-mainnet;
@@ -28,7 +31,6 @@ let
     license = "MIT";
     dependencies = "";
     maintainer = "Serokell https://serokell.io";
-    licenseFile = "${tezos-client-static-mainnet}/LICENSE";
     description = "CLI client for interacting with tezos blockchain";
     gitRevision = mainnet.rev;
     branchName = "mainnet";
@@ -38,7 +40,6 @@ let
     project = "tezos-client-babylonnet";
     bin = binary-babylonnet;
     gitRevision = babylonnet.rev;
-    licenseFile = "${tezos-client-static-babylonnet}/LICENSE";
     branchName = "babylonnet";
   };
 
@@ -71,8 +72,16 @@ let
       cp ${binary-babylonnet} $out/${name}
     '';
   };
+  tezos-license = stdenv.mkDerivation rec {
+    name = "LICENSE";
+    phases = "copyPhase";
+    copyPhase = ''
+      mkdir -p $out
+      cp ${licenseFile} $out/${name}
+    '';
+  };
 
 in rec {
   inherit tezos-client-mainnet tezos-client-babylonnet mainnet-deb-package
-    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package;
+    mainnet-rpm-package babylonnet-rpm-package babylonnet-deb-package tezos-license;
 }

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101" }:
+let closures = builtins.attrValues (import ./. { inherit pkgs timestamp; });
+in pkgs.runCommandNoCC "release" { inherit closures; } ''
+  mkdir -p $out
+  for closure in $closures; do
+  cp $closure/* $out/
+  done
+''

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p gitAndTools.hub git -i bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# Project name, inferred from repository name
+project=$(basename $(pwd))
+
+# The directory in which artifacts will be created
+TEMPDIR=`mktemp -d`
+
+# Build release.nix
+nix-build release.nix -o $TEMPDIR/$project --arg timestamp $(date +\"%Y%m%d%H%M\")
+
+# Delete release
+hub release delete auto-release
+
+# Update the tag
+git fetch # So that the script can be run from an arbitrary checkout
+git tag -f auto-release
+git push --force --tags
+
+# Combine all assets
+assets=""
+for file in $TEMPDIR/$project/*; do
+    assets+="-a $file "
+done
+
+# Create release
+hub release create $assets -m "Automatic build on $(date -I)" --prerelease auto-release


### PR DESCRIPTION
## Description
Problem: We want an easier and more convenient way to get static binaries
(also packages, but this is secondarily, since we have PPAs).

Solution: Add autorelease script that produces github prerelease with
all closures (binaries and packages).

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #11 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
