### PR TITLE
[#23] Compress binaries with upx

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -235,7 +235,7 @@ let
       , js_of_ocaml, cmdliner, easy-format, ocp-ocamlres, tls, lwt4, lwt_log
       , mtime, ocplib-endian, ptime, re, rresult, stdio, uri, uutf, zarith
       , libusb1, hidapi, gmp, irmin, alcotest, dum, genspio, pprint, ocamlgraph
-      , findlib, digestif }:
+      , findlib, digestif, upx }:
       buildDunePackage rec {
         pname = "tezos";
         version = "0.0.1";
@@ -279,7 +279,7 @@ let
           ocamlgraph
           findlib
           genspio
-        ] ++ [ libusb1 libusb1.out (gmp.override { withStatic = true; }) ];
+        ] ++ [ libusb1 libusb1.out (gmp.override { withStatic = true; }) upx ];
         doCheck = false;
         buildPhase = "dune build src/bin_client/tezos-client.install";
         installPhase = ''
@@ -288,6 +288,8 @@ let
           cp _build/default/src/bin_client/main_admin.exe $out/bin/tezos-admin
           # Reuse license from tezos repo in packaging
           cp LICENSE $out/LICENSE
+          # Compress binaries with upx
+          upx $out/bin/*
         '';
       }) { };
   });


### PR DESCRIPTION
Produced static binaries appear to be well amenable to
packing with [upx](https://upx.github.io/) tool. So we compress them to reduce size of the
resulted binaries and packages.

`tezos-client` seems to work as expected, upx compressed the binary approximately at 70%

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #23 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
