### PR TITLE
Make source patches configurable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101" }:
+{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101", patches ? [] }:
 with pkgs;
 
 let
@@ -18,7 +18,7 @@ let
   master = {
     rev = "60b977cd";
     sha256 = "1v9v5z5i3cs9jw48m3xx9w4fqkns37nn464fr7hds7wgmwfmf1sp";
-    patchFile = ./nix/fix-master.patch;
+    patches = [ ./nix/fix-master.patch ] ++ patches;
     inherit protocols;
   };
   static-nix = import ./nix/static.nix;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -365,7 +365,7 @@ let
 
         minimumOCamlVersion = "4.07";
 
-        patches = [ branchInfo.patchFile ];
+        patches = branchInfo.patches;
         src = fetchgit {
           url = "https://gitlab.com/tezos/tezos.git/";
           rev = branchInfo.rev;


### PR DESCRIPTION
## Description
Problem: In one of our projects we want to provide patched static
tezos-binaries.

Solution: Make patches configurable.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
