### PR TITLE
[#38] Fix carthagenet specific binaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,11 @@ steps:
      - ./binaries/*
      - ./deb-packages/*
      - ./rpm-packages/*
-   branches: !master
+   branches: "!master"
+ - commands:
+   - nix-build -A test-binaries --no-out-link
+   label: test binaries
+   branches: "!master"
  - commands:
    - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh
    label: create auto pre-release

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101", patches ? []
+{ pkgs ? import <nixpkgs> { }, timestamp ? "19700101", patches ? [ ]
 , date ? "Thu, 1 Jan 1970 10:00:00 +0300", builderInfo ? ""
-, ubuntuVersion ? "bionic"}:
+, ubuntuVersion ? "bionic" }:
 with pkgs;
 
 let
@@ -164,7 +164,15 @@ let
     cp ${releaseFile} $out/
   '';
 
+  test-binaries = runCommand "test-binaries" { inherit tezos-static-master; } ''
+    for f in ${tezos-static-master}/bin/*; do
+      echo "$f"
+      "$f" --help &> /dev/null
+    done
+    mkdir -p $out
+  '';
+
 in rec {
   inherit deb-packages deb-source-packages rpm-source-packages rpm-packages
-    binaries tezos-license releaseNotes;
+    binaries tezos-license releaseNotes test-binaries;
 }

--- a/nix/fix-master.patch
+++ b/nix/fix-master.patch
@@ -80,6 +80,51 @@ index d1b60c7..a738ef2 100644
  
  (alias
   (name runtest_lint)
+diff --git a/src/proto_006_PsCARTHA/bin_accuser/dune b/src/proto_006_PsCARTHA/bin_accuser/dune
+index e99ac8f..5afd74b 100644
+--- a/src/proto_006_PsCARTHA/bin_accuser/dune
++++ b/src/proto_006_PsCARTHA/bin_accuser/dune
+@@ -10,7 +10,9 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_006_PsCARTHA_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev")))
+ 
+ (alias
+  (name runtest_lint)
+diff --git a/src/proto_006_PsCARTHA/bin_baker/dune b/src/proto_006_PsCARTHA/bin_baker/dune
+index d96ef4c..baa8598 100644
+--- a/src/proto_006_PsCARTHA/bin_baker/dune
++++ b/src/proto_006_PsCARTHA/bin_baker/dune
+@@ -10,7 +10,9 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_006_PsCARTHA_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev")))
+ 
+ (alias
+  (name runtest_lint)
+diff --git a/src/proto_006_PsCARTHA/bin_endorser/dune b/src/proto_006_PsCARTHA/bin_endorser/dune
+index c675ab3..ac0f52b 100644
+--- a/src/proto_006_PsCARTHA/bin_endorser/dune
++++ b/src/proto_006_PsCARTHA/bin_endorser/dune
+@@ -10,7 +10,9 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_006_PsCARTHA_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev")))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/src/bin_signer/dune b/src/bin_signer/dune
 index e4c9a7c..2a5f941 100644
 --- a/src/bin_signer/dune

--- a/release.nix
+++ b/release.nix
@@ -8,6 +8,7 @@ let
     "rpm-packages"
     "deb-source-packages"
     "rpm-source-packages"
+    "test-binaries"
   ];
   closures = builtins.attrValues
     (pkgs.lib.filterAttrs (n: v: !(builtins.elem n ignored_closures))


### PR DESCRIPTION
## Description
Problem: Dune files for `tezos-{accuser, baker, endorser}-006-PsCARTHA`
were lacking flags required for static building. This caused errors
when trying to run built executables.

Solution: Add flags.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #38

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
