### PR TITLE
Add derivation attribute to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ let
         tar -cvzf $out/${name} --mode='u+rwX' -C ${pathToPack} $(ls ${pathToPack})
       '';
     };
+
   binaries =
     packDirectory "binaries-${master.rev}" "${tezos-static-master}/bin";
   licenseFile = "${tezos-static-master}/LICENSE";
@@ -175,4 +176,5 @@ let
 in rec {
   inherit deb-packages deb-source-packages rpm-source-packages rpm-packages
     binaries tezos-license releaseNotes test-binaries;
+    binaries-drv = tezos-static-master;
 }


### PR DESCRIPTION
## Description

In other projects where nix is used it is more convenient to consume binaries in a form of unpacked derivation rather than tarball.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
