### PR TITLE
[#48] Unignore base protocols

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,15 @@ let
       echo "$f"
       "$f" --help &> /dev/null
     done
+    # Test that tezos-node run works for carthagenet
+    ${bundled.binaries}/bin/tezos-node config init --data-dir node-dir --network carthagenet
+    ${bundled.binaries}/bin/tezos-node identity generate 1 --data-dir node-dir
+    timeout --preserve-status 5 ${bundled.binaries}/bin/tezos-node run --data-dir node-dir --network carthagenet
+    rm -rf node-dir
+    # Test that tezos-node run works for mainnet
+    ${bundled.binaries}/bin/tezos-node config init --data-dir node-dir --network mainnet
+    ${bundled.binaries}/bin/tezos-node identity generate 1 --data-dir node-dir
+    timeout --preserve-status 5 ${bundled.binaries}/bin/tezos-node run --data-dir node-dir --network mainnet
     touch $out
   '';
 

--- a/protocols.json
+++ b/protocols.json
@@ -1,10 +1,7 @@
 {
   "ignored": [
     "alpha",
-    "genesis",
-    "genesis-carthagenet",
     "demo-counter",
-    "000-Ps9mPmXa",
     "001-PtCJ7pwo",
     "002-PsYLVpVv",
     "003-PsddFKi3",
@@ -12,7 +9,11 @@
     "005-PsBABY5H",
     "005-PsBabyM1"
   ],
-  "allowed": [],
+  "allowed": [
+    "genesis",
+    "genesis-carthagenet",
+    "000-Ps9mPmXa"
+  ],
   "active": [
     "006-PsCARTHA"
   ]


### PR DESCRIPTION
## Description
Problem: When starting from scratch `tezos-node` required information
about base chain protocols. Currently, we ignore all protocols except
006, this causes `tezos-node run` to fail.

Solution: Unignore `genesis`, `genesis-carthagenet`, `000-Ps9mPmXa`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #48 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
