### PR TITLE
[#47] Tezos releases in versioning

### DIFF
--- a/deb.nix
+++ b/deb.nix
@@ -6,15 +6,16 @@ pkg:
 let
   project = pkg.meta.name;
   version = meta.version;
-  revision = meta.gitRevision;
+  release = meta.release;
+  epoch = meta.epoch;
   pkgArch = meta.arch;
-  pkgName = "${project}_0ubuntu${version}-${revision}_${pkgArch}";
+  pkgName = "${project}_0ubuntu${version}-${release}_${pkgArch}";
 
   writeControlFile = writeTextFile {
     name = "control";
     text = ''
       Package: ${project}
-      Version: ${version}-${revision}
+      Version: ${epoch}:${version}-${release}
       Priority: optional
       Architecture: ${meta.arch}
       Depends: ${meta.dependencies}

--- a/debSource.nix
+++ b/debSource.nix
@@ -7,9 +7,9 @@ pkg:
 let
   project = lib.toLower pkg.meta.name;
   version = meta.version;
-  revision = meta.gitRevision;
+  release = meta.release;
+  epoch = meta.epoch;
   pkgArch = meta.arch;
-  pkgName = "${project}_0ubuntu${version}-${revision}_${pkgArch}";
   inherit (vmTools)
     makeImageFromDebDist commonDebPackages debDistros runInLinuxImage;
   ubuntuImage = makeImageFromDebDist (debDistros.ubuntu1804x86_64 // {
@@ -41,9 +41,9 @@ let
   writeChangelogFile = writeTextFile {
     name = "changelog";
     text = ''
-      ${project} (0ubuntu${version}-${revision}) ${meta.ubuntuVersion}; urgency=medium
+      ${project} (${epoch}:0ubuntu${version}-${release}) ${meta.ubuntuVersion}; urgency=medium
 
-        * Publish ${revision} revision of ${project}.
+        * Publish ${version}-${release} version of ${project}.
 
        -- ${meta.builderInfo} ${meta.date}
     '';
@@ -81,7 +81,7 @@ let
       echo "The Debian Package for ${project}" > debian/README
       echo "3.0 (native)" > debian/source/format
       cp ${writeRulesFile} debian/rules
-      dpkg-buildpackage -S -us -uc | tee ../${project}_0ubuntu${version}-${revision}_source.buildinfo 2>&1
+      dpkg-buildpackage -S -us -uc | tee ../${project}_${epoch}:0ubuntu${version}-${release}_source.buildinfo 2>&1
       mkdir -p $out
       cp ../*.* $out/
     '';

--- a/default.nix
+++ b/default.nix
@@ -14,12 +14,16 @@ let
     inherit (meta) name;
     value = bin pkgs.pkgsMusl.ocamlPackages.${meta.name} // { inherit meta; };
   }) release-binaries);
+
   commonMeta = {
-    gitRevision = source.rev;
-    version = toString timestamp;
+    # release should be updated in case we change something
+    release = "1";
+    # we switched from time-based versioning to proper tezos versioning
+    epoch = "1";
+    version = builtins.replaceStrings ["v"] [""] source.ref;
     license = "MPL-2.0";
     dependencies = "";
-    maintainer = "Serokell https://serokell.io";
+    maintainer = "Serokell https://serokell.io <hi@serokell.io>";
     branchName = source.ref;
     licenseFile = "${source}/LICENSE";
   };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -36,9 +36,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "master",
+        "ref": "v7.0",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "e93d500e20d757a25c87a415de3f0074ec663c84",
+        "rev": "4053147fe577e9a04a5a09634a5645b2e26343e0",
         "type": "git"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -9,7 +9,7 @@ let
   release-notes = writeTextDir "release-notes.md" ''
     Automatic release on ${builtins.substring 0 8 timestamp}
 
-    This release contains assets based on [revision ${source.rev}](https://gitlab.com/tezos/tezos/tree/${source.rev}) of ${source.ref} branch.
+    This release contains assets based on [${source.ref} release](https://gitlab.com/tezos/tezos/tree/${source.ref}).
 
     Binaries without protocol suffixes support the following protocols (unsupported protocols are listed for reference):
     ${builtins.concatStringsSep "\n" (map (x: "- [ ] `${x}`") protocols.ignored
@@ -24,10 +24,11 @@ let
     name = "tezos-release-no-tarball";
     paths = [ "${bundled.binaries}/bin" LICENSE release-notes ];
   };
-  releaseTarball = runCommand "release-tarball" { }
-    "mkdir $out; tar --owner=serokell:1000 --mode='u+rwX' -czhf $out/release.tar.gz -C ${releaseNoTarball} .";
+  tarballName = "binaries-${builtins.replaceStrings ["v"] [""] source.ref}-1.tar.gz";
+  binariesTarball = runCommand "binaries-tarball" { }
+    "mkdir $out; tar --owner=serokell:1000 --mode='u+rwX' -czhf $out/${tarballName} -C ${bundled.binaries}/bin .";
   LICENSE = writeTextDir "LICENSE" (builtins.readFile "${source}/LICENSE");
 in buildEnv {
   name = "tezos-release";
-  paths = [ releaseNoTarball releaseTarball ];
+  paths = [ releaseNoTarball binariesTarball ];
 }

--- a/rpm.nix
+++ b/rpm.nix
@@ -8,9 +8,9 @@ pkg:
 let
   project = pkg.meta.name;
   version = meta.version;
-  revision = meta.gitRevision;
+  release = meta.release;
   arch = meta.arch;
-  pkgName = "${project}-${version}-${revision}.${arch}";
+  pkgName = "${project}-${version}-${release}.${arch}";
   licenseFile = meta.licenseFile;
 
   rpmbuild-env = buildFHSUserEnv {
@@ -26,7 +26,8 @@ let
       # %define _unpackaged_files_terminate_build 0
       Name:    ${project}
       Version: ${version}
-      Release: ${revision}
+      Release: ${release}
+      Epoch: ${meta.epoch}
       Summary: ${pkg.meta.description}
       License: ${meta.license}
       BuildArch: ${arch}


### PR DESCRIPTION
## Description
Problem: Tezos now uses some versioning. `v7.0-rc1` recently was
released. We should use this versioning.

Solution: Optionally replace commit hash in the package version with
tag in case we are using sources that are not from the master branch
(git treats release tags the same way as branches).

We still want to be able to do multiple releases within single tezos
release or make releases that are based on fresh tezos code that wasn't
released.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #47

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
