### PR TITLE
Add tls to conduit

### DIFF
--- a/hacks.nix
+++ b/hacks.nix
@@ -11,7 +11,10 @@ with oself; {
   # FIXME opam-nix needs to do version resolution
   ezjsonm = osuper.ezjsonm.versions."1.1.0";
   ipaddr = osuper.ipaddr.versions."4.0.0";
-  conduit = osuper.conduit.versions."2.1.0";
+  conduit = osuper.conduit.versions."2.1.0".overrideAttrs (oa: rec {
+    buildInputs = [ oself.tls ] ++ oa.buildInputs;
+    propagatedBuildInputs = buildInputs;
+  });
   conduit-lwt-unix = osuper.conduit-lwt-unix.versions."2.0.2";
   cohttp-lwt-unix = osuper.cohttp-lwt-unix.versions."2.4.0";
   cohttp-lwt = osuper.cohttp-lwt.versions."2.4.0";


### PR DESCRIPTION
## Description

### Problem

see #52 

TLDR: 

```
$ tezos-client -S -A mainnet-tezos.giganode.io -P 443 rpc get /chains/main/blocks/head/protocols
Error:
  Rpc request failed:
     - meth: GET
     - uri: https://mainnet-tezos.giganode.io:443/describe/chains/main/blocks/head/protocols?recurse=no
     - error: Unable to connect to the node: "No SSL or TLS support compiled into Conduit"
```

### Solution

Build conduit with tls support.

Now:

```
$ tezos-client -S -A mainnet-tezos.giganode.io -P 443 rpc get /chains/main/blocks/head/protocols
{ "protocol": "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb",
  "next_protocol": "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb" }
```

## Related issue(s)

Resolves #52

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
