### PR TITLE
[#26] Bump tezos to v7.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   source = (import ./nix/nix/sources.nix).tezos;
   commonMeta = {
     # release should be updated in case we change something
-    release = "2";
+    release = "1";
     # we switched from time-based versioning to proper tezos versioning
     epoch = "1";
     version = builtins.replaceStrings [ "v" ] [ "" ] source.ref;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone --single-branch --branch hidapi-0.9.0 https://github.com/libusb/hi
 RUN cd hidapi && autoreconf -fvi && ./bootstrap && ./configure && make && make install
 RUN rm -rf libusb hidapi
 COPY ./static_libs.patch /static.patch
-RUN git clone --single-branch --branch v7.1 https://gitlab.com/tezos/tezos.git --depth 1
+RUN git clone --single-branch --branch v7.2 https://gitlab.com/tezos/tezos.git --depth 1
 WORKDIR /tezos
 RUN git apply ../static.patch
 RUN export OPAMYES="true" && opam init --bare --disable-sandboxing && make build-deps

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,9 +36,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "v7.1",
+        "ref": "v7.2",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "51977265590ba5fbd166b921e265fa22bf9f66a6",
+        "rev": "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090",
         "type": "git"
     }
 }


### PR DESCRIPTION
## Description
Problem: Tezos recently had new v7.2 release, we should update our
packaging as well.

Solution: Bump tezos to v7.2 :shrug:.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #26 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
