### PR TITLE
[#26] Update tezos version to 7.3

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone --single-branch --branch hidapi-0.9.0 https://github.com/libusb/hi
 RUN cd hidapi && autoreconf -fvi && ./bootstrap && ./configure && make && make install
 RUN rm -rf libusb hidapi
 COPY ./build/static_libs.patch /static.patch
-RUN git clone --single-branch --branch v7.2 https://gitlab.com/tezos/tezos.git --depth 1
+RUN git clone --single-branch --branch v7.3 https://gitlab.com/tezos/tezos.git --depth 1
 WORKDIR /tezos
 RUN git apply ../static.patch
 RUN export OPAMYES="true" && opam init --bare --disable-sandboxing && make build-deps

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,9 +36,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "v7.2",
+        "ref": "v7.3",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "6b9f3bc3c90d99d4a2bd5cd26e6f3efbcb977090",
+        "rev": "ba45727cadd0416936fbd49400bcc986a55064ca",
         "type": "git"
     }
 }


### PR DESCRIPTION
## Description

Problem: a new tezos version is released. We want to keep up with upstream updates.

Solution: update revision of tezos to the v7.3 tag.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates to #26

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
