### PR TITLE
[TM-429] WIP Systemd units and launch scripts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,12 +48,14 @@ steps:
    - nix run -f. pkgs.docker -c ./docker/docker-ubuntu-packages.sh source
    artifact_paths:
      - ./out/*
+   branches: "!master"
  - label: test deb binary packages via docker
    commands:
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
    - nix run -f. pkgs.docker -c ./docker/docker-ubuntu-packages.sh binary tezos-baker-006-PsCARTHA
    - rm -rf out
+   branches: "!master"
 
 
  - label: create auto pre-release

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-Files: .github/* nix/* protocols.json meta.json
+Files: .github/* nix/nix/* protocols.json meta.json
 Copyright: TQ Tezos <https://tqtezos.com>
 License: MPL-2.0

--- a/README.md
+++ b/README.md
@@ -36,6 +36,32 @@ sudo apt-get install tezos-baker-006-pscartha
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
+### Systemd units for `tezos-node` and daemons
+
+`tezos-node`, `tezos-accuser-006-pscartha`, `tezos-baker-006-pscartha` and
+`tezos-endorser-006-pscartha` packages have systemd files included to the
+package.
+
+Once you've installed the packages with systemd unit, you can run the service
+with the binary from the package using the following command:
+```
+systemctl start <package-name>.service
+```
+To stop the service run:
+```
+systemctl stop <package-name>.service
+```
+
+Each service has configuration file located in `/etc/default`. Default
+configurations can be found [here](docker/package/defaults/).
+
+Files created by the services will be located in `/var/lib/tezos/` by default.
+`tezos-{accuser, baker, endorser}-006-pscartha` services can have configurable
+data directory.
+
+`tezos-{accuser, endorser}` have configurable node address, so that they can be used with both
+remote and local node.
+
 ## Fedora Copr repository with `tezos-*` binaries
 
 If you are using Fedora you can use Copr in order to install `tezos-*`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo add-apt-repository ppa:serokell/tezos && sudo apt-get update
 sudo apt-get install tezos-client
 # dpkg-source prohibits uppercase in the packages names so the protocol
 # name is in lowercase
-sudo apt-get install tezos-baker-005-psbabym1
+sudo apt-get install tezos-baker-006-pscartha
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
@@ -45,11 +45,11 @@ E.g. in order to install `tezos-client` or `tezos-baker` run the following comma
 # use dnf
 sudo dnf copr enable @Serokell/Tezos
 sudo dnf install tezos-client
-sudo dnf install tezos-baker-005-PsBabyM1
+sudo dnf install tezos-baker-006-PsCARTHA
 
 # or use yum
 sudo yum copr enable @Serokell/Tezos
-sudo yum install tezos-baker-005-PsBabyM1
+sudo yum install tezos-baker-006-PsCARTHA
 ```
 Once you install such packages the commands `tezos-*` will be available.
 

--- a/docker/docker-ubuntu-packages.sh
+++ b/docker/docker-ubuntu-packages.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 
 docker build -t tezos-ubuntu -f docker/package/Dockerfile .
 set +e
-docker run -t --name package_builder tezos-ubuntu "$@"
-docker cp package_builder:/tezos-packaging/docker/out .
+container_id="$(docker create -t tezos-ubuntu "$@")"
+docker start -a "$container_id"
+docker cp "$container_id":/tezos-packaging/docker/out .
 set -e
-docker rm -v package_builder
+docker rm -v "$container_id"

--- a/docker/package/Dockerfile
+++ b/docker/package/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y libev-dev libgmp-dev libhidapi-dev m4 perl pkg-config \
-  debhelper dh-make devscripts autotools-dev python3 python3-distutils wget
+  debhelper dh-make dh-systemd devscripts autotools-dev python3 python3-distutils wget
 RUN apt-get install -y software-properties-common && add-apt-repository ppa:avsm/ppa && apt-get update && apt-get install -y opam
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
@@ -20,4 +20,7 @@ RUN opam switch set ocaml-base-compiler.4.09.1
 RUN opam install opam-bundle=0.4 --yes
 WORKDIR /tezos-packaging/docker
 COPY docker/package/package_generator.py /tezos-packaging/docker/package_generator.py
+COPY docker/package/defaults /tezos-packaging/docker/defaults
+COPY docker/package/scripts /tezos-packaging/docker/scripts
+COPY docker/package/systemd /tezos-packaging/docker/systemd
 ENTRYPOINT ["./package_generator.py"]

--- a/docker/package/defaults/tezos-accuser.conf
+++ b/docker/package/defaults/tezos-accuser.conf
@@ -1,0 +1,9 @@
+# vim: ft=sh
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# shellcheck disable=SC2034
+NODE_HOST="localhost"
+NODE_RPC_PORT="8732"
+DATA_DIR="/var/lib/tezos/accuser"

--- a/docker/package/defaults/tezos-baker.conf
+++ b/docker/package/defaults/tezos-baker.conf
@@ -1,0 +1,9 @@
+# vim: ft=sh
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# shellcheck disable=SC2034
+DATA_DIR="/var/lib/tezos/baker"
+NODE_RPC_PORT="8732"
+BAKER_ACCOUNT=""

--- a/docker/package/defaults/tezos-endorser.conf
+++ b/docker/package/defaults/tezos-endorser.conf
@@ -1,0 +1,9 @@
+# vim: ft=sh
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# shellcheck disable=SC2034
+NODE_HOST="localhost"
+NODE_RPC_PORT="8732"
+DATA_DIR="/var/lib/tezos/endorser"

--- a/docker/package/defaults/tezos-node.conf
+++ b/docker/package/defaults/tezos-node.conf
@@ -1,0 +1,10 @@
+# vim: ft=sh
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# shellcheck disable=SC2034
+NODE_RPC_PORT="8732"
+NETWORK="carthagenet"
+CERT_PATH=""
+KEY_PATH=""

--- a/docker/package/scripts/tezos-accuser-start
+++ b/docker/package/scripts/tezos-accuser-start
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+# $PROTOCOL should be defined in the system unit environment
+accuser="/usr/bin/tezos-accuser-$PROTOCOL"
+
+accuser_dir="$DATA_DIR"
+
+accuser_config="$accuser_dir/config"
+mkdir -p "$accuser_dir"
+
+if [ ! -f "$accuser_config" ]; then
+    "$accuser" --base-dir "$accuser_dir" \
+               --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+               config init --output "$accuser_config" >/dev/null 2>&1
+else
+    "$accuser" --base-dir "$accuser_dir" \
+               --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+               config update >/dev/null 2>&1
+fi
+
+exec "$accuser" --base-dir "$accuser_dir" \
+     --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+     run "$@"

--- a/docker/package/scripts/tezos-baker-start
+++ b/docker/package/scripts/tezos-baker-start
@@ -1,0 +1,38 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+# $PROTOCOL should be defined in the system unit environment
+baker="/usr/bin/tezos-baker-$PROTOCOL"
+
+baker_dir="$DATA_DIR"
+node_data_dir="/var/lib/tezos/node/data"
+
+baker_config="$baker_dir/config"
+mkdir -p "$baker_dir"
+
+if [ ! -f "$baker_config" ]; then
+    "$baker" --base-dir "$baker_dir" \
+             --port "$NODE_RPC_PORT" \
+             config init --output "$baker_config" >/dev/null 2>&1
+else
+    "$baker" --base-dir "$baker_dir" \
+             --port "$NODE_RPC_PORT" \
+             config update >/dev/null 2>&1
+fi
+
+launch_baker() {
+    exec "$baker" \
+         --base-dir "$baker_dir" --port "$NODE_RPC_PORT" \
+         run with local node "$node_data_dir" "$@"
+}
+
+if [[ -z "$BAKER_ACCOUNT" ]]; then
+    launch_baker "$@"
+else
+    launch_baker "$BAKER_ACCOUNT" "$@"
+fi

--- a/docker/package/scripts/tezos-endorser-start
+++ b/docker/package/scripts/tezos-endorser-start
@@ -1,0 +1,29 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+# $PROTOCOL should be defined in the system unit environment
+endorser="/usr/bin/tezos-endorser-$PROTOCOL"
+
+endorser_dir="$DATA_DIR/endorser"
+
+endorser_config="$endorser_dir/config"
+mkdir -p "$endorser_dir"
+
+if [ ! -f "$endorser_config" ]; then
+    "$endorser" --base-dir "$endorser_dir" \
+                --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+                config init --output "$endorser_config" >/dev/null 2>&1
+else
+    "$endorser" --base-dir "$endorser_dir" \
+                --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+                config update >/dev/null 2>&1
+fi
+
+exec "$endorser" --base-dir "$endorser_dir" \
+     --addr "$NODE_HOST" --port "$NODE_RPC_PORT" \
+     run "$@"

--- a/docker/package/scripts/tezos-node-start
+++ b/docker/package/scripts/tezos-node-start
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+: "${BIN_DIR:="/usr/bin"}"
+: "${DATA_DIR:="/var/lib/tezos"}"
+
+node="$BIN_DIR/tezos-node"
+node_dir="$DATA_DIR/node"
+node_data_dir="$node_dir/data"
+
+mkdir -p "$node_data_dir"
+if [ ! -f "$node_data_dir/config.json" ]; then
+    echo "Configuring the node..."
+    "$node" config init \
+            --data-dir "$node_data_dir" \
+            --rpc-addr ":$NODE_RPC_PORT" \
+            --network "$NETWORK"
+            "$@"
+else
+    echo "Updating the node configuration..."
+    "$node" config update \
+            --data-dir "$node_data_dir" \
+            --rpc-addr ":$NODE_RPC_PORT" \
+            --network "$NETWORK"
+            "$@"
+fi
+# Generate a new identity if not present
+
+if [ ! -f "$node_data_dir/identity.json" ]; then
+    echo "Generating a new node identity..."
+    "$node" identity generate "${IDENTITY_POW:-26}". \
+            --data-dir "$node_data_dir"
+fi
+
+# Launching the node
+
+if [[ -z "$CERT_PATH" || -z "$KEY_PATH" ]]; then
+    exec "$node" run --data-dir "$node_data_dir"
+else
+    exec "$node" run --data-dir "$node_data_dir" --rpc-tls="$CERT_PATH","$KEY_PATH"
+fi

--- a/docker/package/systemd/tezos-accuser.service
+++ b/docker/package/systemd/tezos-accuser.service
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+[Unit]
+After=network.target
+Description=Tezos accuser
+
+[Service]
+EnvironmentFile=/etc/default/tezos-accuser-006-pscartha
+Environment="PROTOCOL=006-PsCARTHA"
+ExecStart=/usr/bin/tezos-accuser-start
+StateDirectory=tezos
+User=tezos

--- a/docker/package/systemd/tezos-baker.service
+++ b/docker/package/systemd/tezos-baker.service
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+[Unit]
+After=network.target
+After=tezos-node.service
+Requires=tezos-node.service
+Description=Tezos baker
+
+[Service]
+EnvironmentFile=/etc/default/tezos-baker-006-pscartha
+Environment="PROTOCOL=006-PsCARTHA"
+ExecStart=/usr/bin/tezos-baker-start
+StateDirectory=tezos
+User=tezos

--- a/docker/package/systemd/tezos-endorser.service
+++ b/docker/package/systemd/tezos-endorser.service
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+[Unit]
+After=network.target
+Description=Tezos endorser
+
+[Service]
+EnvironmentFile=/etc/default/tezos-endorser-006-pscartha
+Environment="PROTOCOL=006-PsCARTHA"
+ExecStart=/usr/bin/tezos-endorser-start
+StateDirectory=tezos
+User=tezos

--- a/docker/package/systemd/tezos-node.service
+++ b/docker/package/systemd/tezos-node.service
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+[Unit]
+After=network.target
+Description=Tezos node
+
+[Service]
+EnvironmentFile=/etc/default/tezos-node
+ExecStart=/usr/bin/tezos-node-start
+StateDirectory=tezos
+User=tezos


### PR DESCRIPTION
## Description

Draft. Untested. Pushing early to review as we go.

The aim of this PR is to add systemd service units for the Tezos node, baker, and accuser, along with any scripts necessary to get them up.

The shell script code has been copied from upstream: https://gitlab.com/tezos/tezos/-/blob/v7.2/scripts/docker/entrypoint.inc.sh

Modified to baseless assumptions for correct paths on Ubuntu.

There is a related PR to tezos-infra to spin up a Ubuntu 20.04 machine to test these units.

## Related issue(s)

https://github.com/serokell/tezos-infra/pull/26

https://issues.serokell.io/issue/TM-429

Resolves #68
Resolves #56 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
