### PR TITLE
[#64] Add aarch64 static binaries building

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,6 +19,27 @@ export TEZOS_VERSION="v7.3"
 ```
 After that, directory will contain built static binaries.
 
+This script can optionally accept argument to define resulting binaries target architecture.
+Currently supported architectures are: `host` and `aarch64`, so that
+one can build native binaries for current architecture or build `aarch64` binaries on
+`x86_64` machine.
+
+### Compiling for `aarch64` on `x86_64` prerequisites
+
+Docker image defined in [`Dockerfile.aarch64`](build/Dockerfile.aarch64) uses qemu for
+compilation on `aarch64`. In particular it uses `qemu-aarch64-static` binary from
+[qemu-user-static repo](https://github.com/multiarch/qemu-user-static/).
+In order to be able to compile tezos using `aarch64` emulator you'll need to run:
+```
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
+```
+This command will register qemu emulator in `binfmt_misc`.
+
+Once this is done you should run the following command to build `aarch64` static tezos binaries:
+```
+./docker-static-build.sh aarch64
+```
+
 ## Ubuntu packages
 
 We provide a way to build both binary and source native Ubuntu packages.

--- a/docker/build/Dockerfile.aarch64
+++ b/docker/build/Dockerfile.aarch64
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-FROM alpine:3.11
+FROM alpine:3.11 as binary-fetch
+# Latest v5.0.0-2 qemu-user-static has some weird bug that causes curl and wget to segfault.
+# See https://bugs.launchpad.net/qemu/+bug/1892684.
+RUN wget https://github.com/multiarch/qemu-user-static/releases/download/v4.2.0-7/qemu-aarch64-static
+RUN chmod +x qemu-aarch64-static
+FROM arm64v8/alpine:3.11
+COPY --from=binary-fetch qemu-aarch64-static /usr/bin/qemu-aarch64-static
 RUN apk update
 RUN apk --no-cache --virtual add rsync git m4 build-base patch unzip \
   bubblewrap wget pkgconfig gmp-dev libev-dev hidapi-dev eudev-dev perl opam libusb-dev bash \

--- a/docker/build/build-libusb-and-hidapi.sh
+++ b/docker/build/build-libusb-and-hidapi.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# This script builds and installs libusb and hidapi libraries. It's required since alpine
+# doesn't provide static versions for these libraries, thus we have to compile it ourselves.
+set -euo pipefail
+
+git clone --single-branch --branch v1.0.23 https://github.com/libusb/libusb.git --depth 1
+cd libusb
+autoreconf -fvi && ./configure && make && make install
+
+git clone --single-branch --branch hidapi-0.9.0 https://github.com/libusb/hidapi.git --depth 1
+
+cd hidapi
+autoreconf -fvi && ./bootstrap && ./configure && make && make install
+
+rm -rf libusb hidapi

--- a/docker/build/build-tezos.sh
+++ b/docker/build/build-tezos.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+# This script builds static tezos binaries. It expects patches required for static building to be
+# in parent directory, it also accepts tezos version as an argument.
+set -euo pipefail
+
+tezos_version="$1"
+git clone --single-branch --branch "$tezos_version" https://gitlab.com/tezos/tezos.git --depth 1
+cd tezos
+
+git apply ../static.patch
+export OPAMYES="true"
+opam init --bare --disable-sandboxing
+make build-deps
+eval "$(opam env)" && make


### PR DESCRIPTION
## Description
Problem: We want to support rpi and arm architecture in general.
Unfortunately, it's quite nontrivial to use opam and ocaml on armv7l,
since OCaml 4.09.1 has issues with building on this architecture.

Solution: Add static binaries building for 64bit arm architecture via
qemu + aarch64 docker alpine image.

This PR resolves only part of #64.
Needs to be done:
* Build aarch64 binaries automatically on the remote arm machine in CI.
* Include built binaries to the releases.
* (?) Provide native `.deb` packages with tezos-binaries for RPI.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves part of #64 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
