### PR TITLE
Allow all old protocols

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 env:
-  NIX_PATH: nixpkgs=https://github.com/serokell/nixpkgs/archive/master.tar.gz
   SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref')\""
 
 steps:

--- a/protocols.json
+++ b/protocols.json
@@ -1,18 +1,18 @@
 {
   "ignored": [
     "alpha",
-    "demo-counter",
+    "demo-counter"
+  ],
+  "allowed": [
+    "genesis",
+    "genesis-carthagenet",
+    "000-Ps9mPmXa",
     "001-PtCJ7pwo",
     "002-PsYLVpVv",
     "003-PsddFKi3",
     "004-Pt24m4xi",
     "005-PsBABY5H",
     "005-PsBabyM1"
-  ],
-  "allowed": [
-    "genesis",
-    "genesis-carthagenet",
-    "000-Ps9mPmXa"
   ],
   "active": [
     "006-PsCARTHA"

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 { path-to-binaries ? null } @ args:
-import <nixpkgs/nixos/tests/make-test-python.nix> ({ pkgs, ... }:
+let
+  nixpkgs = (import ../nix/nix/sources.nix).nixpkgs;
+in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }:
 {
   nodes.machine = { ... }: { virtualisation.memorySize = 1024; };
 


### PR DESCRIPTION
## Description
Problem: We doesn't compile all protocols for nix binaries, this lead to
a problem when bootstrapping mainnet node, it says that old protocols
are missing during block validation.

Solution: Allow all old protocols.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
https://issues.serokell.io/issue/OPS-997

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
