### PR TITLE
Fix auto releases

### DIFF
--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -p gitAndTools.hub git rename -i bash
+#!nix-shell shell.nix -i bash
 # SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2019-2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+{ pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs {} }:
+with pkgs;
+mkShell {
+  buildInputs = [ gitAndTools.hub git rename ];
+}


### PR DESCRIPTION
## Description
Problem: `nix-shell -p` requires nixpkgs to be in
`NIX_PATH`, which we removed earlier.

Solution: Use shell.nix file instead of using `-p` option.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
