### PR TITLE
[#64] Arm building in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,21 @@ steps:
    - nix run -f.. pkgs.upx -c upx tezos-*
    artifact_paths:
      - ./docker/tezos-*
+ # arm builer is an ubuntu machine without nix
+ - label: build arm via docker
+   commands:
+   - eval "$SET_VERSION"
+   - cd docker
+   - ./docker-static-build.sh
+   - upx tezos-*
+   - >
+     for f in ./tezos-*; do
+       mv "\$f" "\$f-arm64"
+     done
+   artifact_paths:
+     - ./docker/tezos-*
+   agents:
+     queue: "arm64-build"
  - label: test docker-built binaries
    commands:
    - buildkite-agent artifact download "docker/*" . --step "build via docker"
@@ -60,11 +75,13 @@ steps:
    - rm -rf out
    branches: "!master"
 
-
+ - wait
  - label: create auto pre-release
    commands:
    - mkdir binaries
+   - mkdir arm-binaries
    - buildkite-agent artifact download "docker/*" binaries --step "build via docker"
+   - buildkite-agent artifact download "docker/*" arm-binaries --step "build arm via docker"
    - ls binaries
    - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh
    branches: master

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ docker-binaries ? null }:
+{ docker-binaries ? null, docker-arm-binaries ? null }:
 let
   pkgs = import ./nix/build/pkgs.nix { };
   source = (import ./nix/nix/sources.nix).tezos;
@@ -14,7 +14,7 @@ let
     branchName = source.ref;
     licenseFile = "${source}/LICENSE";
   } // meta;
-  release =
-    pkgs.callPackage ./release.nix { binaries = docker-binaries; inherit commonMeta; };
+  release = pkgs.callPackage ./release.nix
+    { binaries = docker-binaries; arm-binaries = docker-arm-binaries; inherit commonMeta; };
 
 in { inherit release commonMeta pkgs; }

--- a/release.nix
+++ b/release.nix
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ writeTextDir, runCommand, buildEnv, binaries, commonMeta }:
+{ writeTextDir, runCommand, buildEnv, binaries, arm-binaries, commonMeta }:
 let
   release-binaries = import ./nix/build/release-binaries.nix;
   release-notes = writeTextDir "release-notes.md" ''
     Automatic release
 
     This release contains assets based on [${commonMeta.branchName} release](https://gitlab.com/tezos/tezos/tree/${commonMeta.branchName}).
+
+    Binaries that target arm64 architecture has `-arm64` suffix in the name.
+    Other binaries target x86_64.
 
     Descriptions for binaries included in this release:
     ${builtins.concatStringsSep "\n"
@@ -17,13 +20,16 @@ let
   '';
   releaseNoTarball = buildEnv {
     name = "tezos-release-no-tarball";
-    paths = [ "${binaries}" LICENSE release-notes ];
+    paths = [ "${binaries}" "${arm-binaries}" LICENSE release-notes ];
   };
   tarballName = "binaries-${commonMeta.version}-${commonMeta.release}.tar.gz";
+  armTarballName = "binaries-${commonMeta.version}-${commonMeta.release}-arm64.tar.gz";
   binariesTarball = runCommand "binaries-tarball" { }
     "mkdir $out; tar --owner=serokell:1000 --mode='u+rwX' -czhf $out/${tarballName} -C ${binaries} .";
+  armBinariesTarball = runCommand "binaries-tarball" { }
+    "mkdir $out; tar --owner=serokell:1000 --mode='u+rwX' -czhf $out/${armTarballName} -C ${arm-binaries} .";
   LICENSE = writeTextDir "LICENSE" (builtins.readFile commonMeta.licenseFile);
 in buildEnv {
   name = "tezos-release";
-  paths = [ releaseNoTarball binariesTarball ];
+  paths = [ releaseNoTarball binariesTarball armBinariesTarball ];
 }

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -19,7 +19,8 @@ trap finish EXIT
 assets_dir=$TEMPDIR/assets
 
 # Build release.nix
-nix-build -A release -o "$TEMPDIR"/"$project" --arg timestamp "$(date +\"%Y%m%d%H%M\")" --arg docker-binaries ./binaries/docker
+nix-build -A release -o "$TEMPDIR"/"$project" --arg timestamp "$(date +\"%Y%m%d%H%M\")" \
+          --arg docker-binaries ./binaries/docker --arg docker-arm-binaries ./arm-binaries/docker
 mkdir -p "$assets_dir"
 # Move archive with binaries and tezos license to assets
 shopt -s extglob


### PR DESCRIPTION
## Description
Problem: We want to have automated way for building static arm binaries.

Solution: Use dedicated buildkite-agent which is run on arm64 machine
for building static arm binaries.

~Currently depends on [OPS-1058](https://issues.serokell.io/issue/OPS-1058), pipeline setup
can change a bit once this issue is resolved.~
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #64

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
