### PR TITLE
[#26] tezos v7.4

### DIFF
--- a/docker/build/static_libs.patch
+++ b/docker/build/static_libs.patch
@@ -2,10 +2,10 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 diff --git a/src/bin_client/dune b/src/bin_client/dune
-index cd22cd7..dc732e2 100644
+index 28822fb9f..27c6b81ca 100644
 --- a/src/bin_client/dune
 +++ b/src/bin_client/dune
-@@ -68,7 +68,10 @@
+@@ -74,7 +74,10 @@
                      -open Tezos_client_commands
                      -open Tezos_mockup_commands
                      -open Tezos_client_base_unix
@@ -18,10 +18,10 @@ index cd22cd7..dc732e2 100644
  (rule
    (target void_for_linking)
 diff --git a/src/bin_node/dune b/src/bin_node/dune
-index 568dcab..14cf4e0 100644
+index 7ff6a869a..6ee10ed34 100644
 --- a/src/bin_node/dune
 +++ b/src/bin_node/dune
-@@ -79,7 +79,9 @@
+@@ -85,7 +85,9 @@
                     -open Tezos_shell_context
                     -open Tezos_workers
                     -open Tezos_protocol_updater
@@ -32,8 +32,37 @@ index 568dcab..14cf4e0 100644
  
  (rule
    (target void_for_linking)
+diff --git a/src/bin_signer/dune b/src/bin_signer/dune
+index a79e48830..2bafdc807 100644
+--- a/src/bin_signer/dune
++++ b/src/bin_signer/dune
+@@ -20,7 +20,10 @@
+                    -open Tezos_rpc_http_server
+                    -open Tezos_rpc_http_client_unix
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_stdlib)))
++                   -open Tezos_stdlib
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+ 
+ (alias
+  (name runtest_lint)
+diff --git a/src/lib_protocol_compiler/dune b/src/lib_protocol_compiler/dune
+index 21b4bec58..9af9818fd 100644
+--- a/src/lib_protocol_compiler/dune
++++ b/src/lib_protocol_compiler/dune
+@@ -65,7 +65,7 @@
+  (public_name tezos-protocol-compiler)
+  (modes native)
+  (libraries tezos_protocol_compiler_native)
+- (flags (:standard -linkall))
++ (flags (:standard -linkall -ccopt -static))
+  (modules Main_native))
+ 
+ (executable
 diff --git a/src/proto_006_PsCARTHA/bin_accuser/dune b/src/proto_006_PsCARTHA/bin_accuser/dune
-index e99ac8f..5afd74b 100644
+index e99ac8f95..401f9f2fe 100644
 --- a/src/proto_006_PsCARTHA/bin_accuser/dune
 +++ b/src/proto_006_PsCARTHA/bin_accuser/dune
 @@ -10,7 +10,10 @@
@@ -49,7 +78,7 @@ index e99ac8f..5afd74b 100644
  (alias
   (name runtest_lint)
 diff --git a/src/proto_006_PsCARTHA/bin_baker/dune b/src/proto_006_PsCARTHA/bin_baker/dune
-index d96ef4c..baa8598 100644
+index d96ef4cde..855f24ac5 100644
 --- a/src/proto_006_PsCARTHA/bin_baker/dune
 +++ b/src/proto_006_PsCARTHA/bin_baker/dune
 @@ -10,7 +10,10 @@
@@ -65,7 +94,7 @@ index d96ef4c..baa8598 100644
  (alias
   (name runtest_lint)
 diff --git a/src/proto_006_PsCARTHA/bin_endorser/dune b/src/proto_006_PsCARTHA/bin_endorser/dune
-index c675ab3..ac0f52b 100644
+index c675ab3c5..ac0f52b7a 100644
 --- a/src/proto_006_PsCARTHA/bin_endorser/dune
 +++ b/src/proto_006_PsCARTHA/bin_endorser/dune
 @@ -10,7 +10,9 @@
@@ -79,37 +108,55 @@ index c675ab3..ac0f52b 100644
  
  (alias
   (name runtest_lint)
-diff --git a/src/bin_signer/dune b/src/bin_signer/dune
-index e4c9a7c..2a5f941 100644
---- a/src/bin_signer/dune
-+++ b/src/bin_signer/dune
-@@ -19,7 +19,10 @@
-                    -open Tezos_rpc_http_server
-                    -open Tezos_rpc_http_client_unix
+diff --git a/src/proto_007_PsDELPH1/bin_accuser/dune b/src/proto_007_PsDELPH1/bin_accuser/dune
+index da3093f82..0e60e123a 100644
+--- a/src/proto_007_PsDELPH1/bin_accuser/dune
++++ b/src/proto_007_PsDELPH1/bin_accuser/dune
+@@ -10,7 +10,10 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_007_PsDELPH1_commands
                     -open Tezos_stdlib_unix
--                   -open Tezos_stdlib)))
-+                   -open Tezos_stdlib
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
 +                   -ccopt -static
 +                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
 +                   )))
  
  (alias
   (name runtest_lint)
-diff --git a/src/lib_protocol_compiler/dune b/src/lib_protocol_compiler/dune
-index 0902181..30fe55b 100644
---- a/src/lib_protocol_compiler/dune
-+++ b/src/lib_protocol_compiler/dune
-@@ -65,7 +65,7 @@
-  (public_name tezos-protocol-compiler)
-  (modes native)
-  (libraries tezos_protocol_compiler_native)
-- (flags (:standard -linkall))
-+ (flags (:standard -linkall -ccopt -static))
-  (modules Main_native))
+diff --git a/src/proto_007_PsDELPH1/bin_baker/dune b/src/proto_007_PsDELPH1/bin_baker/dune
+index 490b09f8c..1e9d89a87 100644
+--- a/src/proto_007_PsDELPH1/bin_baker/dune
++++ b/src/proto_007_PsDELPH1/bin_baker/dune
+@@ -10,7 +10,10 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_007_PsDELPH1_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
  
- (executable
+ (alias
+  (name runtest_lint)
+diff --git a/src/proto_007_PsDELPH1/bin_endorser/dune b/src/proto_007_PsDELPH1/bin_endorser/dune
+index 074b4e006..cf801b59c 100644
+--- a/src/proto_007_PsDELPH1/bin_endorser/dune
++++ b/src/proto_007_PsDELPH1/bin_endorser/dune
+@@ -10,7 +10,9 @@
+                    -open Tezos_client_commands
+                    -open Tezos_baking_007_PsDELPH1_commands
+                    -open Tezos_stdlib_unix
+-                   -open Tezos_client_base_unix)))
++                   -open Tezos_client_base_unix
++                   -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev")))
+ 
+ (alias
+  (name runtest_lint)
 diff --git a/vendors/index/src/unix/dune b/vendors/index/src/unix/dune
-index 49e819d..833a3f4 100644
+index 49e819dd2..833a3f473 100644
 --- a/vendors/index/src/unix/dune
 +++ b/vendors/index/src/unix/dune
 @@ -2,4 +2,4 @@

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -9,9 +9,11 @@
 
 set -euo pipefail
 
-binaries=("tezos-accuser-006-PsCARTHA" "tezos-admin-client" "tezos-baker-006-PsCARTHA"
-          "tezos-client" "tezos-endorser-006-PsCARTHA" "tezos-node" "tezos-signer"
-         )
+binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer")
+
+for proto in $(jq -r ".active | .[]" ../protocols.json); do
+    binaries+=("tezos-accuser-$proto" "tezos-baker-$proto" "tezos-endorser-$proto")
+done
 
 arch="host"
 

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,9 +36,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "v7.3",
+        "ref": "v7.4",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "ba45727cadd0416936fbd49400bcc986a55064ca",
+        "rev": "e69b63f128701b2cdad665e8037a330305f591ce",
         "type": "git"
     }
 }

--- a/protocols.json
+++ b/protocols.json
@@ -15,6 +15,7 @@
     "005-PsBabyM1"
   ],
   "active": [
-    "006-PsCARTHA"
+    "006-PsCARTHA",
+    "007-PsDELPH1"
   ]
 }


### PR DESCRIPTION
## Description
The new tezos version arrived. 
Now tezos has two actual protocol versions: 006 and 007 (currently used only on delphinet).
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #26

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
