### PR TITLE
[WIP] [LIGO-8] Use opam to get tezos

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 env:
-  SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref')\""
+  SET_VERSION: "export TEZOS_VERSION=\"v$(nix eval --raw -f nix/build/pkgs.nix ocamlPackages.tezos-client.version)\""
   USE_PODMAN: "True"
 
 steps:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,13 +17,15 @@ otherwise improve our project, pull requests are most welcome.
 
 ## Quick maintenance guide
 
-- Tezos revision is located in the [`sources.json`](../nix/nix/sources.json) file.
-  You can either update it manually to newer revision or use `niv` tool.
-  In order to do that run
-  `niv update tezos -a ref=<tag from tezos repo> -a rev=<commit in this tag>`
-  from the [`nix/`](../nix) directory. This command will update sources to some commit
-  from the given tag.
-- Used tezos protocols can be changed by [`proto`](../script/proto) script.
+- For nix-based assets tezos sources are fetched from the opam repository.
+  You can update them via `niv`. In order to do that run
+  `niv update opam-repository` from the [`nix/`](../nix) directory. This command will update
+  opam repository to the latest revision and thus will use the latest tezos version.
+  In order to build custom tezos version you can insert
+  `opam-nix.callOPAMPackage (builtins.fetchTarball https://gitlab.com/tezos/tezos/-/archive/<commit>/tezos-<commit>.tar.gz)`
+  to the [`ocaml-overlay.nix`](../nix/build/ocaml-overlay.nix).
+- For docker based assets tezos sources are fetched based on `TEZOS_VERSION` environment variable.
+- Used tezos protocols can be changed by [`proto`](../scripts/proto) script.
   This script requires `jq` and `moreutils` to be installed.
   Currently used protocols are displayed in [`protocols.json`](../protocols.json).
   - To add a new protocol, `./proto activate ...`.
@@ -33,7 +35,7 @@ otherwise improve our project, pull requests are most welcome.
 
 ### Nix specific maintenance
 
-All nix related files are located in the [nix](./nix) directory.
+All nix related files are located in the [nix](../nix) directory.
 
 If the build breaks because of a dependency issue, `nix repl pkgs.nix`
 can be very useful to investigate it.

--- a/default.nix
+++ b/default.nix
@@ -5,13 +5,14 @@
 { docker-binaries ? null, docker-arm-binaries ? null }:
 let
   pkgs = import ./nix/build/pkgs.nix { };
-  source = (import ./nix/nix/sources.nix).tezos;
+  source = pkgs.ocamlPackages.tezos-client.src;
+
   meta = builtins.fromJSON (builtins.readFile ./meta.json);
   commonMeta = {
-    version = builtins.replaceStrings [ "v" ] [ "" ] source.ref;
+    version = pkgs.ocamlPackages.tezos-client.version;
     license = "MPL-2.0";
     dependencies = "";
-    branchName = source.ref;
+    branchName = "v${pkgs.ocamlPackages.tezos-client.version}";
     licenseFile = "${source}/LICENSE";
   } // meta;
   release = pkgs.callPackage ./release.nix

--- a/nix/build/hacks.nix
+++ b/nix/build/hacks.nix
@@ -19,6 +19,7 @@ with oself; {
   cohttp-lwt-unix = osuper.cohttp-lwt-unix.versions."2.4.0";
   cohttp-lwt = osuper.cohttp-lwt.versions."2.4.0";
   macaddr = osuper.macaddr.versions."4.0.0";
+  index = osuper.index.versions."1.2.1";
 
   lwt = lwt4;
 
@@ -35,7 +36,14 @@ with oself; {
   bigstring = osuper.bigstring.overrideAttrs (_: { doCheck = false; });
 
   # FIXME vendors/index
-  index = oself.index-super;
+
+  # ???
+
+  blake2 = osuper.blake2.override { dune = oself.dune_2; };
+  hacl = osuper.hacl.override { dune = oself.dune_2; };
+  secp256k1-internal =
+    osuper.secp256k1-internal.override { dune = oself.dune_2; };
+  uecc = osuper.uecc.override { dune = oself.dune_2; };
 
   # FIXME dependencies in tezos-protocol-compiler.opam
   tezos-protocol-compiler = osuper.tezos-protocol-compiler.overrideAttrs

--- a/nix/build/hacks.nix
+++ b/nix/build/hacks.nix
@@ -28,6 +28,9 @@ with oself; {
   conf-libev = self.libev;
   conf-hidapi = self.hidapi;
   conf-pkg-config = self.pkg-config;
+  conf-rust = null;
+  conf-libffi = self.libffi;
+  ctypes-foreign = oself.ctypes;
 
   # FIXME X11 in nixpkgs musl
   lablgtk = null;
@@ -53,8 +56,11 @@ with oself; {
     });
 
   # FIXME apply this patch upstream
-  tezos-stdlib-unix = osuper.tezos-stdlib-unix.overrideAttrs
-    (_: { patches = [ ./stdlib-unix.patch ]; });
+  tezos-stdlib-unix = if isNull oself.tezos-source then
+    osuper.tezos-stdlib-unix.overrideAttrs
+    (_: { patches = [ ./stdlib-unix.patch ]; })
+  else
+    osuper.tezos-stdlib-unix;
 
   tezos-client = osuper.tezos-client.overrideAttrs
     (_: { postInstall = "rm $bin/tezos-admin-client $bin/*.sh"; });

--- a/nix/build/hacks.nix
+++ b/nix/build/hacks.nix
@@ -4,6 +4,13 @@
 
 # This file needs to become empty.
 self: super: oself: osuper:
+
+let
+  fixHardeningWarning = pkg: if self.stdenv.isDarwin then pkg.overrideAttrs (_: {
+    hardeningDisable = [ "strictoverflow" ];
+    NIX_CFLAGS_COMPILE = "-Wno-error";
+  }) else pkg;
+in
 with oself; {
   # FIXME opam-nix needs to do this
   ocamlfind = findlib;
@@ -43,10 +50,10 @@ with oself; {
   # ???
 
   blake2 = osuper.blake2.override { dune = oself.dune_2; };
-  hacl = osuper.hacl.override { dune = oself.dune_2; };
   secp256k1-internal =
     osuper.secp256k1-internal.override { dune = oself.dune_2; };
   uecc = osuper.uecc.override { dune = oself.dune_2; };
+  hacl = fixHardeningWarning (osuper.hacl.override { dune = oself.dune_2; });
 
   # FIXME dependencies in tezos-protocol-compiler.opam
   tezos-protocol-compiler = osuper.tezos-protocol-compiler.overrideAttrs

--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -2,15 +2,41 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ sources ? import ./nix/sources.nix
+{ sources ? import ./nix/sources.nix, tezos-source ? null
 , protocols ? builtins.fromJSON (builtins.readFile ../../protocols.json)
 , hacks ? import ./hacks.nix, pkgs ? import sources.nixpkgs { }
 , opam-nix ? import sources.opam-nix pkgs }:
-self: super: {
+self: super:
+let
+  tezos-source-patched = self.stdenv.mkDerivation {
+    name = "tezos-source-patched";
+    src = tezos-source;
+    phases = [ "unpackPhase" "patchPhase" "installPhase" ];
+    patches = [ ./stdlib-unix.patch ];
+    installPhase = "cp -r . $out";
+  };
+
+  tezos-source-eval = builtins.readFile "${tezos-source-patched}/LICENSE";
+in
+{
   ocamlPackages = self.ocaml-ng.ocamlPackages_4_09.overrideScope'
     (builtins.foldl' self.lib.composeExtensions (_: _: { }) [
       (opam-nix.traverseOPAMRepo' sources.opam-repository)
-      (oself: osuper: { inherit ((opam-nix.callOPAMPackage osuper.tezos-node.src) oself osuper) irmin irmin-pack; })
+      (oself: osuper:
+        if !isNull tezos-source then
+          self.lib.filterAttrs (name: _: self.lib.hasPrefix "tezos-" name)
+          (opam-nix.callOPAMPackage (builtins.deepSeq tezos-source-eval tezos-source-patched) oself osuper)
+        else
+          { })
+      (oself: osuper: {
+        inherit tezos-source;
+      })
+      (oself: osuper: {
+        inherit ((opam-nix.callOPAMPackage
+          (if isNull tezos-source then osuper.tezos-node.src else tezos-source))
+          oself osuper)
+          irmin irmin-pack;
+      })
       (_: # Nullify all the ignored protocols so that we don't build them
         builtins.mapAttrs (name: pkg:
           if builtins.any

--- a/nix/build/pkgs.nix
+++ b/nix/build/pkgs.nix
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ sources ? import ../nix/sources.nix, pkgs ? import sources.nixpkgs { } }:
+{ sources ? import ../nix/sources.nix, pkgs ? import sources.nixpkgs { }, tezos-source ? null }:
 let
-  ocaml-overlay = import ./ocaml-overlay.nix { inherit sources pkgs; };
+  ocaml-overlay = import ./ocaml-overlay.nix { inherit sources pkgs tezos-source; };
   static-overlay = import ./static-overlay.nix;
   nixpkgs = import sources.nixpkgs { overlays = [ ocaml-overlay ]; };
 in nixpkgs.extend (self: super: {

--- a/nix/build/static-overlay.nix
+++ b/nix/build/static-overlay.nix
@@ -16,6 +16,7 @@ let
     "-lusb-1.0 -lhidapi-libusb -ludev";
 in {
   ocaml = self.ocaml-ng.ocamlPackages_4_07.ocaml;
+  curl = super.curl.override { gssSupport = false; };
   libev = dds super.libev;
   libusb1 = dds (super.libusb1.override {
     systemd = self.eudev;

--- a/nix/build/stdlib-unix.patch
+++ b/nix/build/stdlib-unix.patch
@@ -4,8 +4,8 @@
 
 diff --git a/src/lib_stdlib_unix/file_descriptor_sink.ml b/src/lib_stdlib_unix/file_descriptor_sink.ml
 index 781668770..124dbaaef 100644
---- a/file_descriptor_sink.ml
-+++ b/file_descriptor_sink.ml
+--- a/src/lib_stdlib_unix/file_descriptor_sink.ml
++++ b/src/lib_stdlib_unix/file_descriptor_sink.ml
 @@ -24,6 +24,7 @@
  (*****************************************************************************)
  

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ patches ? [ ] }:
+{ tezos-source ? null }:
 let
-  pkgs = import ./build/pkgs.nix { };
+  pkgs = import ./build/pkgs.nix { inherit tezos-source; };
   source = (import ./nix/sources.nix).tezos;
   protocols = import ./protocols.nix;
   bin = pkgs.callPackage ./build/bin.nix { };

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -29,16 +29,10 @@
         "homepage": "https://opam.ocaml.org",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "d67e70b40203a6a1c77ccb2edbe136c1509a73a3",
-        "sha256": "1yphw9xcss284p51qnml5jvfs4mhjcjgdka3wk25q0437zdzqj4n",
+        "rev": "4fb8d40be39a2a81da247008e1524bc795dd8fbe",
+        "sha256": "0m57154dd9sm02clczqxii1swgzpvaxms42xdn5djpjq96l5x899",
         "type": "tarball",
-        "url": "https://github.com/ocaml/opam-repository/archive/d67e70b40203a6a1c77ccb2edbe136c1509a73a3.tar.gz",
+        "url": "https://github.com/ocaml/opam-repository/archive/4fb8d40be39a2a81da247008e1524bc795dd8fbe.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "tezos": {
-        "ref": "v7.4",
-        "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "e69b63f128701b2cdad665e8037a330305f591ce",
-        "type": "git"
     }
 }

--- a/release.nix
+++ b/release.nix
@@ -20,7 +20,7 @@ let
   '';
   releaseNoTarball = buildEnv {
     name = "tezos-release-no-tarball";
-    paths = [ "${binaries}" "${arm-binaries}" LICENSE release-notes ];
+    paths = [ binaries arm-binaries LICENSE release-notes ];
   };
   tarballName = "binaries-${commonMeta.version}-${commonMeta.release}.tar.gz";
   armTarballName = "binaries-${commonMeta.version}-${commonMeta.release}-arm64.tar.gz";

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: MPL-2.0
-{ path-to-binaries ? null } @ args:
+{ path-to-binaries ? "${(import ../nix { }).binaries}/bin" } @ args:
 let
   nixpkgs = (import ../nix/nix/sources.nix).nixpkgs;
 in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }:


### PR DESCRIPTION
## Description

Currently, we use a git checkout to get the tezos sources for our nix build. Getting it from opam has multiple benefits, especially for LIGO team.

## Related issue(s)

None

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
