### PR TITLE
Allow using podman instead of docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@
 
 env:
   SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref')\""
+  USE_PODMAN: "True"
 
 steps:
  - label: reuse lint
@@ -29,11 +30,11 @@ steps:
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./binaries/bin
    branches: "!master"
 
- - label: build via docker
+ - label: build via podman
    commands:
    - eval "$SET_VERSION"
    - cd docker
-   - nix run -f.. pkgs.docker -c ./docker-static-build.sh
+   - ./docker-static-build.sh
    - nix run -f.. pkgs.upx -c upx tezos-*
    artifact_paths:
      - ./docker/tezos-*
@@ -42,7 +43,8 @@ steps:
    commands:
    - eval "$SET_VERSION"
    - cd docker
-   - ./docker-static-build.sh
+   # arm builder doesn't have podman installed
+   - USE_PODMAN="False" ./docker-static-build.sh
    - upx tezos-*
    - >
      for f in ./tezos-*; do
@@ -54,24 +56,24 @@ steps:
      queue: "arm64-build"
  - label: test docker-built binaries
    commands:
-   - buildkite-agent artifact download "docker/*" . --step "build via docker"
+   - buildkite-agent artifact download "docker/*" . --step "build via podman"
    - chmod +x ./docker/*
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
 
- - label: test deb source packages via docker
+ - label: test deb source packages via podman
    commands:
    - eval "$SET_VERSION"
-   - nix run -f. pkgs.docker -c ./docker/docker-ubuntu-packages.sh source
+   - ./docker/docker-ubuntu-packages.sh source
    artifact_paths:
      - ./out/*
    branches: "!master"
- - label: test deb binary packages via docker
+ - label: test deb binary packages via podman
    commands:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - nix run -f. pkgs.docker -c ./docker/docker-ubuntu-packages.sh binary tezos-baker-006-PsCARTHA
+   - ./docker/docker-ubuntu-packages.sh binary tezos-baker-006-PsCARTHA
    - rm -rf out
    branches: "!master"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,10 @@
 
 # Building and packaging tezos using docker
 
+The following scripts can be used with `podman` instead of `docker`
+as a virtualisation engine. In order to use `podman` you should
+set environment variable `USE_PODMAN="True"`.
+
 ## Statically built binaries
 
 Static binaries building using custom alpine image.

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # This script builds static tezos-binaries using custom alpine image.
-# It expects docker to be installed and configured.
+# It expects docker or podman to be installed and configured.
 
 set -euo pipefail
 
@@ -14,6 +14,12 @@ binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer")
 for proto in $(jq -r ".active | .[]" ../protocols.json); do
     binaries+=("tezos-accuser-$proto" "tezos-baker-$proto" "tezos-endorser-$proto")
 done
+
+if [[ "${USE_PODMAN-}" == "True" ]]; then
+    virtualisation_engine="podman"
+else
+    virtualisation_engine="docker"
+fi
 
 arch="host"
 
@@ -35,9 +41,9 @@ if [[ $arch == "aarch64" && $(uname -m) != "x86_64" ]]; then
     echo "Compiling for aarch64 is supported only from aarch64 and x86_64"
 fi
 
-docker build -t alpine-tezos -f "$docker_file" --build-arg TEZOS_VERSION="$TEZOS_VERSION" .
-container_id="$(docker create alpine-tezos)"
+"$virtualisation_engine" build -t alpine-tezos -f "$docker_file" --build-arg TEZOS_VERSION="$TEZOS_VERSION" .
+container_id="$("$virtualisation_engine" create alpine-tezos)"
 for b in "${binaries[@]}"; do
-    docker cp "$container_id:/tezos/$b" "$b"
+    "$virtualisation_engine" cp "$container_id:/tezos/$b" "$b"
 done
-docker rm -v "$container_id"
+"$virtualisation_engine" rm -v "$container_id"

--- a/docker/docker-ubuntu-packages.sh
+++ b/docker/docker-ubuntu-packages.sh
@@ -9,10 +9,16 @@
 # 'binary' or 'source' as an argument to this script.
 set -euo pipefail
 
-docker build -t tezos-ubuntu -f docker/package/Dockerfile .
+if [[ "${USE_PODMAN-}" == "True" ]]; then
+    virtualisation_engine="podman"
+else
+    virtualisation_engine="docker"
+fi
+
+"$virtualisation_engine" build -t tezos-ubuntu -f docker/package/Dockerfile .
 set +e
-container_id="$(docker create --env TEZOS_VERSION="$TEZOS_VERSION" -t tezos-ubuntu "$@")"
-docker start -a "$container_id"
-docker cp "$container_id":/tezos-packaging/docker/out .
+container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" -t tezos-ubuntu "$@")"
+"$virtualisation_engine" start -a "$container_id"
+"$virtualisation_engine" cp "$container_id":/tezos-packaging/docker/out .
 set -e
-docker rm -v "$container_id"
+"$virtualisation_engine" rm -v "$container_id"

--- a/docker/package/Dockerfile
+++ b/docker/package/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y libev-dev libgmp-dev libhidapi-dev m4 perl pkg-config \
   debhelper dh-make dh-systemd devscripts autotools-dev python3 python3-distutils wget
-RUN apt-get install -y software-properties-common && add-apt-repository ppa:avsm/ppa && apt-get update && apt-get install -y opam
+RUN apt-get install -y software-properties-common && add-apt-repository ppa:avsm/ppa -y && apt-get update && apt-get install -y opam
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging


### PR DESCRIPTION
## Description
Problem: We cannot longer use docker in our CI pipeline.

Solution: Allow using podman instead of docker, use it in CI and update
instructions to mention an ability to use podman.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)
https://issues.serokell.io/issue/OPS-1063
https://issues.serokell.io/issue/OPS-1064
<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->


#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
