### PR TITLE
Fix default sources in ocaml-overlay.nix

### DIFF
--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ sources ? import ./nix/sources.nix
+{ sources ? import ../nix/sources.nix
 , protocols ? builtins.fromJSON (builtins.readFile ../../protocols.json)
 , hacks ? import ./hacks.nix
 , pkgs ? import sources.nixpkgs { }, opam-nix ? import sources.opam-nix pkgs }:


### PR DESCRIPTION
## Description
Problem: There is invalid default path in ocaml-overlay.nix.
However, we want to use this overlay in on of our projects.

Solution: Fix default path.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

https://issues.serokell.io/issue/OPS-997
#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
