### PR TITLE
[#89][#87] Package along with optional deps

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-    "release": "1",
+    "release": "2",
     "epoch": "1",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: Ledger backend, as well as tls support, is provided
via optional opam dependencies, so they're not included by default.

Solution: Make it possible to explicitly list which optional
dependencies should be bundled along with the desired tezos package.
Add tls and ledger support to all required packages.

TODO: Now we need to bump ubuntu packages versions since the packages sources were updated
(there are new prefetched opam dependencies in them). We should find out what is the best strategy to do that.
See #95, ubuntu packages will be updated only after it's resolved
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #87
Resolves #89 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
