### PR TITLE
Update tezos ref to fix compatibility with newer Nix versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 env:
-  SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref')\""
+  SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref' | cut -d'/' -f3)\""
   USE_PODMAN: "True"
 
 steps:

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,7 +36,7 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "v7.4",
+        "ref": "refs/tags/v7.4",
         "repo": "https://gitlab.com/tezos/tezos",
         "rev": "e69b63f128701b2cdad665e8037a330305f591ce",
         "type": "git"


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Problem: Builds fail in Nix versions 2.4 and above due to a change in default handling of `ref`
Solution: Use a more explicit `ref` for the `tezos` source

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
