### PR TITLE
Fix version fetching in autoreleases 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   source = (import ./nix/nix/sources.nix).tezos;
   meta = builtins.fromJSON (builtins.readFile ./meta.json);
   commonMeta = {
-    version = builtins.replaceStrings [ "v" ] [ "" ] source.ref;
+    version = builtins.replaceStrings [ "refs/tags/v" ] [ "" ] source.ref;
     license = "MPL-2.0";
     dependencies = "";
     branchName = source.ref;


### PR DESCRIPTION
## Description
Problem: In #92 tezos sources ref was changed, however, meta builder
wasn't updated, thus autoreleasing was broken.

Solution: Fix meta building.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
