### PR TITLE
#85 Add tezos-codec packeg

### DIFF
--- a/docker/build/static_libs.patch
+++ b/docker/build/static_libs.patch
@@ -165,3 +165,18 @@ index 49e819dd2..833a3f473 100644
   (c_names fsync pread pwrite)
 - (libraries fmt index logs logs.threaded threads.posix unix))
 + (libraries fmt index logs threads.posix unix))
+diff --git a/src/bin_codec/dune b/src/bin_codec/dune
+index ae32d5d2a..50a2cf09f 100644
+--- a/src/bin_codec/dune
++++ b/src/bin_codec/dune
+@@ -30,7 +30,9 @@
+                    -open Tezos_clic
+                    -open Tezos_stdlib_unix
+                    -open Tezos_event_logging
+-                   -linkall)))
++                   -linkall -ccopt -static
++                   -cclib "-lusb-1.0 -lhidapi-libusb -ludev"
++                   )))
+
+ (rule
+   (target void_for_linking)

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer")
+binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer" "tezos-codec")
 
 for proto in $(jq -r ".active | .[]" ../protocols.json); do
     binaries+=("tezos-accuser-$proto" "tezos-baker-$proto" "tezos-endorser-$proto")

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -16,7 +16,9 @@ packages = [
             optional_opam_deps=["tls"]),
     Package("tezos-signer",
             "A client to remotely sign operations or blocks",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"])
+            optional_opam_deps=["tls", "ledgerwallet-tezos"]),
+    Package("tezos-codec",
+            "A client to decode and encode JSON")
 ]
 
 node_units = []

--- a/nix/build/release-binaries.nix
+++ b/nix/build/release-binaries.nix
@@ -28,6 +28,11 @@ in [
     description = "A client to remotely sign operations or blocks";
     supports = protocolsFormatted;
   }
+  {
+    name = "tezos-codec";
+    description = "A client to decode and encode JSON";
+    supports = protocolsFormatted;
+  }
 ] ++ builtins.concatMap (protocol: [
   {
     name = "tezos-baker-${protocol}";

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -89,3 +89,7 @@ with subtest("test remote signer"):
     machine.succeed(
         f"{tezos_client} -d client-dir import secret key remote-signer-tcp tcp://127.0.0.1:22000/{signer_addr}"
     )
+
+with subtest("test encode and decode JSON"):
+    machine.succeed(f"{tezos_codec} encode timespan.system from 42.42")
+    machine.succeed(f"{tezos_codec} decode timespan.system from 404535c28f5c28f6")

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -17,6 +17,7 @@ in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }:
     tezos_endorser = f"{path_to_binaries}/tezos-endorser-006-PsCARTHA"
     tezos_node = f"{path_to_binaries}/tezos-node"
     tezos_signer = f"{path_to_binaries}/tezos-signer"
+    tezos_codec = f"{path_to_binaries}/tezos-codec"
     openssl = "${pkgs.openssl.bin}/bin/openssl"
     binaries = [
         tezos_accuser,
@@ -26,6 +27,7 @@ in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }:
         tezos_endorser,
         tezos_node,
         tezos_signer,
+        tezos_codec,
     ]
     ${builtins.readFile ./test_script.py}'';
 }) args


### PR DESCRIPTION
## Description

Tezos-codec is a binary to decode and encode JSON. Added the
ability to create static binaries using docker and nyx. It is also possible to build packages using docker.

## Related issue(s)

nope

Resolves #85 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
