### PR TITLE
[#95] Change ubuntu packages versioning

### DIFF
--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -56,7 +56,11 @@ active_protocols = json.load(open("../protocols.json", "r"))["active"]
 
 version = os.environ["TEZOS_VERSION"][1:]
 release = f"{meta['release']}"
-package_version = f"{meta['epoch']}:0ubuntu{version}-{release}"
+
+ubuntu_epoch = 2
+fedora_epoch = 1
+
+package_version = f"{ubuntu_epoch}:0ubuntu{version}-{release}"
 
 pwd = os.getcwd()
 home = os.environ["HOME"]
@@ -121,7 +125,7 @@ systemctl enable %{{name}}.service
 Name:    {full_package_name}
 Version: {version}
 Release: {release}
-Epoch: 1
+Epoch: {fedora_epoch}
 Summary: {pkg.desc}
 License: MPL-2.0
 BuildArch: x86_64

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -60,8 +60,6 @@ release = f"{meta['release']}"
 ubuntu_epoch = 2
 fedora_epoch = 1
 
-package_version = f"{ubuntu_epoch}:0ubuntu{version}-{release}"
-
 pwd = os.getcwd()
 home = os.environ["HOME"]
 
@@ -171,7 +169,7 @@ install: {pkg.get_full_name()}
         f.write(makefile_contents)
 
 def gen_changelog(pkg: Package, ubuntu_version, maintainer, date, out):
-    changelog_contents = f'''{pkg.get_full_name().lower()} ({package_version}) {ubuntu_version}; urgency=medium
+    changelog_contents = f'''{pkg.get_full_name().lower()} ({ubuntu_epoch}:{version}-0ubuntu{release}) {ubuntu_version}; urgency=medium
 
   * Publish {version}-{release} version of {pkg.name}
 
@@ -234,7 +232,7 @@ for protocol in active_protocols:
 for package in packages:
     if package_to_build is None or package.get_full_name() == package_to_build:
         if is_ubuntu:
-            dir = f"{package.get_full_name().lower()}-0ubuntu{version}"
+            dir = f"{package.get_full_name().lower()}-{version}"
         else:
             dir = f"{package.get_full_name()}-{version}"
         # tezos-client and tezos-admin-client are in one opam package

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,4 @@
 {
     "release": "2",
-    "epoch": "1",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: Current ubuntu versioning scheme is incorrect and may
confuse users.

Solution: Use proper versioning scheme:
`<package-name>_<upstream-version>-0ubuntu<release-number>.`
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #95

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
