### PR TITLE
Add timeout for packages building

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,6 +66,7 @@ steps:
    artifact_paths:
      - ./out/*
    branches: "!master"
+   timeout_in_minutes: 30
  - label: test deb binary packages via podman
    commands:
    - eval "$SET_VERSION"
@@ -74,6 +75,7 @@ steps:
    - ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-006-PsCARTHA
    - rm -rf out
    branches: "!master"
+   timeout_in_minutes: 30
  - label: test rpm source packages via podman
    commands:
    - eval "$SET_VERSION"
@@ -81,6 +83,7 @@ steps:
    artifact_paths:
      - ./out/*
    branches: "!master"
+   timeout_in_minutes: 30
  - label: test rpm binary packages via podman
    commands:
    - eval "$SET_VERSION"
@@ -89,6 +92,7 @@ steps:
    - ./docker/docker-tezos-packages.sh fedora binary tezos-baker-007-PsDELPH1
    - rm -rf out
    branches: "!master"
+   timeout_in_minutes: 30
 
  - wait
  - label: create auto pre-release


### PR DESCRIPTION
## Description
Problem: Sometimes packages building can stuck due to some
weird opam errors. Such behaviour can silently block CI.

Solution: Normally, each step should take more than 10-15 minutes, and
we double the timeout just in case.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
