### PR TITLE
[#97] Switch autoreleases from hub to gh

### DIFF
--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -27,19 +27,15 @@ shopt -s extglob
 cp -L "$TEMPDIR"/"$project"/!(*.md) "$assets_dir"
 
 # Delete release if it exists
-hub release delete auto-release || true
+gh release delete auto-release --yes || true
 
 # Update the tag
 git fetch # So that the script can be run from an arbitrary checkout
 git tag -f auto-release
 git push --force --tags
 
-# Combine all assets
-assets=()
-for file in $assets_dir/*; do
-    echo $file
-    assets+=("-a" $file)
-done
-
 # Create release
-hub release create "${assets[@]}" -F "$TEMPDIR"/"$project"/release-notes.md --prerelease auto-release
+gh release create -F "$TEMPDIR"/"$project"/release-notes.md --prerelease auto-release
+
+# Upload assets
+gh release upload auto-release "$assets_dir"/*

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -2,8 +2,28 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs {} }:
+let
+  overlays =
+    [
+      (self: super: {
+        gh = (super.callPackage "${super.path}/pkgs/applications/version-management/git-and-tools/gh" {
+          buildGoModule = args: super.buildGoModule (args // rec {
+            version = "1.2.0";
+            vendorSha256 = "0ybbwbw4vdsxdq4w75s1i0dqad844sfgs69b3vlscwfm6g3i9h51";
+            src = self.fetchFromGitHub {
+              owner = "cli";
+              repo = "cli";
+              rev = "v${version}";
+              sha256 = "17hbgi1jh4p07r4p5mr7w7p01i6zzr28mn5i4jaki7p0jwfqbvvi";
+            };
+          });
+        });
+      })
+    ];
+in
+
+{ pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs { inherit overlays; } }:
 with pkgs;
 mkShell {
-  buildInputs = [ gitAndTools.hub git rename ];
+  buildInputs = [ gh git rename ];
 }


### PR DESCRIPTION
## Description
Problem: There is an official CLI from github, now it can handle
releases.

Solution: Switch to it from hub tool.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #97 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
