### PR TITLE
[#99] Support custom networks within the node service

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ In order to start it run:
 systemctl start tezos-node-<network>
 ```
 
+In addition to node services where the config is predefined to a specific network
+(e.g. `tezos-node-mainnet` or `tezos-node-delphinet`), it's possible to run `tezos-node-custom`
+service and provide a path to the custom node config file via the
+`CUSTOM_NODE_CONFIG` variable in the `tezos-node-custom.service` file.
+
 Another case for running multiple similar systemd services is when one wants to have
 multiple daemons that target different protocols.
 Since daemons for different protocols are provided in the different packages, they will

--- a/docker/package/scripts/tezos-node-start
+++ b/docker/package/scripts/tezos-node-start
@@ -7,28 +7,37 @@
 set -euo pipefail
 
 node="/usr/bin/tezos-node"
+# default location of the config file
+config_file="$DATA_DIR/config.json"
 
 mkdir -p "$DATA_DIR"
-if [ ! -f "$DATA_DIR/config.json" ]; then
-    echo "Configuring the node..."
-    "$node" config init \
-            --data-dir "$DATA_DIR" \
-            --rpc-addr "$NODE_RPC_ADDR" \
-            --network "$NETWORK"
-            "$@"
+# CUSTOM_NODE_CONFIG can be provided in the tezos-node-custom.service environment
+if [[ -z "${CUSTOM_NODE_CONFIG:-}" ]]; then
+    if [[ ! -f "$config_file" ]]; then
+        echo "Configuring the node..."
+        "$node" config init \
+                --data-dir "$DATA_DIR" \
+                --rpc-addr "$NODE_RPC_ADDR" \
+                --network "$NETWORK"
+                "$@"
+    else
+        echo "Updating the node configuration..."
+        "$node" config update \
+                --data-dir "$DATA_DIR" \
+                --rpc-addr "$NODE_RPC_ADDR" \
+                --network "$NETWORK"
+                "$@"
+    fi
 else
-    echo "Updating the node configuration..."
-    "$node" config update \
-            --data-dir "$DATA_DIR" \
-            --rpc-addr "$NODE_RPC_ADDR" \
-            --network "$NETWORK"
-            "$@"
+    echo "Run using custom node config file"
+    config_file="$CUSTOM_NODE_CONFIG"
 fi
 
 # Launching the node
 
 if [[ -z "$CERT_PATH" || -z "$KEY_PATH" ]]; then
-    exec "$node" run --data-dir "$DATA_DIR"
+    exec "$node" run --data-dir "$DATA_DIR" --config-file="$config_file"
 else
-    exec "$node" run --data-dir "$DATA_DIR" --rpc-tls="$CERT_PATH","$KEY_PATH"
+    exec "$node" run --data-dir "$DATA_DIR" --config-file="$config_file" \
+        --rpc-tls="$CERT_PATH","$KEY_PATH"
 fi


### PR DESCRIPTION
## Description

Problem: We want to run node in some custom network. A custom network
can be defined via a custom node config file.

Solution: Using a variable CUSTOM_NODE_CONFIG, you can specify the path
to the node configuration file.

## Related issue(s)

None

Resolves #99 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
