### PR TITLE
Switch back to docker

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,6 @@
 
 env:
   SET_VERSION: "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref' | cut -d'/' -f3)\""
-  USE_PODMAN: "True"
 
 steps:
  - label: reuse lint
@@ -28,7 +27,7 @@ steps:
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./binaries/bin
    branches: "!master"
 
- - label: build via podman
+ - label: build via docker
    commands:
    - eval "$SET_VERSION"
    - cd docker
@@ -36,13 +35,14 @@ steps:
    - nix run -f.. pkgs.upx -c upx tezos-*
    artifact_paths:
      - ./docker/tezos-*
+   agents:
+     queue: "docker"
  # arm builer is an ubuntu machine without nix
  - label: build arm via docker
    commands:
    - eval "$SET_VERSION"
    - cd docker
-   # arm builder doesn't have podman installed
-   - USE_PODMAN="False" ./docker-static-build.sh
+   - ./docker-static-build.sh
    - upx tezos-*
    - >
      for f in ./tezos-*; do
@@ -52,14 +52,18 @@ steps:
      - ./docker/tezos-*
    agents:
      queue: "arm64-build"
+
+ # binaries built by docker are tested on the another machine,
+ # so we should wait for docker build to finish
+ - wait
  - label: test docker-built binaries
    commands:
-   - buildkite-agent artifact download "docker/*" . --step "build via podman"
+   - buildkite-agent artifact download "docker/*" . --step "build via docker"
    - chmod +x ./docker/*
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
 
- - label: test deb source packages via podman
+ - label: test deb source packages via docker
    commands:
    - eval "$SET_VERSION"
    - ./docker/docker-tezos-packages.sh ubuntu source
@@ -67,7 +71,9 @@ steps:
      - ./out/*
    branches: "!master"
    timeout_in_minutes: 30
- - label: test deb binary packages via podman
+   agents:
+     queue: "docker"
+ - label: test deb binary packages via docker
    commands:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
@@ -76,7 +82,9 @@ steps:
    - rm -rf out
    branches: "!master"
    timeout_in_minutes: 30
- - label: test rpm source packages via podman
+   agents:
+     queue: "docker"
+ - label: test rpm source packages via docker
    commands:
    - eval "$SET_VERSION"
    - ./docker/docker-tezos-packages.sh fedora source
@@ -84,7 +92,9 @@ steps:
      - ./out/*
    branches: "!master"
    timeout_in_minutes: 30
- - label: test rpm binary packages via podman
+   agents:
+     queue: "docker"
+ - label: test rpm binary packages via docker
    commands:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
@@ -93,13 +103,15 @@ steps:
    - rm -rf out
    branches: "!master"
    timeout_in_minutes: 30
+   agents:
+     queue: "docker"
 
  - wait
  - label: create auto pre-release
    commands:
    - mkdir binaries
    - mkdir arm-binaries
-   - buildkite-agent artifact download "docker/*" binaries --step "build via podman"
+   - buildkite-agent artifact download "docker/*" binaries --step "build via docker"
    - buildkite-agent artifact download "docker/*" arm-binaries --step "build arm via docker"
    - ls binaries
    - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh

--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -20,4 +20,4 @@ RUN opam install opam-bundle=0.4 --yes
 COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
-ENTRYPOINT ["python3", "-m", "package.package_generator.py"]
+ENTRYPOINT ["python3", "-m", "package.package_generator"]

--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -20,4 +20,4 @@ RUN opam install opam-bundle=0.4 --yes
 COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
-ENTRYPOINT ["python3", "-m", "package.package_generator.py"]
+ENTRYPOINT ["python3", "-m", "package.package_generator"]


### PR DESCRIPTION
## Description
Problem: Podman turned out to be quite unreliable.

Solution: Switch back to docker, since we now have a dedicated agent
with access to the docker.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
