### PR TITLE
Deactivate 006 protocol

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,7 +78,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-006-PsCARTHA
+   - ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-007-PsDELPH1
    - rm -rf out
    branches: "!master"
    timeout_in_minutes: 30

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo add-apt-repository ppa:serokell/tezos && sudo apt-get update
 sudo apt-get install tezos-client
 # dpkg-source prohibits uppercase in the packages names so the protocol
 # name is in lowercase
-sudo apt-get install tezos-baker-006-pscartha
+sudo apt-get install tezos-baker-007-psdelph1
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
@@ -52,11 +52,11 @@ E.g. in order to install `tezos-client` or `tezos-baker` run the following comma
 # use dnf
 sudo dnf copr enable @Serokell/Tezos
 sudo dnf install tezos-client
-sudo dnf install tezos-baker-006-PsCARTHA
+sudo dnf install tezos-baker-007-PsDELPH1
 
 # or use yum
 sudo yum copr enable @Serokell/Tezos
-sudo yum install tezos-baker-006-PsCARTHA
+sudo yum install tezos-baker-007-PsDELPH1
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
@@ -109,7 +109,7 @@ from scratch.
 For this you'll need `.service` file to define systemd service. The easiest way
 to get one is to run [`gen_systemd_service_file.py`](gen_systemd_service_file.py).
 You should specify service name as an argument. Note that there are three
-predefined services for `tezos-node`: `tezos-node-{mainnet, carthagenet, delphinet}`.
+predefined services for `tezos-node`: `tezos-node-{mainnet, delphinet}`.
 
 E.g.:
 ```
@@ -130,8 +130,8 @@ It's possible to run multiple same services, e.g. two `tezos-node`s that run dif
 networks.
 
 `tezos-node` packages provide three services out of the box:
-`tezos-node-delphinet`, `tezos-node-carthagenet` and `tezos-node-mainnet` that run
-`delphinet`, `carthagenet` and `mainnet` networks respectively.
+`tezos-node-delphinet` and `tezos-node-mainnet` that run
+`delphinet` and `mainnet` networks respectively.
 
 In order to start it run:
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,7 +69,7 @@ It is also possible to build single package. In order to do that run the followi
 # cd .. && ./docker/docker-tezos-packages.sh ubuntu binary <tezos-binary-name>
 # Example for baker
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-006-PsCARTHA
+cd .. && ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-007-PsDELPH1
 ```
 
 The build can take some time due to the fact that we build tezos and its dependencies
@@ -89,7 +89,7 @@ In order to build source packages run the following commands:
 export TEZOS_VERSION="v7.3"
 cd .. && ./docker/docker-tezos-packages.sh ubuntu source
 # you can also build single source package
-cd .. && ./docker/docker-tezos-packages.sh ubuntu source tezos-baker-006-PsCARTHA
+cd .. && ./docker/docker-tezos-packages.sh ubuntu source tezos-baker-007-PsDELPH1
 ```
 
 Once the packages build is complete `../out` directory will contain files required
@@ -142,7 +142,7 @@ It is also possible to build single package. In order to do that run the followi
 # cd .. && ./docker/docker-tezos-packages.sh fedora binary <tezos-binary-name>
 # Example for baker
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh fedora binary tezos-baker-006-PsCARTHA
+cd .. && ./docker/docker-tezos-packages.sh fedora binary tezos-baker-007-PsDELPH1
 ```
 
 The build can take some time due to the fact that we build tezos and its dependencies
@@ -162,7 +162,7 @@ In order to build source packages run the following commands:
 export TEZOS_VERSION="v7.3"
 cd .. && ./docker/docker-tezos-packages.sh fedora source
 # you can also build single source package
-cd .. && ./docker/docker-tezos-packages.sh fedora source tezos-baker-006-PsCARTHA
+cd .. && ./docker/docker-tezos-packages.sh fedora source tezos-baker-007-PsDELPH1
 ```
 
 Resulting `.src.rpm` packages can be either built locally or submitted to the Copr.

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -5,7 +5,7 @@ import os, shutil, sys, subprocess, json
 
 from .model import Service, ServiceFile, SystemdUnit, Unit, Package
 
-networks = ["mainnet", "carthagenet", "delphinet"]
+networks = ["mainnet", "delphinet"]
 
 packages = [
     Package("tezos-client",

--- a/protocols.json
+++ b/protocols.json
@@ -12,10 +12,10 @@
     "003-PsddFKi3",
     "004-Pt24m4xi",
     "005-PsBABY5H",
-    "005-PsBabyM1"
+    "005-PsBabyM1",
+    "006-PsCARTHA"
   ],
   "active": [
-    "006-PsCARTHA",
     "007-PsDELPH1"
   ]
 }

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -69,14 +69,14 @@ def test_node_with_daemons_scenario(network, use_tls=False):
     kill_node_with_daemons()
 
 
-with subtest("run node with daemons on carthagenet"):
-    test_node_with_daemons_scenario("carthagenet")
+with subtest("run node with daemons on delphinet"):
+    test_node_with_daemons_scenario("delphinet")
 
 with subtest("run node with daemons on mainnet"):
     test_node_with_daemons_scenario("mainnet")
 
 with subtest("run node with daemons using tls"):
-    test_node_with_daemons_scenario("carthagenet", use_tls=True)
+    test_node_with_daemons_scenario("delphinet", use_tls=True)
 
 with subtest("test remote signer"):
     machine.succeed(f"{tezos_signer} -d signer-dir gen keys signer")

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -10,11 +10,11 @@ in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }:
 
   testScript = ''
     path_to_binaries = "${path-to-binaries}"
-    tezos_accuser = f"{path_to_binaries}/tezos-accuser-006-PsCARTHA"
+    tezos_accuser = f"{path_to_binaries}/tezos-accuser-007-PsDELPH1"
     tezos_admin_client = f"{path_to_binaries}/tezos-admin-client"
-    tezos_baker = f"{path_to_binaries}/tezos-baker-006-PsCARTHA"
+    tezos_baker = f"{path_to_binaries}/tezos-baker-007-PsDELPH1"
     tezos_client = f"{path_to_binaries}/tezos-client"
-    tezos_endorser = f"{path_to_binaries}/tezos-endorser-006-PsCARTHA"
+    tezos_endorser = f"{path_to_binaries}/tezos-endorser-007-PsDELPH1"
     tezos_node = f"{path_to_binaries}/tezos-node"
     tezos_signer = f"{path_to_binaries}/tezos-signer"
     tezos_codec = f"{path_to_binaries}/tezos-codec"


### PR DESCRIPTION
## Description
Problem: 007 protocol was activated on mainnet and carthagenet will die
soon, so it doesn't make much sense to maintain 006 protocol-specific
binaries and packages.

Solution: Move 006 from active to allowed in protocols.json and update other
files accordingly.

Currently based on #110 
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
