### PR TITLE
[#100] tezos-signer services

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Run `./tezos-client` or add it to your PATH to be able to run it anywhere.
 
 ### Systemd units on Ubuntu or Fedora
 
-`tezos-node`, `tezos-accuser-<proto>`, `tezos-baker-<proto>` and
-`tezos-endorser-<proto>` packages have systemd files included to the
+`tezos-node`, `tezos-accuser-<proto>`, `tezos-baker-<proto>`,
+`tezos-endorser-<proto>`, and `tezos-signer` packages have systemd files included to the
 Ubuntu and Fedora packages.
 
 Once you've installed the packages with systemd unit, you can run the service
@@ -144,6 +144,13 @@ Since daemons for different protocols are provided in the different packages, th
 have different service files. The only thing that needs to be changed is config file.
 One should provide desired node address, data directory for daemon files and node directory
 (however, this is the case only for baker daemon).
+
+`tezos-signer` package provides four services one for each mode in which signing daemon can run:
+* Over TCP socket (`tezos-signer-tcp.service`).
+* Over UNIX socker (`tezos-signer-unix.service`).
+* Over HTTP (`tezos-signer-http.service`).
+* Over HTTPS (`tezos-signer-https.service`)
+Each signer service has dedicated config file in e.g. `/etc/default/tezos-signer-{mode}`.
 
 ## Build Instructions
 

--- a/docker/package/defaults/tezos-signer.conf
+++ b/docker/package/defaults/tezos-signer.conf
@@ -1,0 +1,10 @@
+# vim: ft=sh
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# shellcheck disable=SC2034
+DATA_DIR="/var/lib/tezos/signer"
+PIDFILE=""
+MAGIC_BYTES=""
+CHECK_HIGH_WATERMARK=""

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -7,7 +7,7 @@ from typing import List
 # There are more possible fields, but only these are used by tezos services
 class Service:
     def __init__(self, exec_start: str, state_directory:str, user: str,
-                 environment_file: str=None, environment: List[str]=[],):
+                 environment_file: str=None, environment: List[str]=[]):
         self.environment_file = environment_file
         self.environment = environment
         self.exec_start = exec_start

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -200,6 +200,7 @@ def gen_rules(pkg: Package, out):
     for systemd_unit in pkg.systemd_units:
         if systemd_unit.suffix is not None:
             override_dh_install_init += f"	dh_installinit --name={pkg.name}-{systemd_unit.suffix}\n"
+    override_dh_install_init += "	dh_installinit --noscripts\n"
     rules_contents = f'''#!/usr/bin/make -f
 
 %:
@@ -233,7 +234,7 @@ for package in packages:
         os.rename(f"{opam_package}-bundle", dir)
         # subprocess.run(["mkdir", dir])
         gen_makefile(package, f"{dir}/Makefile")
-        config_files = list(filter(lambda x: x is not None, map(lambda x: x.config_file, package.systemd_units)))
+        config_files = list(set(filter(lambda x: x is not None, map(lambda x: x.config_file, package.systemd_units))))
         if len(config_files) > 1:
             raise Exception("Packages cannot have more than one default config file for package")
         if not is_ubuntu:

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -47,8 +47,9 @@ fedora_epoch = 1
 pwd = os.getcwd()
 home = os.environ["HOME"]
 
+
 def gen_control_file(pkg: Package, out):
-    str_build_deps = ", ".join(build_deps)
+    str_build_deps = ", ".join(common_deps)
     file_contents = f'''
 Source: {pkg.name.lower()}
 Section: utils
@@ -66,8 +67,9 @@ Description: {pkg.desc}
     with open(out, 'w') as f:
         f.write(file_contents)
 
+
 def gen_spec_file(pkg: Package, out):
-    build_requires = " ".join(build_deps + run_deps)
+    build_requires = " ".join(common_deps)
     config_files = list(filter(lambda x: x is not None, map(lambda x: x.config_file, package.systemd_units)))
     requires = " ".join(run_deps)
     if len(pkg.systemd_units) > 0:

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -11,7 +11,7 @@ signer_units = [
     SystemdUnit(
         ServiceFile(Unit(after=["network.target"],
                          description="Tezos signer daemon running over TCP socket"),
-                    Service(environment_file="/etc/default/tezos-signer",
+                    Service(environment_file="/etc/default/tezos-signer-tcp",
                             environment=["ADDRESS=127.0.0.1", "PORT=8000", "TIMEOUT=1"],
                             exec_start="/usr/bin/tezos-signer-start launch socket signer " \
                             + " --address ${ADDRESS} --port ${PORT} --timeout ${TIMEOUT}",
@@ -22,7 +22,7 @@ signer_units = [
     SystemdUnit(
         ServiceFile(Unit(after=["network.target"],
                          description="Tezos signer daemon running over UNIX socket"),
-                    Service(environment_file="/etc/default/tezos-signer",
+                    Service(environment_file="/etc/default/tezos-signer-unix",
                             environment=["SOCKET="],
                             exec_start="/usr/bin/tezos-signer-start launch local signer " \
                             + "--socket ${SOCKET}",
@@ -33,7 +33,7 @@ signer_units = [
     SystemdUnit(
         ServiceFile(Unit(after=["network.target"],
                          description="Tezos signer daemon running over HTTP"),
-                    Service(environment_file="/etc/default/tezos-signer",
+                    Service(environment_file="/etc/default/tezos-signer-http",
                             environment=["CERT_PATH=", "KEY_PATH=", "ADDRESS=127.0.0.1", "PORT=8080"],
                             exec_start="/usr/bin/tezos-signer-start launch http signer " \
                             + "--address ${ADDRESS} --port ${PORT}",
@@ -44,7 +44,7 @@ signer_units = [
     SystemdUnit(
         ServiceFile(Unit(after=["network.target"],
                          description="Tezos signer daemon running over HTTPs"),
-                    Service(environment_file="/etc/default/tezos-signer",
+                    Service(environment_file="/etc/default/tezos-signer-https",
                             environment=["CERT_PATH=", "KEY_PATH=", "ADDRESS=127.0.0.1", "PORT=8080"],
                             exec_start="/usr/bin/tezos-signer-start launch https signer " \
                             + "${CERT_PATH} ${KEY_PATH} --address ${ADDRESS} --port ${PORT}",

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -7,6 +7,53 @@ from .model import Service, ServiceFile, SystemdUnit, Unit, Package
 
 networks = ["mainnet", "delphinet"]
 
+signer_units = [
+    SystemdUnit(
+        ServiceFile(Unit(after=["network.target"],
+                         description="Tezos signer daemon running over TCP socket"),
+                    Service(environment_file="/etc/default/tezos-signer",
+                            environment=["ADDRESS=127.0.0.1", "PORT=8000", "TIMEOUT=1"],
+                            exec_start="/usr/bin/tezos-signer-start launch socket signer " \
+                            + " --address ${ADDRESS} --port ${PORT} --timeout ${TIMEOUT}",
+                            state_directory="tezos", user="tezos")),
+        suffix="tcp",
+        startup_script="tezos-signer-start",
+        config_file="tezos-signer.conf"),
+    SystemdUnit(
+        ServiceFile(Unit(after=["network.target"],
+                         description="Tezos signer daemon running over UNIX socket"),
+                    Service(environment_file="/etc/default/tezos-signer",
+                            environment=["SOCKET="],
+                            exec_start="/usr/bin/tezos-signer-start launch local signer " \
+                            + "--socket ${SOCKET}",
+                            state_directory="tezos", user="tezos")),
+        suffix="unix",
+        startup_script="tezos-signer-start",
+        config_file="tezos-signer.conf"),
+    SystemdUnit(
+        ServiceFile(Unit(after=["network.target"],
+                         description="Tezos signer daemon running over HTTP"),
+                    Service(environment_file="/etc/default/tezos-signer",
+                            environment=["CERT_PATH=", "KEY_PATH=", "ADDRESS=127.0.0.1", "PORT=8080"],
+                            exec_start="/usr/bin/tezos-signer-start launch http signer " \
+                            + "--address ${ADDRESS} --port ${PORT}",
+                            state_directory="tezos", user="tezos")),
+        suffix="http",
+        startup_script="tezos-signer-start",
+        config_file="tezos-signer.conf"),
+    SystemdUnit(
+        ServiceFile(Unit(after=["network.target"],
+                         description="Tezos signer daemon running over HTTPs"),
+                    Service(environment_file="/etc/default/tezos-signer",
+                            environment=["CERT_PATH=", "KEY_PATH=", "ADDRESS=127.0.0.1", "PORT=8080"],
+                            exec_start="/usr/bin/tezos-signer-start launch https signer " \
+                            + "${CERT_PATH} ${KEY_PATH} --address ${ADDRESS} --port ${PORT}",
+                            state_directory="tezos", user="tezos")),
+        suffix="https",
+        startup_script="tezos-signer-start",
+        config_file="tezos-signer.conf")
+]
+
 packages = [
     Package("tezos-client",
             "CLI client for interacting with tezos blockchain",
@@ -16,7 +63,8 @@ packages = [
             optional_opam_deps=["tls"]),
     Package("tezos-signer",
             "A client to remotely sign operations or blocks",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"]),
+            optional_opam_deps=["tls", "ledgerwallet-tezos"],
+            systemd_units=signer_units),
     Package("tezos-codec",
             "A client to decode and encode JSON")
 ]

--- a/docker/package/scripts/tezos-signer-start
+++ b/docker/package/scripts/tezos-signer-start
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+set -euo pipefail
+
+# $PROTOCOL should be defined in the system unit environment
+signer="/usr/bin/tezos-signer"
+
+if [[ -n $PIDFILE ]]; then
+   pid_file_args=("--pid-file" "$PIDFILE")
+else
+   pid_file_args=()
+fi
+
+if [[ -n $MAGIC_BYTES ]]; then
+   magic_bytes_args=("--magic-bytes" "$MAGIC_BYTES")
+else
+   magic_bytes_args=()
+fi
+
+if [[ -n $CHECK_HIGH_WATERMARK ]]; then
+   check_high_watermark_args=("--check-high-watermark")
+else
+   check_high_watermark_args=()
+fi
+
+"$signer" -d "$DATA_DIR" "${pid_file_args[@]}" "${magic_bytes_args[@]}" \
+  "${check_high_watermark_args[@]}" "$@"


### PR DESCRIPTION
## Description
Problem: tezos-signer can be run as a signing daemon in one of four
modes.

Solution: Add services for each signer daemon mode: over TCP socket,
over Unix socket, over HTTP, and over HTTPS.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #100

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
