### PR TITLE
Fix autoreleasing once again

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -114,5 +114,5 @@ steps:
    - buildkite-agent artifact download "docker/*" binaries --step "build via docker"
    - buildkite-agent artifact download "docker/*" arm-binaries --step "build arm via docker"
    - ls binaries
-   - GITHUB_TOKEN=$(cat ~/niv-bot-token) ./scripts/autorelease.sh
+   - ./scripts/autorelease.sh
    branches: master

--- a/default.nix
+++ b/default.nix
@@ -15,6 +15,6 @@ let
     licenseFile = "${source}/LICENSE";
   } // meta;
   release = pkgs.callPackage ./release.nix
-    { binaries = docker-binaries; arm-binaries = docker-arm-binaries; inherit commonMeta; };
+    { binaries = docker-binaries; arm-binaries = docker-arm-binaries; inherit commonMeta; inherit (pkgs.lib) replaceStrings; };
 
 in { inherit release commonMeta pkgs; }

--- a/release.nix
+++ b/release.nix
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-{ writeTextDir, runCommand, buildEnv, binaries, arm-binaries, commonMeta }:
+{ writeTextDir, runCommand, buildEnv, binaries, arm-binaries, commonMeta, replaceStrings }:
 let
   release-binaries = import ./nix/build/release-binaries.nix;
+  version = replaceStrings ["refs/tags/"] [""] commonMeta.branchName;
   release-notes = writeTextDir "release-notes.md" ''
     Automatic release
 
-    This release contains assets based on [${commonMeta.branchName} release](https://gitlab.com/tezos/tezos/tree/${commonMeta.branchName}).
+    This release contains assets based on [${version} release](https://gitlab.com/tezos/tezos/tree/${version}).
 
     Binaries that target arm64 architecture has `-arm64` suffix in the name.
     Other binaries target x86_64.

--- a/release.nix
+++ b/release.nix
@@ -7,8 +7,6 @@ let
   release-binaries = import ./nix/build/release-binaries.nix;
   version = replaceStrings ["refs/tags/"] [""] commonMeta.branchName;
   release-notes = writeTextDir "release-notes.md" ''
-    Automatic release
-
     This release contains assets based on [${version} release](https://gitlab.com/tezos/tezos/tree/${version}).
 
     Binaries that target arm64 architecture has `-arm64` suffix in the name.

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -35,7 +35,7 @@ git tag -f auto-release
 git push --force --tags
 
 # Create release
-gh release create -F "$TEMPDIR"/"$project"/release-notes.md --prerelease auto-release
+gh release create -F "$TEMPDIR"/"$project"/release-notes.md --prerelease auto-release --title auto-release
 
 # Upload assets
 gh release upload auto-release "$assets_dir"/*


### PR DESCRIPTION
## Description
Problem: Buildkite agent was moved to another server and the file with
token now isn't presented in the filesystem.

Solution: Don't rely on file and fetch token directly from vault.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
