### PR TITLE
[#118] Simplify Ubuntu release updating

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,7 @@ steps:
  - label: test deb source packages via docker
    commands:
    - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh ubuntu source
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
    artifact_paths:
      - ./out/*
    branches: "!master"
@@ -78,7 +78,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-007-PsDELPH1
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
    - rm -rf out
    branches: "!master"
    timeout_in_minutes: 30
@@ -87,7 +87,7 @@ steps:
  - label: test rpm source packages via docker
    commands:
    - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh fedora source
+   - ./docker/docker-tezos-packages.sh --os fedora --type source
    artifact_paths:
      - ./out/*
    branches: "!master"
@@ -99,7 +99,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh fedora binary tezos-baker-007-PsDELPH1
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
    - rm -rf out
    branches: "!master"
    timeout_in_minutes: 30

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,15 +61,15 @@ In order to build binary `.deb` packages specify `TEZOS_VERSION` and
 run the following command:
 ```
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh ubuntu binary
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type binary
 ```
 
 It is also possible to build single package. In order to do that run the following:
 ```
-# cd .. && ./docker/docker-tezos-packages.sh ubuntu binary <tezos-binary-name>
+# cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package <tezos-binary-name>
 # Example for baker
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh ubuntu binary tezos-baker-007-PsDELPH1
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
 ```
 
 The build can take some time due to the fact that we build tezos and its dependencies
@@ -87,9 +87,9 @@ sudo apt install <path to deb file>
 In order to build source packages run the following commands:
 ```
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh ubuntu source
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type source
 # you can also build single source package
-cd .. && ./docker/docker-tezos-packages.sh ubuntu source tezos-baker-007-PsDELPH1
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type source --package tezos-baker-007-PsDELPH1
 ```
 
 Once the packages build is complete `../out` directory will contain files required
@@ -121,6 +121,22 @@ command for each `.changes` file:
 dput ppa:serokell/tezos ../out/<package>.changes
 ```
 
+#### Updating release in scope of the same upstream version
+
+In case you're uploading the same version of the package but with the a different
+release number, you'll highly likely have to use the same source archive (`.orig.tar.gz` archive)
+that was used for the first release in the scope of the same version, it can be downloaded from
+the launchpad package details (e.g. https://launchpad.net/~serokell/+archive/ubuntu/tezos/+sourcefiles/tezos-client/2:7.4-0ubuntu2/tezos-client_7.4.orig.tar.gz).
+Otherwise, Launchpad will prohibit the build of the new release.
+
+In order to build new proper source package using existing source archive run the following:
+```
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type source --package tezos-client --sources <path to .orig.tar.gz>
+```
+
+After that, the resulting source package can be signed and uploaded to the Launchpad using the commands
+described previously.
+
 ## Fedora packages
 
 We provide a way to build both binary(`.rpm`) and source(`.src.rpm`) native Fedora packages.
@@ -134,15 +150,15 @@ In order to build binary `.rpm` packages specify `TEZOS_VERSION` and
 run the following command:
 ```
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh fedora binary
+cd .. && ./docker/docker-tezos-packages.sh --os fedora --type binary
 ```
 
 It is also possible to build single package. In order to do that run the following:
 ```
-# cd .. && ./docker/docker-tezos-packages.sh fedora binary <tezos-binary-name>
+# cd .. && ./docker/docker-tezos-packages.sh --os fedora --type binary --package <tezos-binary-name>
 # Example for baker
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh fedora binary tezos-baker-007-PsDELPH1
+cd .. && ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
 ```
 
 The build can take some time due to the fact that we build tezos and its dependencies
@@ -160,9 +176,9 @@ sudo yum localinstall <path to rpm file>
 In order to build source packages run the following commands:
 ```
 export TEZOS_VERSION="v7.3"
-cd .. && ./docker/docker-tezos-packages.sh fedora source
+cd .. && ./docker/docker-tezos-packages.sh --os fedora --type source
 # you can also build single source package
-cd .. && ./docker/docker-tezos-packages.sh fedora source tezos-baker-007-PsDELPH1
+cd .. && ./docker/docker-tezos-packages.sh --os fedora --type source --package tezos-baker-007-PsDELPH1
 ```
 
 Resulting `.src.rpm` packages can be either built locally or submitted to the Copr.

--- a/docker/docker-tezos-packages.sh
+++ b/docker/docker-tezos-packages.sh
@@ -16,11 +16,29 @@ else
     virtualisation_engine="docker"
 fi
 
-target_os="${1-}"
+args=()
+
+while true;
+do
+    arg="${1-}"
+    if [[ -z "$arg" ]];
+    then
+        break
+    fi
+    case $arg in
+        --os )
+            target_os="$2"
+            shift 2
+            ;;
+        * )
+            args+=("$arg")
+            shift
+    esac
+done
 
 "$virtualisation_engine" build -t tezos-"$target_os" -f docker/package/Dockerfile-"$target_os" .
 set +e
-container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "$@")"
+container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
 "$virtualisation_engine" start -a "$container_id"
 exit_code="$?"
 "$virtualisation_engine" cp "$container_id":/tezos-packaging/docker/out .

--- a/docker/docker-tezos-packages.sh
+++ b/docker/docker-tezos-packages.sh
@@ -27,18 +27,31 @@ do
     fi
     case $arg in
         --os )
+            args+=("$arg" "$2")
             target_os="$2"
+            shift 2
+            ;;
+        --sources )
+            source_archive="$2"
+            source_archive_name="$(basename "$2")"
+            args+=("$arg" "$source_archive_name")
             shift 2
             ;;
         * )
             args+=("$arg")
             shift
+            ;;
     esac
 done
 
 "$virtualisation_engine" build -t tezos-"$target_os" -f docker/package/Dockerfile-"$target_os" .
 set +e
-container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
+if [[ -z ${source_archive-} ]]; then
+    container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
+else
+    container_id="$("$virtualisation_engine" create -v "$PWD/$source_archive:/tezos-packaging/docker/$source_archive_name" \
+     --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
+fi
 "$virtualisation_engine" start -a "$container_id"
 exit_code="$?"
 "$virtualisation_engine" cp "$container_id":/tezos-packaging/docker/out .


### PR DESCRIPTION
## Description
Problem: Launchpad requires the source archive to be the same for
the same package version, but a different release number.

Solution: Allow using existing source archive when building ubuntu
packages.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #118

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
