### PR TITLE
[#109] Static tezos-sandbox binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@
 
 [![Build status](https://badge.buildkite.com/e899e9e54babcd14139e3bd4381bad39b5d680e08e7b7766d4.svg?branch=master)](https://buildkite.com/serokell/tezos-packaging)
 
-This repo provides various form of distribution for tezos-related executables
-(`tezos-client`, `tezos-client-admin`, `tezos-node`, `tezos-baker`,
-`tezos-accuser`, `tezos-endorser`, `tezos-signer` and `tezos-protocol-compiler`).
+This repo provides various form of distribution for tezos-related executables:
+* `tezos-client`
+* `tezos-admin-client`
+* `tezos-node`
+* `tezos-baker`
+* `tezos-accuser`
+* `tezos-endorser`
+* `tezos-signer`
+* `tezos-codec`
+* `tezos-sandbox`
 
 Daemon binaries (as well as packages for them) have suffix that defines their target protocol,
 e.g. `tezos-baker-007-PsDELPH1` can be used only on the chain with 007 protocol.

--- a/docker/build/build-tezos.sh
+++ b/docker/build/build-tezos.sh
@@ -16,4 +16,4 @@ git apply ../static.patch
 export OPAMYES="true"
 opam init --bare --disable-sandboxing
 make build-deps
-eval "$(opam env)" && make
+eval "$(opam env)" && make && make build-sandbox

--- a/docker/build/static_libs.patch
+++ b/docker/build/static_libs.patch
@@ -180,3 +180,16 @@ index ae32d5d2a..50a2cf09f 100644
 
  (rule
    (target void_for_linking)
+diff --git a/src/bin_sandbox/dune b/src/bin_sandbox/dune
+index c7f477c33..1fbee635e 100644
+--- a/src/bin_sandbox/dune
++++ b/src/bin_sandbox/dune
+@@ -1,7 +1,7 @@
+ (executables
+   (names main)
+   (libraries flextesa)
+-  (flags :standard))
++  (flags :standard -ccopt -static))
+ 
+ (alias
+   (name runtest_sandbox_accusations_simple_double_baking)

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -9,7 +9,7 @@
 
 set -euo pipefail
 
-binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer" "tezos-codec")
+binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer" "tezos-codec" "tezos-sandbox")
 
 for proto in $(jq -r ".active | .[]" ../protocols.json); do
     binaries+=("tezos-accuser-$proto" "tezos-baker-$proto" "tezos-endorser-$proto")

--- a/nix/build/release-binaries.nix
+++ b/nix/build/release-binaries.nix
@@ -33,6 +33,11 @@ in [
     description = "A client to decode and encode JSON";
     supports = protocolsFormatted;
   }
+  {
+    name = "tezos-sandbox";
+    description = "A tool for setting up and running testing scenarios with the local blockchain";
+    supports = protocolsFormatted;
+  }
 ] ++ builtins.concatMap (protocol: [
   {
     name = "tezos-baker-${protocol}";

--- a/nix/build/static-overlay.nix
+++ b/nix/build/static-overlay.nix
@@ -31,5 +31,5 @@ in {
     builtins.listToAttrs (map ({ name, ... }: {
       inherit name;
       value = makeStaticDefaults osuper.${name};
-    }) release-binaries));
+    }) (builtins.filter (elem: elem.name != "tezos-sandbox") release-binaries)));
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,7 +8,8 @@ let
   source = (import ./nix/sources.nix).tezos;
   protocols = import ./protocols.nix;
   bin = pkgs.callPackage ./build/bin.nix { };
-  release-binaries = import ./build/release-binaries.nix;
+  release-binaries = builtins.filter (elem: elem.name != "tezos-sandbox")
+    (import ./build/release-binaries.nix);
   binaries = builtins.listToAttrs (map (meta: {
     inherit (meta) name;
     value = bin pkgs.pkgsMusl.ocamlPackages.${meta.name} // { inherit meta; };


### PR DESCRIPTION
## Description
Problem: There is a program called tezos-sandbox that can be helpful
for setting up and testing various scenarios with the blockchain.
Also, it's not built by default, however, it's still useful for the
developers

Solution: Build and bundle static tezos-sandbox binary.

Suddenly, there is no opam package for tezos-sandbox, thus we cannot
provide native Ubuntu and Fedora packages with tezos-sandbox.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #109 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
