### PR TITLE
[#114] Sign and hash artifacts

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -181,4 +181,10 @@ cd .. && ./docker/docker-tezos-packages.sh --os fedora --type source
 cd .. && ./docker/docker-tezos-packages.sh --os fedora --type source --package tezos-baker-007-PsDELPH1
 ```
 
+Sign source packages:
+```
+rpm --add-sign out/*.src.rpm
+```
+Note, that in order to sign them, you'll need gpg key to be set up in `~/.rpmmacros`.
+
 Resulting `.src.rpm` packages can be either built locally or submitted to the Copr.

--- a/release.nix
+++ b/release.nix
@@ -12,6 +12,9 @@ let
     Binaries that target arm64 architecture has `-arm64` suffix in the name.
     Other binaries target x86_64.
 
+    Release artifacts are signed with the following key: 0x7EAF9B150ACE940CF8C008A0BF847A85AC7BF43E.
+    You can check it on http://keys.gnupg.net/.
+
     Descriptions for binaries included in this release:
     ${builtins.concatStringsSep "\n"
     (map ({ name, description, ... }: "- `${name}`: ${description}")

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -22,6 +22,9 @@ assets_dir=$TEMPDIR/assets
 nix-build -A release -o "$TEMPDIR"/"$project" --arg timestamp "$(date +\"%Y%m%d%H%M\")" \
           --arg docker-binaries ./binaries/docker --arg docker-arm-binaries ./arm-binaries/docker
 mkdir -p "$assets_dir"
+for asset in "$assets_dir"/*; do
+    sha256sum "$asset" > "$asset.sha256"
+done
 # Move archive with binaries and tezos license to assets
 shopt -s extglob
 cp -L "$TEMPDIR"/"$project"/!(*.md) "$assets_dir"

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -25,5 +25,5 @@ in
 { pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs { inherit overlays; } }:
 with pkgs;
 mkShell {
-  buildInputs = [ gh git rename ];
+  buildInputs = [ gh git rename gnupg ];
 }


### PR DESCRIPTION
## Description
We want to provide some way for people to check whether binaries/packages they're using are genuine
and created by Serokell.

This PR adds sha256 sum calculation along with PGP signing for all autorelease artifacts.

Also, this PR adds instruction about how native packages should be signed before publishing.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #114

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
