### PR TITLE
v7.5 release

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,48 +63,49 @@ steps:
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
 
- - label: test deb source packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
-   artifact_paths:
-     - ./out/*
-   branches: "!master"
-   timeout_in_minutes: 30
-   agents:
-     queue: "docker"
- - label: test deb binary packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   # Building all binary packages will take significant amount of time, so we build only one
-   # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
-   - rm -rf out
-   branches: "!master"
-   timeout_in_minutes: 30
-   agents:
-     queue: "docker"
- - label: test rpm source packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh --os fedora --type source
-   artifact_paths:
-     - ./out/*
-   branches: "!master"
-   timeout_in_minutes: 30
-   agents:
-     queue: "docker"
- - label: test rpm binary packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   # Building all binary packages will take significant amount of time, so we build only one
-   # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
-   - rm -rf out
-   branches: "!master"
-   timeout_in_minutes: 30
-   agents:
-     queue: "docker"
+ # Native packaging is suspended for now, because opam-repository isn't updated
+ # - label: test deb source packages via docker
+ #   commands:
+ #   - eval "$SET_VERSION"
+ #   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
+ #   artifact_paths:
+ #     - ./out/*
+ #   branches: "!master"
+ #   timeout_in_minutes: 30
+ #   agents:
+ #     queue: "docker"
+ # - label: test deb binary packages via docker
+ #   commands:
+ #   - eval "$SET_VERSION"
+ #   # Building all binary packages will take significant amount of time, so we build only one
+ #   # in order to ensure package generation sanity
+ #   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
+ #   - rm -rf out
+ #   branches: "!master"
+ #   timeout_in_minutes: 30
+ #   agents:
+ #     queue: "docker"
+ # - label: test rpm source packages via docker
+ #   commands:
+ #   - eval "$SET_VERSION"
+ #   - ./docker/docker-tezos-packages.sh --os fedora --type source
+ #   artifact_paths:
+ #     - ./out/*
+ #   branches: "!master"
+ #   timeout_in_minutes: 30
+ #   agents:
+ #     queue: "docker"
+ # - label: test rpm binary packages via docker
+ #   commands:
+ #   - eval "$SET_VERSION"
+ #   # Building all binary packages will take significant amount of time, so we build only one
+ #   # in order to ensure package generation sanity
+ #   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
+ #   - rm -rf out
+ #   branches: "!master"
+ #   timeout_in_minutes: 30
+ #   agents:
+ #     queue: "docker"
 
  - wait
  - label: create auto pre-release

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "2",
+    "release": "1",
     "maintainer": "Serokell <hi@serokell.io>"
 }

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,9 +36,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "refs/tags/v7.4",
+        "ref": "refs/tags/v7.5",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "e69b63f128701b2cdad665e8037a330305f591ce",
+        "rev": "ce36545683607b68d59e03ec6122a50a09909462",
         "type": "git"
     }
 }


### PR DESCRIPTION
## Description
Bump tezos to v7.5.

Suspend native packaging for now, because tezos packages in opam repository are still outdated
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
