### PR TITLE
Draft: [#135] Store opam dependencies separately from Tezos sources

### DIFF
--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -5,7 +5,7 @@
 FROM fedora:32
 RUN dnf update -y
 RUN dnf install -y libev-devel gmp-devel hidapi-devel libffi-devel m4 perl pkg-config \
-  rpmdevtools python3 wget opam rsync which cargo
+  rpmdevtools python3 wget opam rsync git which cargo
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+import os, shutil, sys, subprocess, json
+from abc import ABCMeta, abstractmethod
 from typing import List
 
 # There are more possible fields, but only these are used by tezos services
@@ -33,7 +35,44 @@ class SystemdUnit:
         self.startup_script = startup_script
         self.config_file = config_file
 
-class Package:
+class AbstractPackage:
+    @abstractmethod
+    def fetch_sources(self, out_dir):
+        pass
+
+    @abstractmethod
+    def gen_control_file(self, out):
+        pass
+
+    @abstractmethod
+    def get_spec_file(self, out):
+        pass
+
+    @abstractmethod
+    def gen_makefile(self, out):
+        pass
+
+    @abstractmethod
+    def gen_changelog(self, out):
+        pass
+
+    @abstractmethod
+    def gen_rules(self, out):
+        pass
+
+    @abstractmethod
+    def gen_install(self, out):
+        pass
+
+
+meta = json.load(open(f"{os.path.dirname(__file__)}/../../meta.json", "r"))
+version = os.environ["TEZOS_VERSION"][1:]
+release = f"{meta['release']}"
+ubuntu_epoch = 2
+fedora_epoch = 1
+
+
+class OpamBasedPackage(AbstractPackage):
     def __init__(self, name: str, desc: str, systemd_units: List[SystemdUnit]=[],
                  target_proto: str=None, optional_opam_deps=[]):
         self.name = name
@@ -41,6 +80,192 @@ class Package:
         self.systemd_units = systemd_units
         self.target_proto = target_proto
         self.optional_opam_deps = optional_opam_deps
+
+    def fetch_sources(self, out_dir):
+        opam_package = "tezos-client" if self.name == "tezos-admin-client" else self.name
+        subprocess.run(["opam", "exec", "--", "opam-bundle", f"{opam_package}={version}"] + self.optional_opam_deps +
+                       ["--ocaml=4.09.1", "--yes", "--opam=2.0.5"], check=True)
+        subprocess.run(["tar", "-zxf", f"{opam_package}-bundle.tar.gz"], check=True)
+        os.rename(f"{opam_package}-bundle", out_dir)
+
+
+    def gen_control_file(self, deps, out):
+        str_build_deps = ", ".join(deps)
+        file_contents = f'''
+Source: {self.name.lower()}
+Section: utils
+Priority: optional
+Maintainer: {meta['maintainer']}
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, {str_build_deps}
+Standards-Version: 3.9.6
+Homepage: https://gitlab.com/tezos/tezos/
+
+Package: {self.name.lower()}
+Architecture: amd64
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}
+Description: {self.desc}
+'''
+        with open(out, 'w') as f:
+            f.write(file_contents)
+
+    def gen_spec_file(self, build_deps, run_deps, out):
+        build_requires = " ".join(build_deps)
+        config_files = list(filter(lambda x: x is not None, map(lambda x: x.config_file,
+                                                                self.systemd_units)))
+        requires = " ".join(run_deps)
+        if len(self.systemd_units) > 0:
+            startup_scripts = list(set(map(lambda x: x.startup_script, self.systemd_units)))
+            install_unit_files = ""
+            systemd_unit_files = ""
+            enable_units = ""
+            systemd_units_post = ""
+            systemd_units_preun = ""
+            systemd_units_postun = ""
+            if len(config_files) > 0:
+                install_default = f"mkdir -p %{{buildroot}}/%{{_sysconfdir}}/default\n"
+            else:
+                install_default = ""
+            default_files = ""
+            for systemd_unit in self.systemd_units:
+                if systemd_unit.suffix is None:
+                    install_unit_files += f"install -m 644 %{{name}}.service %{{buildroot}}/%{{_unitdir}}\n"
+                    systemd_unit_files += f"%{{_unitdir}}/%{{name}}.service\n"
+                    enable_units += f"systemctl enable %{{name}}.service\n"
+                    systemd_units_post += f"%systemd_post %{{name}}.service\n"
+                    systemd_units_preun += f"%systemd_preun %{{name}}.service\n"
+                    systemd_units_postun += f"%systemd_postun_with_restart %{{name}}.service\n"
+                    if systemd_unit.config_file is not None:
+                        install_default += f"install -m 644 %{{name}}.default " + \
+                            f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}\n"
+                        default_files += f"%{{_sysconfdir}}/default/%{{name}}\n"
+                else:
+                    install_unit_files += f"install -m 644 %{{name}}-{systemd_unit.suffix}.service %{{buildroot}}/%{{_unitdir}}\n"
+                    systemd_unit_files += f"%{{_unitdir}}/%{{name}}-{systemd_unit.suffix}.service\n"
+                    enable_units += f"systemctl enable %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_post += f"%systemd_post %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_preun += f"%systemd_preun %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_postun += f"%systemd_postun_with_restart %{{name}}-{systemd_unit.suffix}.service\n"
+                    if systemd_unit.config_file is not None:
+                        install_default += f"install -m 644 %{{name}}-{systemd_unit.suffix}.default " + \
+                            f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
+                        default_files += f"%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
+            install_startup_scripts = ""
+            systemd_startup_files = ""
+            for startup_script in startup_scripts:
+                install_startup_scripts += f"install -m 0755 {startup_script} %{{buildroot}}/%{{_bindir}}\n"
+                systemd_startup_files += f"%{{_bindir}}/{startup_script}\n"
+            systemd_deps = "systemd systemd-rpm-macros"
+            systemd_install = f'''
+mkdir -p %{{buildroot}}/%{{_unitdir}}
+{install_unit_files}
+{install_default}
+{install_startup_scripts}
+'''
+            systemd_files = f'''
+{systemd_startup_files}
+{systemd_unit_files}
+{default_files}
+'''
+            systemd_macros= f'''
+%post
+{systemd_units_post}
+useradd tezos -d /var/lib/tezos || true
+{enable_units}
+
+%preun
+{systemd_units_preun}
+
+%postun
+{systemd_units_postun}
+'''
+        else:
+            systemd_deps = ""
+            systemd_install = ""
+            systemd_files = ""
+            systemd_macros = ""
+
+        file_contents = f'''
+    %define debug_package %{{nil}}
+    Name:    {self.name}
+    Version: {version}
+    Release: {release}
+    Epoch: {fedora_epoch}
+    Summary: {self.desc}
+    License: MIT
+    BuildArch: x86_64
+    Source0: {self.name}-{version}.tar.gz
+    Source1: https://gitlab.com/tezos/tezos/tree/v{version}/
+    BuildRequires: {build_requires} {systemd_deps}
+    Requires: {requires}
+    %description
+    {self.desc}
+    Maintainer: {meta['maintainer']}
+    %prep
+    %setup -q
+    %build
+    %install
+    make %{{name}}
+    mkdir -p %{{buildroot}}/%{{_bindir}}
+    install -m 0755 %{{name}} %{{buildroot}}/%{{_bindir}}
+    {systemd_install}
+    %files
+    %license LICENSE
+    %{{_bindir}}/%{{name}}
+    {systemd_files}
+    {systemd_macros}
+    '''
+        with open(out, 'w') as f:
+            f.write(file_contents)
+
+    def gen_makefile(self, out):
+        makefile_contents =f'''
+.PHONY: install
+
+BINDIR=/usr/bin
+
+{self.name}:
+	./compile.sh
+	cp $(CURDIR)/opam/default/bin/{self.name} {self.name}
+
+install: {self.name}
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp $(CURDIR)/{self.name} $(DESTDIR)$(BINDIR)
+'''
+        with open(out, 'w') as f:
+            f.write(makefile_contents)
+
+    def gen_changelog(self, ubuntu_version, maintainer, date, out):
+        changelog_contents = f'''{self.name.lower()} ({ubuntu_epoch}:{version}-0ubuntu{release}~{ubuntu_version}) {ubuntu_version}; urgency=medium
+
+  * Publish {version}-{release} version of {self.name}
+
+ -- {maintainer} {date}'''
+        with open(out, 'w') as f:
+            f.write(changelog_contents)
+
+    def gen_rules(self, out):
+        override_dh_install_init = "override_dh_installinit:\n"
+        for systemd_unit in self.systemd_units:
+            if systemd_unit.suffix is not None:
+                override_dh_install_init += f"	dh_installinit --name={self.name}-{systemd_unit.suffix}\n"
+        rules_contents = f'''#!/usr/bin/make -f
+
+%:
+	dh $@ {"--with systemd" if len(self.systemd_units) > 0 else ""}
+override_dh_systemd_start:
+	dh_systemd_start --no-start
+{override_dh_install_init if len(self.systemd_units) > 1 else ""}'''
+
+        with open(out, 'w') as f:
+            f.write(rules_contents)
+
+    def gen_install(self, out):
+        startup_scripts = list(set(map(lambda x: x.startup_script, self.systemd_units)))
+        install_contents = "\n".join(map(lambda x: f"debian/{x} usr/bin",
+                                         startup_scripts))
+        with open(out, 'w') as f:
+            f.write(install_contents)
+
 
 def print_service_file(service_file: ServiceFile, out):
     after = "".join(map(lambda x: f"After={x}\n", service_file.unit.after))

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -5,7 +5,7 @@
 import os, shutil, sys, subprocess, json, argparse
 from distutils.dir_util import copy_tree
 
-from .model import Package, print_service_file
+from .model import OpamBasedPackage, print_service_file
 from .packages import packages
 
 is_ubuntu = None
@@ -65,183 +65,6 @@ pwd = os.getcwd()
 home = os.environ["HOME"]
 
 
-def gen_control_file(pkg: Package, out):
-    str_build_deps = ", ".join(common_deps)
-    file_contents = f'''
-Source: {pkg.name.lower()}
-Section: utils
-Priority: optional
-Maintainer: {meta['maintainer']}
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, {str_build_deps}
-Standards-Version: 3.9.6
-Homepage: https://gitlab.com/tezos/tezos/
-
-Package: {pkg.name.lower()}
-Architecture: amd64
-Depends: ${{shlibs:Depends}}, ${{misc:Depends}}
-Description: {pkg.desc}
-'''
-    with open(out, 'w') as f:
-        f.write(file_contents)
-
-
-def gen_spec_file(pkg: Package, out):
-    build_requires = " ".join(common_deps)
-    config_files = list(filter(lambda x: x is not None, map(lambda x: x.config_file, package.systemd_units)))
-    requires = " ".join(run_deps)
-    if len(pkg.systemd_units) > 0:
-        startup_scripts = list(set(map(lambda x: x.startup_script, pkg.systemd_units)))
-        install_unit_files = ""
-        systemd_unit_files = ""
-        enable_units = ""
-        systemd_units_post = ""
-        systemd_units_preun = ""
-        systemd_units_postun = ""
-        if len(config_files) > 0:
-            install_default = f"mkdir -p %{{buildroot}}/%{{_sysconfdir}}/default\n"
-        else:
-            install_default = ""
-        default_files = ""
-        for systemd_unit in pkg.systemd_units:
-            if systemd_unit.suffix is None:
-                install_unit_files += f"install -m 644 %{{name}}.service %{{buildroot}}/%{{_unitdir}}\n"
-                systemd_unit_files += f"%{{_unitdir}}/%{{name}}.service\n"
-                enable_units += f"systemctl enable %{{name}}.service\n"
-                systemd_units_post += f"%systemd_post %{{name}}.service\n"
-                systemd_units_preun += f"%systemd_preun %{{name}}.service\n"
-                systemd_units_postun += f"%systemd_postun_with_restart %{{name}}.service\n"
-                if systemd_unit.config_file is not None:
-                    install_default += f"install -m 644 %{{name}}.default " + \
-                        f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}\n"
-                    default_files += f"%{{_sysconfdir}}/default/%{{name}}\n"
-            else:
-                install_unit_files += f"install -m 644 %{{name}}-{systemd_unit.suffix}.service %{{buildroot}}/%{{_unitdir}}\n"
-                systemd_unit_files += f"%{{_unitdir}}/%{{name}}-{systemd_unit.suffix}.service\n"
-                enable_units += f"systemctl enable %{{name}}-{systemd_unit.suffix}.service\n"
-                systemd_units_post += f"%systemd_post %{{name}}-{systemd_unit.suffix}.service\n"
-                systemd_units_preun += f"%systemd_preun %{{name}}-{systemd_unit.suffix}.service\n"
-                systemd_units_postun += f"%systemd_postun_with_restart %{{name}}-{systemd_unit.suffix}.service\n"
-                if systemd_unit.config_file is not None:
-                    install_default += f"install -m 644 %{{name}}-{systemd_unit.suffix}.default " + \
-                        f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
-                    default_files += f"%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
-        install_startup_scripts = ""
-        systemd_startup_files = ""
-        for startup_script in startup_scripts:
-            install_startup_scripts += f"install -m 0755 {startup_script} %{{buildroot}}/%{{_bindir}}\n"
-            systemd_startup_files += f"%{{_bindir}}/{startup_script}\n"
-        systemd_deps = "systemd systemd-rpm-macros"
-        systemd_install = f'''
-mkdir -p %{{buildroot}}/%{{_unitdir}}
-{install_unit_files}
-{install_default}
-{install_startup_scripts}
-'''
-        systemd_files = f'''
-{systemd_startup_files}
-{systemd_unit_files}
-{default_files}
-'''
-        systemd_macros= f'''
-%post
-{systemd_units_post}
-useradd tezos -d /var/lib/tezos || true
-{enable_units}
-
-%preun
-{systemd_units_preun}
-
-%postun
-{systemd_units_postun}
-'''
-    else:
-        systemd_deps = ""
-        systemd_install = ""
-        systemd_files = ""
-        systemd_macros = ""
-
-    file_contents = f'''
-%define debug_package %{{nil}}
-Name:    {pkg.name}
-Version: {version}
-Release: {release}
-Epoch: {fedora_epoch}
-Summary: {pkg.desc}
-License: MIT
-BuildArch: x86_64
-Source0: {pkg.name}-{version}.tar.gz
-Source1: https://gitlab.com/tezos/tezos/tree/v{version}/
-BuildRequires: {build_requires} {systemd_deps}
-Requires: {requires}
-%description
-{pkg.desc}
-Maintainer: {meta['maintainer']}
-%prep
-%setup -q
-%build
-%install
-make %{{name}}
-mkdir -p %{{buildroot}}/%{{_bindir}}
-install -m 0755 %{{name}} %{{buildroot}}/%{{_bindir}}
-{systemd_install}
-%files
-%license LICENSE
-%{{_bindir}}/%{{name}}
-{systemd_files}
-{systemd_macros}
-'''
-    with open(out, 'w') as f:
-        f.write(file_contents)
-
-def gen_makefile(pkg: Package, out):
-    makefile_contents =f'''
-.PHONY: install
-
-BINDIR=/usr/bin
-
-{pkg.name}:
-	./compile.sh
-	cp $(CURDIR)/opam/default/bin/{pkg.name} {pkg.name}
-
-install: {pkg.name}
-	mkdir -p $(DESTDIR)$(BINDIR)
-	cp $(CURDIR)/{pkg.name} $(DESTDIR)$(BINDIR)
-'''
-    with open(out, 'w') as f:
-        f.write(makefile_contents)
-
-def gen_changelog(pkg: Package, ubuntu_version, maintainer, date, out):
-    changelog_contents = f'''{pkg.name.lower()} ({ubuntu_epoch}:{version}-0ubuntu{release}~{ubuntu_version}) {ubuntu_version}; urgency=medium
-
-  * Publish {version}-{release} version of {pkg.name}
-
- -- {maintainer} {date}'''
-    with open(out, 'w') as f:
-        f.write(changelog_contents)
-
-def gen_rules(pkg: Package, out):
-    override_dh_install_init = "override_dh_installinit:\n"
-    for systemd_unit in pkg.systemd_units:
-        if systemd_unit.suffix is not None:
-            override_dh_install_init += f"	dh_installinit --name={pkg.name}-{systemd_unit.suffix}\n"
-    rules_contents = f'''#!/usr/bin/make -f
-
-%:
-	dh $@ {"--with systemd" if len(pkg.systemd_units) > 0 else ""}
-override_dh_systemd_start:
-	dh_systemd_start --no-start
-{override_dh_install_init if len(pkg.systemd_units) > 1 else ""}'''
-
-    with open(out, 'w') as f:
-        f.write(rules_contents)
-
-def gen_install(pkg: Package, out):
-    startup_scripts = list(set(map(lambda x: x.startup_script, pkg.systemd_units)))
-    install_contents = "\n".join(map(lambda x: f"debian/{x} usr/bin",
-                                     startup_scripts))
-    with open(out, 'w') as f:
-        f.write(install_contents)
-
 for package in packages:
     if package_to_build is None or package.name == package_to_build:
         if is_ubuntu:
@@ -249,12 +72,8 @@ for package in packages:
         else:
             dir = f"{package.name}-{version}"
         if source_archive is None:
-            opam_package = "tezos-client" if package.name == "tezos-admin-client" else package.name
-            subprocess.run(["opam", "exec", "--", "opam-bundle", f"{opam_package}={version}"] + package.optional_opam_deps +
-                            ["--ocaml=4.09.1", "--yes", "--opam=2.0.5"], check=True)
-            subprocess.run(["tar", "-zxf", f"{opam_package}-bundle.tar.gz"], check=True)
-            os.rename(f"{opam_package}-bundle", dir)
-            gen_makefile(package, f"{dir}/Makefile")
+            package.fetch_sources(dir)
+            package.gen_makefile(f"{dir}/Makefile")
             if not is_ubuntu:
                 subprocess.run(["wget", "-q", "-O", f"{dir}/LICENSE", f"https://gitlab.com/tezos/tezos/-/raw/v{version}/LICENSE"], check=True)
         if is_ubuntu:
@@ -281,12 +100,12 @@ for package in packages:
                             shutil.copy(f"{os.path.dirname(__file__)}/defaults/{systemd_unit.config_file}",
                                         f"debian/{package.name.lower()}-{systemd_unit.suffix}.default")
                     shutil.copy(f"{os.path.dirname(__file__)}/scripts/{systemd_unit.startup_script}", f"debian/{systemd_unit.startup_script}")
-                    gen_install(package, "debian/install")
-                gen_control_file(package, "debian/control")
+                    package.gen_install("debian/install")
+                package.gen_control_file(common_deps, "debian/control")
                 subprocess.run(["wget", "-q", "-O", "debian/copyright", f"https://gitlab.com/tezos/tezos/-/raw/v{version}/LICENSE"], check=True)
                 subprocess.run("rm debian/*.ex debian/*.EX debian/README*", shell=True, check=True)
-                gen_changelog(package, ubuntu_version, meta["maintainer"], date, "debian/changelog")
-                gen_rules(package, "debian/rules")
+                package.gen_changelog(ubuntu_version, meta["maintainer"], date, "debian/changelog")
+                package.gen_rules("debian/rules")
                 subprocess.run(["dpkg-buildpackage", "-S" if is_source else "-b", "-us", "-uc"],
                             check=True)
                 os.chdir("..")
@@ -308,7 +127,7 @@ for package in packages:
             subprocess.run(["tar", "-czf", f"{dir}.tar.gz", dir], check=True)
             os.makedirs(f"{home}/rpmbuild/SPECS", exist_ok=True)
             os.makedirs(f"{home}/rpmbuild/SOURCES", exist_ok=True)
-            gen_spec_file(package, f"{home}/rpmbuild/SPECS/{package.name}.spec")
+            package.gen_spec_file(common_deps, run_deps, f"{home}/rpmbuild/SPECS/{package.name}.spec")
             os.rename(f"{dir}.tar.gz", f"{home}/rpmbuild/SOURCES/{dir}.tar.gz")
             subprocess.run(["rpmbuild", "-bs" if is_source else "-bb", f"{home}/rpmbuild/SPECS/{package.name}.spec"],
                            check = True)

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 import os, shutil, sys, subprocess, json
 
-from .model import Service, ServiceFile, SystemdUnit, Unit, Package
+from .model import Service, ServiceFile, SystemdUnit, Unit, OpamBasedPackage
 
 networks = ["mainnet", "delphinet", "edonet"]
 
@@ -55,18 +55,18 @@ signer_units = [
 ]
 
 packages = [
-    Package("tezos-client",
-            "CLI client for interacting with tezos blockchain",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"]),
-    Package("tezos-admin-client",
-            "Administration tool for the node",
-            optional_opam_deps=["tls"]),
-    Package("tezos-signer",
-            "A client to remotely sign operations or blocks",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"],
-            systemd_units=signer_units),
-    Package("tezos-codec",
-            "A client to decode and encode JSON")
+    OpamBasedPackage("tezos-client",
+                     "CLI client for interacting with tezos blockchain",
+                     optional_opam_deps=["tls", "ledgerwallet-tezos"]),
+    OpamBasedPackage("tezos-admin-client",
+                     "Administration tool for the node",
+                     optional_opam_deps=["tls"]),
+    OpamBasedPackage("tezos-signer",
+                     "A client to remotely sign operations or blocks",
+                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                     systemd_units=signer_units),
+    OpamBasedPackage("tezos-codec",
+                     "A client to decode and encode JSON")
 ]
 
 node_units = []
@@ -82,7 +82,7 @@ for network in networks:
     node_units.append(SystemdUnit(suffix=network,
                                   service_file=service_file,
                                   startup_script="tezos-node-start"))
-packages.append(Package("tezos-node",
+packages.append(OpamBasedPackage("tezos-node",
                         "Entry point for initializing, configuring and running a Tezos node",
                         node_units))
 
@@ -120,22 +120,22 @@ for proto in active_protocols:
                                                 environment=[f"PROTOCOL={proto}"],
                                                 exec_start="/usr/bin/tezos-endorser-start",
                                                 state_directory="tezos", user="tezos"))
-    packages.append(Package(f"tezos-baker-{proto}", "Daemon for baking",
-                            [SystemdUnit(service_file=service_file_baker,
-                                         startup_script="tezos-baker-start",
-                                         config_file="tezos-baker.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(Package(f"tezos-accuser-{proto}", "Daemon for accusing",
-                            [SystemdUnit(service_file=service_file_accuser,
-                                         startup_script="tezos-accuser-start",
-                                         config_file="tezos-accuser.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(Package(f"tezos-endorser-{proto}", "Daemon for endorsing",
-                            [SystemdUnit(service_file=service_file_endorser,
-                                         startup_script="tezos-endorser-start",
-                                         config_file="tezos-endorser.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-baker-{proto}", "Daemon for baking",
+                                     [SystemdUnit(service_file=service_file_baker,
+                                                  startup_script="tezos-baker-start",
+                                                  config_file="tezos-baker.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
+                                     [SystemdUnit(service_file=service_file_accuser,
+                                                  startup_script="tezos-accuser-start",
+                                                  config_file="tezos-accuser.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
+                                     [SystemdUnit(service_file=service_file_endorser,
+                                                  startup_script="tezos-endorser-start",
+                                                  config_file="tezos-endorser.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
 

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -55,17 +55,37 @@ signer_units = [
 ]
 
 packages = [
-    OpamBasedPackage("tezos-client",
+    OpamBasedPackage("tezos-client", "src/bin_client/tezos-client.opam",
                      "CLI client for interacting with tezos blockchain",
-                     optional_opam_deps=["tls", "ledgerwallet-tezos"]),
-    OpamBasedPackage("tezos-admin-client",
+                     optional_opam_deps=["tls", "ledgerwallet-tezos",
+                                         "tezos-client-genesis",
+                                         "tezos-client-demo-counter",
+                                         "tezos-client-alpha-commands-registration",
+                                         "tezos-baking-alpha-commands",
+                                         "tezos-client-001-PtCJ7pwo-commands",
+                                         "tezos-client-002-PsYLVpVv-commands",
+                                         "tezos-client-003-PsddFKi3-commands",
+                                         "tezos-client-004-Pt24m4xi-commands",
+                                         "tezos-client-005-PsBabyM1-commands",
+                                         "tezos-client-006-PsCARTHA-commands"
+                     ]),
+    OpamBasedPackage("tezos-admin-client", "src/bin_client/tezos-client.opam",
                      "Administration tool for the node",
-                     optional_opam_deps=["tls"]),
-    OpamBasedPackage("tezos-signer",
+                     optional_opam_deps=["tls", "tezos-client-genesis",
+                                         "tezos-client-demo-counter",
+                                         "tezos-client-alpha-commands-registration",
+                                         "tezos-baking-alpha-commands",
+                                         "tezos-client-001-PtCJ7pwo-commands",
+                                         "tezos-client-002-PsYLVpVv-commands",
+                                         "tezos-client-003-PsddFKi3-commands",
+                                         "tezos-client-004-Pt24m4xi-commands",
+                                         "tezos-client-005-PsBabyM1-commands",
+                                         "tezos-client-006-PsCARTHA-commands"]),
+    OpamBasedPackage("tezos-signer", "src/bin_signer/tezos-signer.opam",
                      "A client to remotely sign operations or blocks",
                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
                      systemd_units=signer_units),
-    OpamBasedPackage("tezos-codec",
+    OpamBasedPackage("tezos-codec", "src/bin_codec/tezos-codec.opam",
                      "A client to decode and encode JSON")
 ]
 
@@ -82,9 +102,21 @@ for network in networks:
     node_units.append(SystemdUnit(suffix=network,
                                   service_file=service_file,
                                   startup_script="tezos-node-start"))
-packages.append(OpamBasedPackage("tezos-node",
-                        "Entry point for initializing, configuring and running a Tezos node",
-                        node_units))
+packages.append(OpamBasedPackage("tezos-node", "src/bin_node/tezos-node.opam",
+                                 "Entry point for initializing, configuring and running a Tezos node",
+                                 node_units,
+                                 optional_opam_deps=["tezos-embedded-protocol-001-PtCJ7pwo",
+                                                     "tezos-embedded-protocol-002-PsYLVpVv",
+                                                     "tezos-embedded-protocol-003-PsddFKi3",
+                                                     "tezos-embedded-protocol-004-Pt24m4xi",
+                                                     "tezos-embedded-protocol-005-PsBABY5H",
+                                                     "tezos-embedded-protocol-005-PsBabyM1",
+                                                     "tezos-embedded-protocol-006-PsCARTHA",
+                                                     "tezos-embedded-protocol-demo-counter",
+                                                     "tezos-embedded-protocol-alpha",
+                                                     "tezos-embedded-protocol-demo-noops",
+                                                     "tezos-embedded-protocol-genesis"
+                                 ]))
 
 active_protocols = json.load(open(f"{os.path.dirname( __file__)}/../../protocols.json", "r"))["active"]
 
@@ -120,19 +152,26 @@ for proto in active_protocols:
                                                 environment=[f"PROTOCOL={proto}"],
                                                 exec_start="/usr/bin/tezos-endorser-start",
                                                 state_directory="tezos", user="tezos"))
-    packages.append(OpamBasedPackage(f"tezos-baker-{proto}", "Daemon for baking",
+    src_dir = f"src/proto_{proto.replace('-', '_')}"
+    packages.append(OpamBasedPackage(f"tezos-baker-{proto}",
+                                     f"{src_dir}/bin_baker/tezos-baker-{proto}.opam",
+                                     "Daemon for baking",
                                      [SystemdUnit(service_file=service_file_baker,
                                                   startup_script="tezos-baker-start",
                                                   config_file="tezos-baker.conf")],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
+    packages.append(OpamBasedPackage(f"tezos-accuser-{proto}",
+                                     f"{src_dir}/bin_accuser/tezos-accuser-{proto}.opam",
+                                     "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script="tezos-accuser-start",
                                                   config_file="tezos-accuser.conf")],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
+    packages.append(OpamBasedPackage(f"tezos-endorser-{proto}",
+                                     f"{src_dir}/bin_endorser/tezos-endorser-{proto}.opam",
+                                     "Daemon for endorsing",
                                      [SystemdUnit(service_file=service_file_endorser,
                                                   startup_script="tezos-endorser-start",
                                                   config_file="tezos-endorser.conf")],


### PR DESCRIPTION
## Description
Problem: Sometimes (quite rarely, tbh) we want to update the set of
opam dependencies without updating the Tezos sources and without
bumping packages version. However, it's impossible for Ubuntu packages
when the Tezos sources and its opam dependencies are stored together in
`.orig.tar.gz` archive.

Solution: Move all opam dependencies to the `.debian.tar.xz` archive
with metafiles, thus it's possible to update these dependencies along
with package release number update.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #135

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
