### PR TITLE
Resurrect v8.2 native packaging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,51 +69,50 @@ steps:
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
 
- # TODO: Uncomment once https://github.com/ocaml/opam-repository/pull/18133 is merged
- # - label: test deb source packages via docker
- #   commands:
- #   - eval "$SET_VERSION"
- #   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
- #   artifact_paths:
- #     - ./out/*
- #   branches: "!master"
- #   timeout_in_minutes: 30
- #   agents:
- #     queue: "docker"
- # - label: test deb binary packages via docker
- #   commands:
- #   - eval "$SET_VERSION"
- #   # Building all binary packages will take significant amount of time, so we build only one
- #   # in order to ensure package generation sanity
- #   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
- #   - rm -rf out
- #   # It takes much time to build binary package, so we do it only on master
- #   branches: "master"
- #   timeout_in_minutes: 90
- #   agents:
- #     queue: "docker"
- # - label: test rpm source packages via docker
- #   commands:
- #   - eval "$SET_VERSION"
- #   - ./docker/docker-tezos-packages.sh --os fedora --type source
- #   artifact_paths:
- #     - ./out/*
- #   branches: "!master"
- #   timeout_in_minutes: 30
- #   agents:
- #     queue: "docker"
- # - label: test rpm binary packages via docker
- #   commands:
- #   - eval "$SET_VERSION"
- #   # Building all binary packages will take significant amount of time, so we build only one
- #   # in order to ensure package generation sanity
- #   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
- #   - rm -rf out
- #   # It takes much time to build binary package, so we do it only on master
- #   branches: "master"
- #   timeout_in_minutes: 90
- #   agents:
- #     queue: "docker"
+ - label: test deb source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 30
+   agents:
+     queue: "docker"
+ - label: test deb binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-007-PsDELPH1
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
+ - label: test rpm source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os fedora --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 30
+   agents:
+     queue: "docker"
+ - label: test rpm binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-007-PsDELPH1
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
 
  - wait
  - label: create auto pre-release


### PR DESCRIPTION
## Description
Problem: PR to opam-repository was merged. CI now should be capable of
checking native packaging.

Solution: Uncomment CI steps related to native packaging.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
