### PR TITLE
Add mojave bottles hashes

### DIFF
--- a/Formula/tezos-accuser-007-PsDELPH1.rb
+++ b/Formula/tezos-accuser-007-PsDELPH1.rb
@@ -12,6 +12,7 @@ class TezosAccuser007Psdelph1 < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser007Psdelph1.version}/"
     cellar :any
     sha256 "de6b8c02b8dffd110acd290a451e2a351e9f37b173eac22f4963a0b7bc3913ea" => :catalina
+    sha256 "fd1c2993b4836bed3b26006dd86db50b603ccd1c9f38cbb486a52d3c473a35dd" => :mojave
   end
 
   def install

--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -12,6 +12,7 @@ class TezosAccuser008Ptedo2zk < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser008Ptedo2zk.version}/"
     cellar :any
     sha256 "c5e5e21e6413c8a669ae1febedbaf294814cb98bb27f43b16d8e02ff11b82f21" => :catalina
+    sha256 "3c949e4a73f233f067dce4c5c99ea0b7717b4009eaed2a39b0db0f576c4c3982" => :mojave
   end
 
   def install

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -12,6 +12,7 @@ class TezosAdminClient < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
     cellar :any
     sha256 "c960611dff0c7a3c0be44f7f56c555a722bf4bc905cb6ba9dbd7bbcb7218d6c2" => :catalina
+    sha256 "ee448cf224e05593ff8fb65188ec8df19a98e3161be96c392719779322a32c2f" => :mojave
   end
 
   def install

--- a/Formula/tezos-baker-007-PsDELPH1.rb
+++ b/Formula/tezos-baker-007-PsDELPH1.rb
@@ -12,6 +12,7 @@ class TezosBaker007Psdelph1 < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker007Psdelph1.version}/"
     cellar :any
     sha256 "c915cc5827546a2f2842b7904d17e6a962a3a16fbe019a2cf50335fb7fb91b18" => :catalina
+    sha256 "381aee11b3c9019c0dabd32b57fd0015dee97682855af22feaf42cb208d9d083" => :mojave
   end
 
   def install

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -12,6 +12,7 @@ class TezosBaker008Ptedo2zk < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker008Ptedo2zk.version}/"
     cellar :any
     sha256 "b2a05a2cbed1fc6dfe9bd2025676a3a718fb976fc6d1140e7fa3b691eb72be81" => :catalina
+    sha256 "68e5dc9d352e96b74e855e5cb35c7c83e37e162177d4db85a254db6409464e94" => :mojave
   end
 
   def install

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -12,6 +12,7 @@ class TezosClient < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
     cellar :any
     sha256 "2aaddacfbc9328a2b4d4066851c9f073901842bc1a1464f6cc94e0b603066184" => :catalina
+    sha256 "52fd2d0f9789e3321c20f2b2f33478a13f74d0c29621bd76a5867e286dc9c72b" => :mojave
   end
 
   def install

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -12,6 +12,7 @@ class TezosCodec < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
     cellar :any
     sha256 "aeab96953b1014aa5009cc89e4919b111a24d33192c452849387721bd030be94" => :catalina
+    sha256 "b623e5bdbdada505839e00dcd39aab7fefc64891a96145748b58bbd21a9621c2" => :mojave
   end
 
   def install

--- a/Formula/tezos-endorser-007-PsDELPH1.rb
+++ b/Formula/tezos-endorser-007-PsDELPH1.rb
@@ -12,6 +12,7 @@ class TezosEndorser007Psdelph1 < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser007Psdelph1.version}/"
     cellar :any
     sha256 "474040ee021cd5df167ef2aa8078f8169d26f6574475170de0f067015aff46a8" => :catalina
+    sha256 "0a4e9b96898e48bf7c273b309dfde242d84ba230028c7de1de035c3c816de1c4" => :mojave
   end
 
   def install

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -12,6 +12,7 @@ class TezosEndorser008Ptedo2zk < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser008Ptedo2zk.version}/"
     cellar :any
     sha256 "24ed930b86471a647840b15405d91fa2a7f0215b12196e36a266442e6e5492b1" => :catalina
+    sha256 "f975198e886c0ed637f1917fd0b23670567440b0ef03717daf346a8a7d61a978" => :mojave
   end
 
   def install

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -12,6 +12,7 @@ class TezosNode < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
     cellar :any
     sha256 "f2a1dd65245399ea48f544e37467845445659522dbca01c367f6ec53a59df7c3" => :catalina
+    sha256 "793fe3b61d536a0bdad18fc508a74702ab50e1c313cc740d497c6092db56e3ea" => :mojave
   end
 
   def install

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -12,6 +12,7 @@ class TezosSandbox < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
     cellar :any
     sha256 "d6ed3d403243b29d8b55534d2258abc83a3fdecc656f87da24dd9b2c1a8b00ae" => :catalina
+    sha256 "05edf9ca4dd841f1e5a364d9eb77f313bd4c55aa85bbf727e4d6202cd5b605e0" => :mojave
   end
 
   def install

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -12,6 +12,7 @@ class TezosSigner < Tezos
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
     cellar :any
     sha256 "8a0dc41a239c0acd6b0cf8456b48cf2c39a40cbf1fcc93c013bf5b83198e9471" => :catalina
+    sha256 "86811a82bdb4140513c831fa160a80bdcf67f12173978879d0d1d7e9632f717b" => :mojave
   end
 
   def install


### PR DESCRIPTION
## Description
Problem: MacOS users don't want to build Tezos from scratch.

Solution: Provide bottles with Tezos binaries for MacOS Mojave.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
