### PR TITLE
[#132] Native package with sapling params

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+import os, shutil, sys, subprocess, json
+from abc import ABCMeta, abstractmethod
 from typing import List
 
 # There are more possible fields, but only these are used by tezos services
@@ -33,7 +35,44 @@ class SystemdUnit:
         self.startup_script = startup_script
         self.config_file = config_file
 
-class Package:
+class AbstractPackage:
+    @abstractmethod
+    def fetch_sources(self, out_dir):
+        pass
+
+    @abstractmethod
+    def gen_control_file(self, out):
+        pass
+
+    @abstractmethod
+    def get_spec_file(self, out):
+        pass
+
+    @abstractmethod
+    def gen_makefile(self, out):
+        pass
+
+    @abstractmethod
+    def gen_changelog(self, out):
+        pass
+
+    @abstractmethod
+    def gen_rules(self, out):
+        pass
+
+    @abstractmethod
+    def gen_install(self, out):
+        pass
+
+
+meta = json.load(open(f"{os.path.dirname(__file__)}/../../meta.json", "r"))
+version = os.environ["TEZOS_VERSION"][1:]
+release = f"{meta['release']}"
+ubuntu_epoch = 2
+fedora_epoch = 1
+
+
+class OpamBasedPackage(AbstractPackage):
     def __init__(self, name: str, desc: str, systemd_units: List[SystemdUnit]=[],
                  target_proto: str=None, optional_opam_deps=[]):
         self.name = name
@@ -41,6 +80,191 @@ class Package:
         self.systemd_units = systemd_units
         self.target_proto = target_proto
         self.optional_opam_deps = optional_opam_deps
+
+    def fetch_sources(self, out_dir):
+        opam_package = "tezos-client" if self.name == "tezos-admin-client" else self.name
+        subprocess.run(["opam", "exec", "--", "opam-bundle", f"{opam_package}={version}"] + self.optional_opam_deps +
+                       ["--ocaml=4.09.1", "--yes", "--opam=2.0.5"], check=True)
+        subprocess.run(["tar", "-zxf", f"{opam_package}-bundle.tar.gz"], check=True)
+        os.rename(f"{opam_package}-bundle", out_dir)
+
+
+    def gen_control_file(self, deps, out):
+        str_build_deps = ", ".join(deps)
+        file_contents = f'''
+Source: {self.name.lower()}
+Section: utils
+Priority: optional
+Maintainer: {meta['maintainer']}
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, {str_build_deps}
+Standards-Version: 3.9.6
+Homepage: https://gitlab.com/tezos/tezos/
+
+Package: {self.name.lower()}
+Architecture: amd64
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}
+Description: {self.desc}
+'''
+        with open(out, 'w') as f:
+            f.write(file_contents)
+
+    def gen_spec_file(self, build_deps, run_deps, out):
+        build_requires = " ".join(build_deps)
+        config_files = list(filter(lambda x: x is not None, map(lambda x: x.config_file,
+                                                                self.systemd_units)))
+        requires = " ".join(run_deps)
+        if len(self.systemd_units) > 0:
+            startup_scripts = list(set(map(lambda x: x.startup_script, self.systemd_units)))
+            install_unit_files = ""
+            systemd_unit_files = ""
+            enable_units = ""
+            systemd_units_post = ""
+            systemd_units_preun = ""
+            systemd_units_postun = ""
+            if len(config_files) > 0:
+                install_default = f"mkdir -p %{{buildroot}}/%{{_sysconfdir}}/default\n"
+            else:
+                install_default = ""
+            default_files = ""
+            for systemd_unit in self.systemd_units:
+                if systemd_unit.suffix is None:
+                    install_unit_files += f"install -m 644 %{{name}}.service %{{buildroot}}/%{{_unitdir}}\n"
+                    systemd_unit_files += f"%{{_unitdir}}/%{{name}}.service\n"
+                    enable_units += f"systemctl enable %{{name}}.service\n"
+                    systemd_units_post += f"%systemd_post %{{name}}.service\n"
+                    systemd_units_preun += f"%systemd_preun %{{name}}.service\n"
+                    systemd_units_postun += f"%systemd_postun_with_restart %{{name}}.service\n"
+                    if systemd_unit.config_file is not None:
+                        install_default += f"install -m 644 %{{name}}.default " + \
+                            f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}\n"
+                        default_files += f"%{{_sysconfdir}}/default/%{{name}}\n"
+                else:
+                    install_unit_files += f"install -m 644 %{{name}}-{systemd_unit.suffix}.service %{{buildroot}}/%{{_unitdir}}\n"
+                    systemd_unit_files += f"%{{_unitdir}}/%{{name}}-{systemd_unit.suffix}.service\n"
+                    enable_units += f"systemctl enable %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_post += f"%systemd_post %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_preun += f"%systemd_preun %{{name}}-{systemd_unit.suffix}.service\n"
+                    systemd_units_postun += f"%systemd_postun_with_restart %{{name}}-{systemd_unit.suffix}.service\n"
+                    if systemd_unit.config_file is not None:
+                        install_default += f"install -m 644 %{{name}}-{systemd_unit.suffix}.default " + \
+                            f"%{{buildroot}}/%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
+                        default_files += f"%{{_sysconfdir}}/default/%{{name}}-{systemd_unit.suffix}\n"
+            install_startup_scripts = ""
+            systemd_startup_files = ""
+            for startup_script in startup_scripts:
+                install_startup_scripts += f"install -m 0755 {startup_script} %{{buildroot}}/%{{_bindir}}\n"
+                systemd_startup_files += f"%{{_bindir}}/{startup_script}\n"
+            systemd_deps = "systemd systemd-rpm-macros"
+            systemd_install = f'''
+mkdir -p %{{buildroot}}/%{{_unitdir}}
+{install_unit_files}
+{install_default}
+{install_startup_scripts}
+'''
+            systemd_files = f'''
+{systemd_startup_files}
+{systemd_unit_files}
+{default_files}
+'''
+            systemd_macros= f'''
+%post
+{systemd_units_post}
+useradd tezos -d /var/lib/tezos || true
+{enable_units}
+
+%preun
+{systemd_units_preun}
+
+%postun
+{systemd_units_postun}
+'''
+        else:
+            systemd_deps = ""
+            systemd_install = ""
+            systemd_files = ""
+            systemd_macros = ""
+
+        file_contents = f'''
+    %define debug_package %{{nil}}
+    Name:    {self.name}
+    Version: {version}
+    Release: {release}
+    Epoch: {fedora_epoch}
+    Summary: {self.desc}
+    License: MIT
+    BuildArch: x86_64
+    Source0: {self.name}-{version}.tar.gz
+    Source1: https://gitlab.com/tezos/tezos/tree/v{version}/
+    BuildRequires: {build_requires} {systemd_deps}
+    Requires: {requires}
+    %description
+    {self.desc}
+    Maintainer: {meta['maintainer']}
+    %prep
+    %setup -q
+    %build
+    %install
+    make %{{name}}
+    mkdir -p %{{buildroot}}/%{{_bindir}}
+    install -m 0755 %{{name}} %{{buildroot}}/%{{_bindir}}
+    {systemd_install}
+    %files
+    %license LICENSE
+    %{{_bindir}}/%{{name}}
+    {systemd_files}
+    {systemd_macros}
+    '''
+        with open(out, 'w') as f:
+            f.write(file_contents)
+
+    def gen_makefile(self, out):
+        makefile_contents =f'''
+.PHONY: install
+
+BINDIR=/usr/bin
+
+{self.name}:
+	./compile.sh
+	cp $(CURDIR)/opam/default/bin/{self.name} {self.name}
+
+install: {self.name}
+	mkdir -p $(DESTDIR)$(BINDIR)
+	cp $(CURDIR)/{self.name} $(DESTDIR)$(BINDIR)
+'''
+        with open(out, 'w') as f:
+            f.write(makefile_contents)
+
+    def gen_changelog(self, ubuntu_version, maintainer, date, out):
+        changelog_contents = f'''{self.name.lower()} ({ubuntu_epoch}:{version}-0ubuntu{release}~{ubuntu_version}) {ubuntu_version}; urgency=medium
+
+  * Publish {version}-{release} version of {self.name}
+
+ -- {maintainer} {date}'''
+        with open(out, 'w') as f:
+            f.write(changelog_contents)
+
+    def gen_rules(self, out):
+        override_dh_install_init = "override_dh_installinit:\n"
+        for systemd_unit in self.systemd_units:
+            if systemd_unit.suffix is not None:
+                override_dh_install_init += f"	dh_installinit --name={self.name}-{systemd_unit.suffix}\n"
+        rules_contents = f'''#!/usr/bin/make -f
+
+%:
+	dh $@ {"--with systemd" if len(self.systemd_units) > 0 else ""}
+override_dh_systemd_start:
+	dh_systemd_start --no-start
+{override_dh_install_init if len(self.systemd_units) > 1 else ""}'''
+        with open(out, 'w') as f:
+            f.write(rules_contents)
+
+    def gen_install(self, out):
+        startup_scripts = list(set(map(lambda x: x.startup_script, self.systemd_units)))
+        install_contents = "\n".join(map(lambda x: f"debian/{x} usr/bin",
+                                         startup_scripts))
+        with open(out, 'w') as f:
+            f.write(install_contents)
+
 
 def print_service_file(service_file: ServiceFile, out):
     after = "".join(map(lambda x: f"After={x}\n", service_file.unit.after))

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -74,12 +74,14 @@ fedora_epoch = 1
 
 class OpamBasedPackage(AbstractPackage):
     def __init__(self, name: str, desc: str, systemd_units: List[SystemdUnit]=[],
-                 target_proto: str=None, optional_opam_deps=[]):
+                 target_proto: str=None, optional_opam_deps: List[str]=[],
+                 requires_sapling_params: bool=False):
         self.name = name
         self.desc = desc
         self.systemd_units = systemd_units
         self.target_proto = target_proto
         self.optional_opam_deps = optional_opam_deps
+        self.requires_sapling_params = requires_sapling_params
 
     def fetch_sources(self, out_dir):
         opam_package = "tezos-client" if self.name == "tezos-admin-client" else self.name
@@ -102,7 +104,7 @@ Homepage: https://gitlab.com/tezos/tezos/
 
 Package: {self.name.lower()}
 Architecture: amd64
-Depends: ${{shlibs:Depends}}, ${{misc:Depends}}
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {"tezos-sapling-params" if self.requires_sapling_params else ""}
 Description: {self.desc}
 '''
         with open(out, 'w') as f:
@@ -196,7 +198,7 @@ BuildArch: x86_64
 Source0: {self.name}-{version}.tar.gz
 Source1: https://gitlab.com/tezos/tezos/tree/v{version}/
 BuildRequires: {build_requires} {systemd_deps}
-Requires: {requires}
+Requires: {requires}, {"tezos-sapling-params" if self.requires_sapling_params else ""}
 %description
 {self.desc}
 Maintainer: {meta['maintainer']}

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -94,7 +94,7 @@ for package in packages:
                             shutil.copy(f"{os.path.dirname(__file__)}/defaults/{systemd_unit.config_file}",
                                         f"debian/{package.name.lower()}-{systemd_unit.suffix}.default")
                     shutil.copy(f"{os.path.dirname(__file__)}/scripts/{systemd_unit.startup_script}", f"debian/{systemd_unit.startup_script}")
-                    package.gen_install("debian/install")
+                package.gen_install("debian/install")
                 package.gen_control_file(common_deps, "debian/control")
                 subprocess.run(["wget", "-q", "-O", "debian/copyright", f"https://gitlab.com/tezos/tezos/-/raw/v{version}/LICENSE"], check=True)
                 subprocess.run("rm debian/*.ex debian/*.EX debian/README*", shell=True, check=True)

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 import os, shutil, sys, subprocess, json
 
-from .model import Service, ServiceFile, SystemdUnit, Unit, Package
+from .model import Service, ServiceFile, SystemdUnit, Unit, OpamBasedPackage
 
 networks = ["mainnet", "delphinet", "edonet"]
 
@@ -55,18 +55,18 @@ signer_units = [
 ]
 
 packages = [
-    Package("tezos-client",
-            "CLI client for interacting with tezos blockchain",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"]),
-    Package("tezos-admin-client",
-            "Administration tool for the node",
-            optional_opam_deps=["tls"]),
-    Package("tezos-signer",
-            "A client to remotely sign operations or blocks",
-            optional_opam_deps=["tls", "ledgerwallet-tezos"],
-            systemd_units=signer_units),
-    Package("tezos-codec",
-            "A client to decode and encode JSON")
+    OpamBasedPackage("tezos-client",
+                     "CLI client for interacting with tezos blockchain",
+                     optional_opam_deps=["tls", "ledgerwallet-tezos"]),
+    OpamBasedPackage("tezos-admin-client",
+                     "Administration tool for the node",
+                     optional_opam_deps=["tls"]),
+    OpamBasedPackage("tezos-signer",
+                     "A client to remotely sign operations or blocks",
+                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                     systemd_units=signer_units),
+    OpamBasedPackage("tezos-codec",
+                     "A client to decode and encode JSON")
 ]
 
 
@@ -90,17 +90,16 @@ node_units.append(mk_node_unit(suffix="custom", env=["DATA_DIR=/var/lib/tezos/no
                                                      "CUSTOM_NODE_CONFIG="] + common_node_env,
                                desc="Tezos node with custom config"))
 
-packages.append(Package("tezos-node",
-                        "Entry point for initializing, configuring and running a Tezos node",
-                        node_units,
-                        optional_opam_deps=[
-                            "tezos-embedded-protocol-001-PtCJ7pwo",
-                            "tezos-embedded-protocol-002-PsYLVpVv",
-                            "tezos-embedded-protocol-003-PsddFKi3",
-                            "tezos-embedded-protocol-004-Pt24m4xi",
-                            "tezos-embedded-protocol-005-PsBABY5H",
-                            "tezos-embedded-protocol-005-PsBabyM1",
-                            "tezos-embedded-protocol-006-PsCARTHA"]))
+packages.append(OpamBasedPackage("tezos-node",
+                                 node_units,
+                                 optional_opam_deps=[
+                                     "tezos-embedded-protocol-001-PtCJ7pwo",
+                                     "tezos-embedded-protocol-002-PsYLVpVv",
+                                     "tezos-embedded-protocol-003-PsddFKi3",
+                                     "tezos-embedded-protocol-004-Pt24m4xi",
+                                     "tezos-embedded-protocol-005-PsBABY5H",
+                                     "tezos-embedded-protocol-005-PsBabyM1",
+                                     "tezos-embedded-protocol-006-PsCARTHA"]))
 
 active_protocols = json.load(open(f"{os.path.dirname( __file__)}/../../protocols.json", "r"))["active"]
 
@@ -136,22 +135,22 @@ for proto in active_protocols:
                                                 environment=[f"PROTOCOL={proto}"],
                                                 exec_start="/usr/bin/tezos-endorser-start",
                                                 state_directory="tezos", user="tezos"))
-    packages.append(Package(f"tezos-baker-{proto}", "Daemon for baking",
-                            [SystemdUnit(service_file=service_file_baker,
-                                         startup_script="tezos-baker-start",
-                                         config_file="tezos-baker.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(Package(f"tezos-accuser-{proto}", "Daemon for accusing",
-                            [SystemdUnit(service_file=service_file_accuser,
-                                         startup_script="tezos-accuser-start",
-                                         config_file="tezos-accuser.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
-    packages.append(Package(f"tezos-endorser-{proto}", "Daemon for endorsing",
-                            [SystemdUnit(service_file=service_file_endorser,
-                                         startup_script="tezos-endorser-start",
-                                         config_file="tezos-endorser.conf")],
-                            proto,
-                            optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-baker-{proto}", "Daemon for baking",
+                                     [SystemdUnit(service_file=service_file_baker,
+                                                  startup_script="tezos-baker-start",
+                                                  config_file="tezos-baker.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
+                                     [SystemdUnit(service_file=service_file_accuser,
+                                                  startup_script="tezos-accuser-start",
+                                                  config_file="tezos-accuser.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+    packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
+                                     [SystemdUnit(service_file=service_file_endorser,
+                                                  startup_script="tezos-endorser-start",
+                                                  config_file="tezos-endorser.conf")],
+                                     proto,
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
 

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 import os, shutil, sys, subprocess, json
 
-from .model import Service, ServiceFile, SystemdUnit, Unit, OpamBasedPackage
+from .model import Service, ServiceFile, SystemdUnit, Unit, OpamBasedPackage, TezosSaplingParamsPackage
 
 networks = ["mainnet", "delphinet", "edonet"]
 
@@ -154,3 +154,4 @@ for proto in active_protocols:
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"]))
 
+packages.append(TezosSaplingParamsPackage())

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -57,7 +57,8 @@ signer_units = [
 packages = [
     OpamBasedPackage("tezos-client",
                      "CLI client for interacting with tezos blockchain",
-                     optional_opam_deps=["tls", "ledgerwallet-tezos"]),
+                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                     requires_sapling_params=True),
     OpamBasedPackage("tezos-admin-client",
                      "Administration tool for the node",
                      optional_opam_deps=["tls"]),
@@ -91,6 +92,7 @@ node_units.append(mk_node_unit(suffix="custom", env=["DATA_DIR=/var/lib/tezos/no
                                desc="Tezos node with custom config"))
 
 packages.append(OpamBasedPackage("tezos-node",
+                                 "Entry point for initializing, configuring and running a Tezos node",
                                  node_units,
                                  optional_opam_deps=[
                                      "tezos-embedded-protocol-001-PtCJ7pwo",
@@ -99,7 +101,8 @@ packages.append(OpamBasedPackage("tezos-node",
                                      "tezos-embedded-protocol-004-Pt24m4xi",
                                      "tezos-embedded-protocol-005-PsBABY5H",
                                      "tezos-embedded-protocol-005-PsBabyM1",
-                                     "tezos-embedded-protocol-006-PsCARTHA"]))
+                                     "tezos-embedded-protocol-006-PsCARTHA"],
+                                 requires_sapling_params=True))
 
 active_protocols = json.load(open(f"{os.path.dirname( __file__)}/../../protocols.json", "r"))["active"]
 
@@ -140,7 +143,8 @@ for proto in active_protocols:
                                                   startup_script="tezos-baker-start",
                                                   config_file="tezos-baker.conf")],
                                      proto,
-                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                                     requires_sapling_params=True))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script="tezos-accuser-start",


### PR DESCRIPTION
## Description
Sapling params are a hard runtime dependency for some of the Tezos binaries.
This PR adds a native package that wraps the required `sapling-spend.params` and `sapling-output.params`.
This package is later used as a dependency for `tezos-client`, `tezos-node` and `tezos-baker` packages.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #132 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
