### PR TITLE
[#133] Native packages postinstalls

### DIFF
--- a/docker/docker-tezos-packages.sh
+++ b/docker/docker-tezos-packages.sh
@@ -47,10 +47,10 @@ done
 "$virtualisation_engine" build -t tezos-"$target_os" -f docker/package/Dockerfile-"$target_os" .
 set +e
 if [[ -z ${source_archive-} ]]; then
-    container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
+    container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=240 -t tezos-"$target_os" "${args[@]}")"
 else
     container_id="$("$virtualisation_engine" create -v "$PWD/$source_archive:/tezos-packaging/docker/$source_archive_name" \
-     --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=120 -t tezos-"$target_os" "${args[@]}")"
+     --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=240 -t tezos-"$target_os" "${args[@]}")"
 fi
 "$virtualisation_engine" start -a "$container_id"
 exit_code="$?"

--- a/docker/package/defaults/tezos-accuser.conf
+++ b/docker/package/defaults/tezos-accuser.conf
@@ -5,4 +5,4 @@
 
 # shellcheck disable=SC2034
 NODE_RPC_ENDPOINT="http://localhost:8732"
-DATA_DIR="/var/lib/tezos/accuser"
+DATA_DIR="/var/lib/tezos/client"

--- a/docker/package/defaults/tezos-baker.conf
+++ b/docker/package/defaults/tezos-baker.conf
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 # shellcheck disable=SC2034
-DATA_DIR="/var/lib/tezos/baker"
+DATA_DIR="/var/lib/tezos/client"
 NODE_DATA_DIR=""
 NODE_RPC_ENDPOINT="http://localhost:8732"
 BAKER_ACCOUNT=""

--- a/docker/package/defaults/tezos-endorser.conf
+++ b/docker/package/defaults/tezos-endorser.conf
@@ -5,5 +5,5 @@
 
 # shellcheck disable=SC2034
 NODE_RPC_ENDPOINT="http://localhost:8732"
-DATA_DIR="/var/lib/tezos/endorser"
+DATA_DIR="/var/lib/tezos/client"
 ENDORSER_ACCOUNT=""

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -95,6 +95,7 @@ for package in packages:
                                         f"debian/{package.name.lower()}-{systemd_unit.suffix}.default")
                     shutil.copy(f"{os.path.dirname(__file__)}/scripts/{systemd_unit.startup_script}", f"debian/{systemd_unit.startup_script}")
                 package.gen_install("debian/install")
+                package.gen_postinst("debian/postinst")
                 package.gen_control_file(common_deps, "debian/control")
                 subprocess.run(["wget", "-q", "-O", "debian/copyright", f"https://gitlab.com/tezos/tezos/-/raw/v{version}/LICENSE"], check=True)
                 subprocess.run("rm debian/*.ex debian/*.EX debian/README*", shell=True, check=True)

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -127,6 +127,8 @@ default_testnets = {
     "008-PtEdoTez": "edonet"
 }
 
+daemon_postinst = postinst_steps_common + "\nmkdir -p /var/lib/tezos/client\n"
+
 for proto in active_protocols:
     service_file_baker = ServiceFile(Unit(after=["network.target"],
                                           description="Tezos baker"),
@@ -153,23 +155,20 @@ for proto in active_protocols:
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
                                      requires_sapling_params=True,
-                                     postinst_steps=postinst_steps_common + '''
-mkdir -p /var/lib/tezos/baker'''))
+                                     postinst_steps=daemon_postinst))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script="tezos-accuser-start",
                                                   config_file="tezos-accuser.conf")],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                                     postinst_steps=postinst_steps_common + '''
-mkdir -p /var/lib/tezos/accuser'''))
+                                     postinst_steps=daemon_postinst))
     packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
                                      [SystemdUnit(service_file=service_file_endorser,
                                                   startup_script="tezos-endorser-start",
                                                   config_file="tezos-endorser.conf")],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                                     postinst_steps=postinst_steps_common + '''
-mkdir -p /var/lib/tezos/endorser'''))
+                                     postinst_steps=daemon_postinst))
 
 packages.append(TezosSaplingParamsPackage())

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -70,6 +70,10 @@ packages = [
                      "A client to decode and encode JSON")
 ]
 
+postinst_steps_common = '''
+useradd --home-dir /var/lib/tezos tezos || true
+'''
+
 
 def mk_node_unit(suffix, env, desc):
     service_file = ServiceFile(Unit(after=["network.target"], requires=[],
@@ -82,14 +86,17 @@ def mk_node_unit(suffix, env, desc):
 
 
 node_units = []
+node_postinst_steps = ""
 common_node_env = ["NODE_RPC_ADDR=127.0.0.1:8732", "CERT_PATH=", "KEY_PATH="]
 for network in networks:
     env = [f"DATA_DIR=/var/lib/tezos/node-{network}", f"NETWORK={network}"] + common_node_env
     node_units.append(mk_node_unit(suffix=network, env=env, desc=f"Tezos node {network}"))
+    node_postinst_steps += f"mkdir -p /var/lib/tezos/node-{network}\n"
 
 node_units.append(mk_node_unit(suffix="custom", env=["DATA_DIR=/var/lib/tezos/node-custom",
                                                      "CUSTOM_NODE_CONFIG="] + common_node_env,
                                desc="Tezos node with custom config"))
+node_postinst_steps += "mkdir -p /var/lib/tezos/node-custom\n"
 
 packages.append(OpamBasedPackage("tezos-node",
                                  "Entry point for initializing, configuring and running a Tezos node",
@@ -102,7 +109,8 @@ packages.append(OpamBasedPackage("tezos-node",
                                      "tezos-embedded-protocol-005-PsBABY5H",
                                      "tezos-embedded-protocol-005-PsBabyM1",
                                      "tezos-embedded-protocol-006-PsCARTHA"],
-                                 requires_sapling_params=True))
+                                 requires_sapling_params=True,
+                                 postinst_steps=node_postinst_steps))
 
 active_protocols = json.load(open(f"{os.path.dirname( __file__)}/../../protocols.json", "r"))["active"]
 
@@ -144,18 +152,24 @@ for proto in active_protocols:
                                                   config_file="tezos-baker.conf")],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                                     requires_sapling_params=True))
+                                     requires_sapling_params=True,
+                                     postinst_steps=postinst_steps_common + '''
+mkdir -p /var/lib/tezos/baker'''))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script="tezos-accuser-start",
                                                   config_file="tezos-accuser.conf")],
                                      proto,
-                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                                     postinst_steps=postinst_steps_common + '''
+mkdir -p /var/lib/tezos/accuser'''))
     packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
                                      [SystemdUnit(service_file=service_file_endorser,
                                                   startup_script="tezos-endorser-start",
                                                   config_file="tezos-endorser.conf")],
                                      proto,
-                                     optional_opam_deps=["tls", "ledgerwallet-tezos"]))
+                                     optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                                     postinst_steps=postinst_steps_common + '''
+mkdir -p /var/lib/tezos/endorser'''))
 
 packages.append(TezosSaplingParamsPackage())


### PR DESCRIPTION
## Description
Problem: We want users and default data directories to be created
automatically along with the package installation.

Solution: Add scripts that do that in the package post-installation
stage.

Currently based on #142 
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #133

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
