### PR TITLE
[#133] Fix postinst scripts

### DIFF
--- a/docker/docker-tezos-packages.sh
+++ b/docker/docker-tezos-packages.sh
@@ -47,10 +47,10 @@ done
 "$virtualisation_engine" build -t tezos-"$target_os" -f docker/package/Dockerfile-"$target_os" .
 set +e
 if [[ -z ${source_archive-} ]]; then
-    container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=240 -t tezos-"$target_os" "${args[@]}")"
+    container_id="$("$virtualisation_engine" create --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=900 -t tezos-"$target_os" "${args[@]}")"
 else
     container_id="$("$virtualisation_engine" create -v "$PWD/$source_archive:/tezos-packaging/docker/$source_archive_name" \
-     --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=240 -t tezos-"$target_os" "${args[@]}")"
+     --env TEZOS_VERSION="$TEZOS_VERSION" --env OPAMSOLVERTIMEOUT=900 -t tezos-"$target_os" "${args[@]}")"
 fi
 "$virtualisation_engine" start -a "$container_id"
 exit_code="$?"

--- a/docker/package/defaults/tezos-accuser.conf
+++ b/docker/package/defaults/tezos-accuser.conf
@@ -5,4 +5,4 @@
 
 # shellcheck disable=SC2034
 NODE_RPC_ENDPOINT="http://localhost:8732"
-DATA_DIR="/var/lib/tezos/client"
+DATA_DIR="/var/lib/tezos/.tezos-client"

--- a/docker/package/defaults/tezos-baker.conf
+++ b/docker/package/defaults/tezos-baker.conf
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 # shellcheck disable=SC2034
-DATA_DIR="/var/lib/tezos/client"
+DATA_DIR="/var/lib/tezos/.tezos-client"
 NODE_DATA_DIR=""
 NODE_RPC_ENDPOINT="http://localhost:8732"
 BAKER_ACCOUNT=""

--- a/docker/package/defaults/tezos-endorser.conf
+++ b/docker/package/defaults/tezos-endorser.conf
@@ -5,5 +5,5 @@
 
 # shellcheck disable=SC2034
 NODE_RPC_ENDPOINT="http://localhost:8732"
-DATA_DIR="/var/lib/tezos/client"
+DATA_DIR="/var/lib/tezos/.tezos-client"
 ENDORSER_ACCOUNT=""

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -276,6 +276,9 @@ override_dh_systemd_start:
         postinst_contents = f'''#!/bin/sh
 
 set -e
+
+#DEBHELPER#
+
 {self.postinst_steps}
 '''
         with open(out, 'w') as f:

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -132,7 +132,7 @@ rm -f /var/lib/tezos/node-edo2net/config.json
 cat > /var/lib/tezos/node-edo2net/config.json <<- EOM
 {edo2net_config}
 EOM
-chown tezos:tezos /var/lib/tezos/node-edo2net/config.json
+chown -R tezos:tezos /var/lib/tezos/node-edo2net
 '''
 
 packages.append(OpamBasedPackage("tezos-node",
@@ -159,7 +159,7 @@ daemon_decs = {
     "endorser": "daemon for endorsing"
 }
 
-daemon_postinst = postinst_steps_common + "\nmkdir -p /var/lib/tezos/client\n"
+daemon_postinst = postinst_steps_common + "\nmkdir -p /var/lib/tezos/client\nchown -R tezos:tezos /var/lib/tezos/client\n"
 
 for proto in active_protocols:
     service_file_baker = ServiceFile(Unit(after=["network.target"],

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -159,7 +159,7 @@ daemon_decs = {
     "endorser": "daemon for endorsing"
 }
 
-daemon_postinst = postinst_steps_common + "\nmkdir -p /var/lib/tezos/client\nchown -R tezos:tezos /var/lib/tezos/client\n"
+daemon_postinst = postinst_steps_common + "\nmkdir -p /var/lib/tezos/.tezos-client\nchown -R tezos:tezos /var/lib/tezos/.tezos-client\n"
 
 for proto in active_protocols:
     service_file_baker = ServiceFile(Unit(after=["network.target"],

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "2",
+    "release": "3",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Custom postinst scripts were added to some of the packages in #143. However, there are some bugs in them:
* Some of the services data directories lack appropriate permissions for tezos user
* Automatically generated part of `postinst` script was dropped, thus serviced weren't unmasked during the package installation.

This PR fixes both aforementioned bugs.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
