### PR TITLE
[#130] brew formulas postinstalls

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -110,4 +110,7 @@ class TezosAccuser008Ptedo2zk < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/client"
+  end
 end

--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -97,7 +97,7 @@ class TezosAccuser008Ptedo2zk < Formula
           <key>EnvironmentVariables</key>
             <dict>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/client</string>
+              <string>#{var}/lib/tezos/client</string>
               <key>NODE_RPC_ENDPOINT</key>
               <string>http://localhost:8732</string>
           </dict>

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -104,7 +104,7 @@ class TezosBaker008Ptedo2zk < Formula
           <key>EnvironmentVariables</key>
             <dict>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/client</string>
+              <string>#{var}/lib/tezos/client</string>
               <key>NODE_DATA_DIR</key>
               <string></string>
               <key>NODE_RPC_ENDPOINT</key>

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -121,4 +121,7 @@ class TezosBaker008Ptedo2zk < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/client"
+  end
 end

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -122,4 +122,7 @@ class TezosEndorser008Ptedo2zk < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/client"
+  end
 end

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -107,7 +107,7 @@ class TezosEndorser008Ptedo2zk < Formula
           <key>EnvironmentVariables</key>
             <dict>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/client</string>
+              <string>#{var}/lib/tezos/client</string>
               <key>NODE_RPC_ENDPOINT</key>
               <string>http://localhost:8732</string>
               <key>ENDORSER_ACCOUNT</key>

--- a/Formula/tezos-node-edo2net.rb
+++ b/Formula/tezos-node-edo2net.rb
@@ -85,7 +85,7 @@ class TezosNodeEdo2net < Formula
           <key>EnvironmentVariables</key>
             <dict>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/node-edo2net</string>
+              <string>#{var}/lib/tezos/node-edo2net</string>
               <key>NODE_RPC_ADDR</key>
               <string>127.0.0.1:8732</string>
               <key>CERT_PATH</key>

--- a/Formula/tezos-node-edo2net.rb
+++ b/Formula/tezos-node-edo2net.rb
@@ -11,8 +11,7 @@ class TezosNodeEdo2net < Formula
 
   desc "Meta formula that provides backround tezos-node service that runs on edo2net"
 
-  def install
-    edo2net_config =
+  @@edo2net_config =
       <<~EOS
 {
 "p2p": {},
@@ -31,7 +30,8 @@ class TezosNodeEdo2net < Formula
         [ "edonet.tezos.co.il", "188.40.128.216:29732", "edo2net.kaml.fr",
           "edonet2.smartpy.io", "51.79.165.131", "edonetb.boot.tezostaquito.io" ] }
 }
-    EOS
+  EOS
+  def install
     startup_contents =
       <<~EOS
       #!/usr/bin/env bash
@@ -46,7 +46,7 @@ class TezosNodeEdo2net < Formula
       if [[ ! -f "$config_file" ]]; then
           echo "Configuring the node..."
           cat > "$config_file" <<-EOM
-      #{edo2net_config}
+      #{@@edo2net_config}
       EOM
           "$node" config update \
                   --data-dir "$DATA_DIR" \
@@ -101,5 +101,9 @@ class TezosNodeEdo2net < Formula
         </dict>
       </plist>
     EOS
+  end
+  def post_install
+    mkdir "#{var}/lib/tezos/node-edo2net"
+    File.write("#{var}/lib/tezos/node-edo2net/config.json", @@edo2net_config)
   end
 end

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -65,7 +65,7 @@ class TezosNodeMainnet < Formula
           <key>EnvironmentVariables</key>
             <dict>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/node-mainnet</string>
+              <string>#{var}/lib/tezos/node-mainnet</string>
               <key>NODE_RPC_ADDR</key>
               <string>127.0.0.1:8732</string>
               <key>CERT_PATH</key>

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -82,4 +82,8 @@ class TezosNodeMainnet < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir_p "#{var}/lib/tezos/node-mainnet"
+    system "tezos-node", "config", "init", "--data-dir" "#{var}/lib/tezos/node-mainnet", "--network", "mainnet"
+  end
 end

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -63,7 +63,7 @@ class TezosSignerHttp < Formula
               <key>PORT</key>
               <string>8080</string>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/signer-http</string>
+              <string>#{var}/lib/tezos/signer-http</string>
               <key>PIDFILE</key>
               <string></string>
               <key>MAGIC_BYTES</key>

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -80,4 +80,7 @@ class TezosSignerHttp < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/signer-http"
+  end
 end

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -84,4 +84,7 @@ class TezosSignerHttps < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/signer-https"
+  end
 end

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -67,7 +67,7 @@ class TezosSignerHttps < Formula
               <key>KEY_PATH</key>
               <string></string>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/signer-https</string>
+              <string>#{var}/lib/tezos/signer-https</string>
               <key>PIDFILE</key>
               <string></string>
               <key>MAGIC_BYTES</key>

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -82,4 +82,7 @@ class TezosSignerTcp < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/signer-tcp"
+  end
 end

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -65,7 +65,7 @@ class TezosSignerTcp < Formula
               <key>TIMEOUT</key>
               <string>1</string>
               <key>DATA_DIR</key>
-              <string>#{ENV["HOME"]}/tezos/signer-tcp</string>
+              <string>#{var}/lib/tezos/signer-tcp</string>
               <key>PIDFILE</key>
               <string></string>
               <key>MAGIC_BYTES</key>

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -60,7 +60,7 @@ class TezosSignerUnix < Formula
             <dict>
               <key>SOCKET</key>
               <string></string>
-              <string>#{ENV["HOME"]}/tezos/signer-unix</string>
+              <string>#{var}/lib/tezos/signer-unix</string>
               <key>PIDFILE</key>
               <string></string>
               <key>MAGIC_BYTES</key>

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -77,4 +77,7 @@ class TezosSignerUnix < Formula
       </plist>
     EOS
   end
+  def post_install
+    mkdir "#{var}/lib/tezos/signer-unix"
+  end
 end


### PR DESCRIPTION
## Description
Problem: We want to create default data directories and init node
configs during the post-install stage.

Solution: Add corresponding post_install to the formulas that provide
brew services.

Currently based and targets #149 
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #130 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
