### PR TITLE
Don't depend on rust brew formula

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -14,7 +14,7 @@ class TezosAccuser008Ptedo2zk < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosAccuser008Ptedo2zk < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -14,7 +14,7 @@ class TezosAdminClient < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosAdminClient < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -14,7 +14,7 @@ class TezosBaker008Ptedo2zk < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosBaker008Ptedo2zk < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -14,7 +14,7 @@ class TezosClient < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosClient < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -14,7 +14,7 @@ class TezosCodec < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosCodec < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -14,7 +14,7 @@ class TezosEndorser008Ptedo2zk < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -33,11 +33,10 @@ class TezosEndorser008Ptedo2zk < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -14,7 +14,7 @@ class TezosNode < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosNode < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -14,7 +14,7 @@ class TezosSandbox < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosSandbox < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -14,7 +14,7 @@ class TezosSigner < Formula
 
   version "v8.2-3"
 
-  build_dependencies = %w[pkg-config autoconf rsync wget opam rust]
+  build_dependencies = %w[pkg-config autoconf rsync wget opam rustup-init]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end
@@ -32,11 +32,10 @@ class TezosSigner < Formula
 
   def make_deps
     ENV.deparallelize
-
+    ENV["CARGO_HOME"]="./.cargo"
+    system "rustup-init", "--default-toolchain", "1.44.0", "-y"
     system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
-
-    ENV["RUST_VERSION"] = "1.49.0"
-    system "make", "build-deps"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
   end
 
   def install_template(dune_path, exec_path, name)


### PR DESCRIPTION
## Description
Problem: Tezos requires rust version to be specified explicitly in case
no default suggested version (1.44.0) is used. Previously, we
depended on rust brew formulas, but the rust version in it can be
changed at any time, which means that our formulas are quite unstable.

Solution: Depend on rustup-init and fetch rust compiler via
`rustup-init --default-toolchain 1.44.0`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
