### PR TITLE
[#148] tezos-node-<network> aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,17 +205,22 @@ file, they can be found in [`scripts`](./docker/package/scripts) and
 It's possible to run multiple same services, e.g. two `tezos-node`s that run different
 networks.
 
-`tezos-node` packages provide three services out of the box:
-`tezos-node-delphinet` and `tezos-node-mainnet` that run
-`delphinet` and `mainnet` networks respectively.
+`tezos-node` packages provide multiple services out of the box:
+`tezos-node-edo2net` and `tezos-node-mainnet` that run
+`edo2net` and `mainnet` networks respectively.
 
 In order to start it run:
 ```
 systemctl start tezos-node-<network>
 ```
 
+Also, there are `tezos-node-<network>` binary aliases that are equivalent to
+```
+TEZOS_NODE_DIR="<DATA_DIR from tezos-node-<network>.service>" tezos-node
+```
+
 In addition to node services where the config is predefined to a specific network
-(e.g. `tezos-node-mainnet` or `tezos-node-delphinet`), it's possible to run `tezos-node-custom`
+(e.g. `tezos-node-mainnet` or `tezos-node-edo2net`), it's possible to run `tezos-node-custom`
 service and provide a path to the custom node config file via the
 `CUSTOM_NODE_CONFIG` variable in the `tezos-node-custom.service` file.
 

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -96,6 +96,7 @@ for package in packages:
                     shutil.copy(f"{os.path.dirname(__file__)}/scripts/{systemd_unit.startup_script}", f"debian/{systemd_unit.startup_script}")
                 package.gen_install("debian/install")
                 package.gen_postinst("debian/postinst")
+                package.gen_postrm("debian/postrm")
                 package.gen_control_file(common_deps, "debian/control")
                 subprocess.run(["wget", "-q", "-O", "debian/copyright", f"https://gitlab.com/tezos/tezos/-/raw/v{version}/LICENSE"], check=True)
                 subprocess.run("rm debian/*.ex debian/*.EX debian/README*", shell=True, check=True)

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "3",
+    "release": "4",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: It would be convenient to have such aliases when it's required
to run node with the data directory specified in the systemd service
environment.

Solution: Add tezos-node-<network> scripts that are generated during
postinst stage. They are also cleaned up during the postrm.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves part of #148 (it'll be closed once the updated packages are published and the baking article is updated)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
