### PR TITLE
Update bottles hashes

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -28,6 +28,8 @@ class TezosAccuser008Ptedo2zk < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser008Ptedo2zk.version}/"
     cellar :any
+    sha256 "4efaedef768f5114ae6e142aeba62c883e1703bcaf725a9c53cceee0f55c4427" => :mojave
+    sha256 "12378615cf0f6291e89f58e8c6aa04aef56d52d823dcab18bb72d954fb7e4b73" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -28,6 +28,8 @@ class TezosAdminClient < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
     cellar :any
+    sha256 "dc851c99e9056ca0cad7867057a2fc87dce25936a1017e2cabc31009f69414b9" => :mojave
+    sha256 "d90e59edf2345bb905c5c2f1969a69435eb7d61c0805e56f18874dd88826ef50" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -28,6 +28,8 @@ class TezosBaker008Ptedo2zk < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker008Ptedo2zk.version}/"
     cellar :any
+    sha256 "774db0d3db3ac06dc6eb7216b0be9cbde36adf37c6706894b44b232d067bbb5e" => :mojave
+    sha256 "d02f82402146a961b3a055aa8e59d4e87d44d086bd6d3ad6bebb47b98a3d0e76" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -28,6 +28,8 @@ class TezosClient < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
     cellar :any
+    sha256 "bce5ba2314112ad023b9a6caceba8f0ee74311ff235358c5a8f7bfa605fdf0cf" => :mojave
+    sha256 "e16b7fb7c7b872ac9f81abd42afb4707f69dd878f4bc4fbe83e9fff3faccb671" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -28,6 +28,8 @@ class TezosCodec < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
     cellar :any
+    sha256 "b89b972018f6a59086163b426029734ab43a9319459962bb5b37ab8459ab0a5e" => :mojave
+    sha256 "f186cd6d8eb3c1c028223880aec51293665c806ef1269a97e8fd0710daec842a" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -29,6 +29,8 @@ class TezosEndorser008Ptedo2zk < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser008Ptedo2zk.version}/"
     cellar :any
+    sha256 "0f5fa558641e1e08fda154be2b9d076dfa373fc0120f41b0c14ccb30dd2183f8" => :mojave
+    sha256 "513ef0ab298831919c763beca1d37500af094cba442a4f8397704d2dc9d10df5" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -28,6 +28,8 @@ class TezosNode < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
     cellar :any
+    sha256 "8325cec25211095a9196723a5801fadc3f593eefd67ffae69508a095fc263985" => :mojave
+    sha256 "9f9876e33268117a300147dabb7d2aab2602b46db4e0968f89b22c7a5c71db38" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -28,6 +28,8 @@ class TezosSandbox < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
     cellar :any
+    sha256 "8325cec25211095a9196723a5801fadc3f593eefd67ffae69508a095fc263985" => :mojave
+    sha256 "54048e33fdafa63be4cd5f1a351d1a22b8dc00e96c0bcd90a3c8ef588d69f6d7" => :catalina
   end
 
   def make_deps

--- a/Formula/tezos-sapling-params.rb
+++ b/Formula/tezos-sapling-params.rb
@@ -13,6 +13,8 @@ class TezosSaplingParams < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSaplingParams.version}/"
     cellar :any
+    sha256 "4e89932b0626cffe80214ba45342280c340b34c58ebbf7c3e0185a6d4662732d" => :mojave
+    sha256 "5f7a5687d67051eafcfb7cb5ac542143a325a135403daeca6595602bfd400441" => :catalina
   end
 
   def install

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -28,6 +28,8 @@ class TezosSigner < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
     cellar :any
+    sha256 "fb36d48f47fb20d9cb4a93663c74e0eefe54e2f01f83e1c17b23ed187c733fc4" => :mojave
+    sha256 "6fc1ee3ecd0b214280e0011b5e375ed4292d9ffbdca8dcf47e8b9091d71800ea" => :catalina
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: New release was created, brew formulas now have
tezos-sapling-params dependency and also provide background services.
We should provide an easy way to obtain updated packages without
building them from scratch.

Solution: Provide hashes for the new bottles.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
