### PR TITLE
[#157] Do native packaging for arm64

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -108,7 +108,7 @@ Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
 Package: {self.name.lower()}
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {"tezos-sapling-params" if self.requires_sapling_params else ""}
 Description: {self.desc}
 '''
@@ -199,7 +199,7 @@ Release: {release}
 Epoch: {fedora_epoch}
 Summary: {self.desc}
 License: MIT
-BuildArch: x86_64
+BuildArch: x86_64 aarch64
 Source0: {self.name}-{version}.tar.gz
 Source1: https://gitlab.com/tezos/tezos/tree/v{version}/
 BuildRequires: {build_requires} {systemd_deps}
@@ -308,7 +308,7 @@ Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
 Package: {self.name.lower()}
-Architecture: amd64
+Architecture: amd64 arm64
 Depends: ${{shlibs:Depends}}, ${{misc:Depends}}
 Description: {self.desc}
 '''
@@ -324,7 +324,7 @@ Release: {release}
 Epoch: {fedora_epoch}
 Summary: {self.desc}
 License: MIT
-BuildArch: x86_64
+BuildArch: x86_64 aarch64
 Source0: {self.name}-{version}.tar.gz
 BuildRequires: wget
 %description


### PR DESCRIPTION
## Description
Problem: Currently both Ubuntu and Fedora native packages target only
amd64, thus it's not possible to use our package repos on the other
architectures.

Solution: Add arm64 to the list of target architectures.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves part of #157 (It'll be fully resolved only once the arm64 packages are uploaded and built)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
