### PR TITLE
[#107] Add nixos modules for tezos binaries

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -59,6 +59,10 @@ steps:
    agents:
      queue: "x86_64-darwin"
 
+ - label: test nixos modules
+   commands:
+   - nix-build tests/tezos-modules.nix --no-out-link
+
  # binaries built by docker are tested on the another machine,
  # so we should wait for docker build to finish
  - wait

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{ lib, pkgs, ... }:
+
+with lib;
+rec {
+  sharedOptions = {
+
+    logVerbosity = mkOption {
+      type = types.enum [ "fatal" "error" "warning" "notice" "info" "debug" ];
+      default = "warning";
+      description = ''
+        Level of logs verbosity. Possible values are:
+        fatal, error, warn, notice, info or debug.
+      '';
+    };
+
+  };
+
+  daemonOptions = sharedOptions // {
+
+    baseProtocol = mkOption {
+      type = types.enum [ "009-PsFLoren"];
+      description = ''
+        Base protocol version,
+        only '009-PsFLoren' is supported.
+      '';
+      example = "009-PsFLoren";
+    };
+
+    rpcPort = mkOption {
+      type = types.int;
+      default = 8732;
+      example = 8732;
+      description = ''
+        Tezos node RPC port.
+      '';
+    };
+
+  };
+
+  genDaemonConfig = instancesCfg: service-name: service-pkgs: service-script:
+    mkIf (instancesCfg != {}) {
+      users = mkMerge (flip mapAttrsToList instancesCfg (node-name: node-cfg: genUsers node-name ));
+      systemd = mkMerge (flip mapAttrsToList instancesCfg (node-name: node-cfg:
+        let tezos-service = service-pkgs."${node-cfg.baseProtocol}";
+        in {
+          services."tezos-${node-name}-tezos-${service-name}" = genSystemdService node-name node-cfg service-name // rec {
+            bindsTo = [ "network.target" "tezos-${node-name}-tezos-node.service" ];
+            after = bindsTo;
+            path = with pkgs; [ curl ];
+            preStart =
+              ''
+                while ! _="$(curl --silent http://localhost:${toString node-cfg.rpcPort}/chains/main/blocks/head/)"; do
+                  echo "Trying to connect to tezos-node"
+                  sleep 1s
+                done
+
+                service_data_dir="$STATE_DIRECTORY/client/data"
+                mkdir -p "$service_data_dir"
+
+                # Generate or update service config file
+                if [[ ! -f "$service_data_dir/config" ]]; then
+                  ${tezos-service} -d "$service_data_dir" -E "http://localhost:${toString node-cfg.rpcPort}" \
+                  config init --output "$service_data_dir/config" >/dev/null 2>&1
+                else
+                  ${tezos-service} -d "$service_data_dir" -E "http://localhost:${toString node-cfg.rpcPort}" \
+                  config update >/dev/null 2>&1
+                fi
+              '';
+            script = service-script node-cfg;
+          };
+      }));
+    };
+
+  genUsers = node-name: {
+    groups."tezos-${node-name}" = { };
+    users."tezos-${node-name}" = { group = "tezos-${node-name}"; };
+  };
+
+  genSystemdService = node-name: node-cfg: service-name: {
+    wantedBy = [ "multi-user.target" ];
+    description = "Tezos ${service-name}";
+    environment = {
+      TEZOS_LOG = "* -> ${node-cfg.logVerbosity}";
+    };
+    serviceConfig = {
+      User = "tezos-${node-name}";
+      Group = "tezos-${node-name}";
+      StateDirectory = "tezos-${node-name}";
+      Restart = "always";
+      RestartSec = "10";
+    };
+  };
+
+}

--- a/nix/modules/tezos-accuser.nix
+++ b/nix/modules/tezos-accuser.nix
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  tezos-accuser-pkgs = {
+    "009-PsFLoren" =
+      "${pkgs.ocamlPackages.tezos-baker-009-PsFLoren}/bin/tezos-baker-009-PsFLoren";
+  };
+  cfg = config.services.tezos-accuser;
+  common = import ./common.nix { inherit lib; inherit pkgs; };
+  instanceOptions = types.submodule ( {...} : {
+    options = common.daemonOptions // {
+
+      enable = mkEnableOption "Tezos accuser service";
+
+    };
+  });
+
+in {
+  options.services.tezos-accuser = {
+    instances = mkOption {
+      type = types.attrsOf instanceOptions;
+      description = "Configuration options";
+      default = {};
+    };
+  };
+  config =
+    let accuser-script = node-cfg: ''
+        ${tezos-accuser-pkgs.${node-cfg.baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
+        -E "http://localhost:${toString node-cfg.rpcPort}" \
+        run with local node "$STATE_DIRECTORY/node/data" "$@"
+      '';
+    in common.genDaemonConfig cfg.instances "accuser" tezos-accuser-pkgs accuser-script;
+}

--- a/nix/modules/tezos-baker.nix
+++ b/nix/modules/tezos-baker.nix
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  tezos-baker-pkgs = {
+    "009-PsFLoren" =
+      "${pkgs.ocamlPackages.tezos-baker-009-PsFLoren}/bin/tezos-baker-009-PsFLoren";
+  };
+  cfg = config.services.tezos-baker;
+  common = import ./common.nix { inherit lib; inherit pkgs; };
+  instanceOptions = types.submodule ( {...} : {
+    options = common.daemonOptions // {
+
+      enable = mkEnableOption "Tezos baker service";
+
+      endorserAccountAlias = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Alias for the tezos-endorser account.
+        '';
+      };
+
+    };
+  });
+
+in {
+  options.services.tezos-baker = {
+    instances = mkOption {
+      type = types.attrsOf instanceOptions;
+      description = "Configuration options";
+      default = {};
+    };
+  };
+  config =
+    let baker-script = node-cfg: ''
+        ${tezos-baker-pkgs.${node-cfg.baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
+        -E "http://localhost:${toString node-cfg.rpcPort}" \
+        run with local node "$STATE_DIRECTORY/node/data" ${node-cfg.endorserAccountAlias}
+      '';
+    in common.genDaemonConfig cfg.instances "baker" tezos-baker-pkgs baker-script;
+}

--- a/nix/modules/tezos-endorser.nix
+++ b/nix/modules/tezos-endorser.nix
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  tezos-endorser-pkgs = {
+    "009-PsFLoren" =
+      "${pkgs.ocamlPackages.tezos-baker-009-PsFLoren}/bin/tezos-baker-009-PsFLoren";
+  };
+  common = import ./common.nix { inherit lib; inherit pkgs; };
+  cfg = config.services.tezos-endorser;
+  instanceOptions = types.submodule ( {...} : {
+    options = common.daemonOptions // {
+
+      enable = mkEnableOption "Tezos endorser service";
+
+      bakerAccountAlias = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Alias for the tezos-baker account.
+        '';
+      };
+
+    };
+  });
+
+in {
+  options.services.tezos-endorser = {
+    instances = mkOption {
+      type = types.attrsOf instanceOptions;
+      description = "Configuration options";
+      default = {};
+    };
+  };
+  config =
+    let endorser-script = node-cfg: ''
+        ${tezos-endorser-pkgs.${node-cfg.baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
+        -E "http://localhost:${toString node-cfg.rpcPort}" \
+        run with local node "$STATE_DIRECTORY/node/data" ${node-cfg.bakerAccountAlias}
+      '';
+    in common.genDaemonConfig cfg.instances "endorser" tezos-endorser-pkgs endorser-script;
+}

--- a/nix/modules/tezos-node.nix
+++ b/nix/modules/tezos-node.nix
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  tezos-node-pkg = pkgs.ocamlPackages.tezos-node;
+  cfg = config.services.tezos-node;
+  sources = import ../nix/sources.nix;
+  genConfigCommand = historyMode: rpcPort: netPort: network: ''
+    --data-dir "$node_data_dir" \
+    --history-mode "${historyMode}" \
+    --rpc-addr ":${toString rpcPort}" \
+    --net-addr ":${toString netPort}" \
+    --network "${network}"
+  '';
+  common = import ./common.nix { inherit lib; inherit pkgs; };
+  instanceOptions = types.submodule ( {...} : {
+    options = common.sharedOptions // {
+      enable = mkEnableOption "Tezos node service";
+
+      package = mkOption {
+        default = tezos-node-pkg;
+        type = types.package;
+      };
+
+      rpcPort = mkOption {
+        type = types.int;
+        default = 8732;
+        example = 8732;
+        description = ''
+          Tezos node RPC port.
+        '';
+      };
+
+      netPort = mkOption {
+        type = types.int;
+        default = 9732;
+        example = 9732;
+        description = ''
+          Tezos node net port.
+        '';
+      };
+
+      network = mkOption {
+        type = types.str;
+        default = "florencenet";
+        description = ''
+          Network which node will be running on.
+        '';
+      };
+
+      historyMode = mkOption {
+        type = types.enum [ "full" "experimental-rolling" "archive" ];
+        default = "full";
+        description = ''
+          Node history mode. Possible values are:
+          full, experimental-rolling or archive.
+        '';
+      };
+
+      nodeConfig = mkOption {
+        default = null;
+        type = types.nullOr (import sources.serokell-nix).lib.types.jsonConfig;
+        description = ''
+          Custom node config.
+          This option overrides the all other options that affect
+          tezos-node config.
+        '';
+      };
+    };
+  });
+in {
+
+  options.services.tezos-node = {
+    instances = mkOption {
+      type = types.attrsOf instanceOptions;
+      description = "Configuration options";
+      default = {};
+    };
+  };
+  config = mkIf (cfg.instances != {}) {
+    users = mkMerge (flip mapAttrsToList cfg.instances (node-name: node-cfg: common.genUsers node-name ));
+    systemd = mkMerge (flip mapAttrsToList cfg.instances (node-name: node-cfg: {
+      services."tezos-${node-name}-tezos-node" = common.genSystemdService node-name node-cfg "node" // {
+        after = [ "network.target" ];
+        preStart =
+          ''
+            node_data_dir="$STATE_DIRECTORY/node/data"
+            mkdir -p "$node_data_dir"
+          '' + (
+            if node-cfg.nodeConfig == null
+            then
+              ''
+                # Generate or update node config file
+                if [[ ! -f "$node_data_dir/config.json" ]]; then
+                  ${node-cfg.package}/bin/tezos-node config init \
+                  ${genConfigCommand node-cfg.historyMode node-cfg.rpcPort node-cfg.netPort node-cfg.network}
+                else
+                  ${node-cfg.package}/bin/tezos-node config update \
+                  ${genConfigCommand node-cfg.historyMode node-cfg.rpcPort node-cfg.netPort node-cfg.network}
+                fi
+              ''
+            else
+              ''
+                cp ${node-cfg.nodeConfig} "$node_data_dir/config.json"
+              ''
+          );
+        script = ''
+          ${node-cfg.package}/bin/tezos-node run --data-dir "$STATE_DIRECTORY/node/data" \
+          --connections 50 --bootstrap-threshold=1
+        '';
+      };
+    }));
+  };
+}

--- a/nix/modules/tezos-signer.nix
+++ b/nix/modules/tezos-signer.nix
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+{config, lib, pkgs, ...}:
+
+with lib;
+
+let
+  tezos-signer-launch = "${pkgs.ocamlPackages.tezos-signer}/bin/tezos-signer launch";
+  common = import ./common.nix { inherit lib; inherit pkgs; };
+  cfg = config.services.tezos-signer;
+  instanceOptions = types.submodule ( {...} : {
+    options = common.sharedOptions // {
+
+      enable = mkEnableOption "Tezos signer service";
+
+      networkProtocol = mkOption {
+        type = types.enum [ "http" "https" "tcp" "unix" ];
+        description = ''
+          Network protocol version. Supports http, https, tcp and unix.
+        '';
+        example = "http";
+      };
+
+      netAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "127.0.0.1";
+        description = ''
+          Tezos signer net address.
+        '';
+      };
+
+      netPort = mkOption {
+        type = types.int;
+        default = 8080;
+        example = 8080;
+        description = ''
+          Tezos signer net port.
+        '';
+      };
+
+      certPath = mkOption {
+        type = types.str;
+        default = null;
+        description = ''
+          Path of the SSL certificate to use for https Tezos signer.
+        '';
+      };
+
+      keyPath = mkOption {
+        type = types.str;
+        default = null;
+        description = ''
+          Key path to use for https Tezos signer.
+        '';
+      };
+
+      unixSocket = mkOption {
+        type = types.str;
+        default = null;
+        description = ''
+          Socket to use for Tezos signer running over UNIX socket.
+        '';
+      };
+
+      timeout = mkOption {
+        type = types.int;
+        default = 1;
+        example = 1;
+        description = ''
+          Timeout for Tezos signer.
+        '';
+      };
+
+    };
+  });
+in {
+  options.services.tezos-signer = {
+    instances = mkOption {
+      type = types.attrsOf instanceOptions;
+      description = "Configuration options";
+      default = {};
+    };
+  };
+  config = mkIf (cfg.instances != {}) {
+    users = mkMerge (flip mapAttrsToList cfg.instances (node-name: node-cfg: common.genUsers node-name ));
+    systemd = mkMerge (flip mapAttrsToList cfg.instances (node-name: node-cfg:
+      let tezos-signers = {
+        "http" =
+          "${tezos-signer-launch} http signer --address ${node-cfg.netAddress} --port ${toString node-cfg.netPort}";
+        "https" =
+          "${tezos-signer-launch} https signer ${node-cfg.certPath} ${node-cfg.keyPath} --address ${node-cfg.netAddress} --port ${toString node-cfg.netPort}";
+        "tcp" =
+          "${tezos-signer-launch} socket signer --address ${node-cfg.netAddress} --port ${toString node-cfg.netPort} --timeout ${toString node-cfg.timeout}";
+        "unix" =
+          "${tezos-signer-launch} local signer --socket ${node-cfg.unixSocket}";
+      };
+      in {
+      services."tezos-${node-name}-tezos-signer" = common.genSystemdService node-name node-cfg "signer" // {
+        after = [ "network.target" ];
+        script = ''
+          ${tezos-signers.${node-cfg.networkProtocol}}
+        '';
+      };
+    }));
+  };
+}

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -47,6 +47,18 @@
         "url": "https://github.com/ocaml/opam-repository/archive/d90747963ba246b00526d08d26241e5654f418bf.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "serokell-nix": {
+        "branch": "master",
+        "description": "Serokell Nix infrastructure library",
+        "homepage": "",
+        "owner": "serokell",
+        "repo": "serokell.nix",
+        "rev": "c8d39be5ea3b5cac5da952f28d37095ef385b89f",
+        "sha256": "0db2hgh2fgpr8hn7rpg1fixjsvl20clj6ld893825rn56a2aq76v",
+        "type": "tarball",
+        "url": "https://github.com/serokell/serokell.nix/archive/c8d39be5ea3b5cac5da952f28d37095ef385b89f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "tezos": {
         "ref": "refs/tags/v9.1",
         "repo": "https://gitlab.com/tezos/tezos",

--- a/tests/tezos-modules.nix
+++ b/tests/tezos-modules.nix
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+let
+  nixpkgs = (import ../nix/nix/sources.nix).nixpkgs;
+  pkgs = import ../nix/build/pkgs.nix {};
+in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
+{
+  machine = { ... }: {
+    virtualisation.memorySize = 1024;
+    virtualisation.diskSize = 1024;
+
+    nixpkgs.pkgs = pkgs;
+    imports = [ ../nix/modules/tezos-node.nix
+                ../nix/modules/tezos-signer.nix
+                ../nix/modules/tezos-accuser.nix
+                ../nix/modules/tezos-baker.nix
+                ../nix/modules/tezos-endorser.nix
+              ];
+
+    services.tezos-node.instances.florencenet.enable = true;
+
+    services.tezos-signer.instances.florencenet = {
+      enable = true;
+      networkProtocol = "http";
+    };
+
+    services.tezos-accuser.instances.florencenet = {
+      enable = true;
+      baseProtocol = "009-PsFLoren";
+    };
+
+    services.tezos-baker.instances.florencenet = {
+      enable = true;
+      baseProtocol = "009-PsFLoren";
+    };
+
+    services.tezos-endorser.instances.florencenet = {
+      enable = true;
+      baseProtocol = "009-PsFLoren";
+    };
+
+  };
+
+  testScript = ''
+    start_all()
+
+    services = [
+        "tezos-node",
+        "tezos-signer",
+        "tezos-baker",
+        "tezos-accuser",
+        "tezos-endorser",
+    ]
+
+    for s in services:
+        machine.wait_for_unit(f"tezos-florencenet-{s}.service")
+
+    with subtest("check tezos-node rpc response"):
+        machine.wait_for_open_port(8732)
+        machine.wait_until_succeeds(
+            "curl --silent http://localhost:8732/chains/main/blocks/head/header | grep level"
+        )
+
+    with subtest("service status sanity check"):
+        for s in services:
+            machine.succeed(f"systemctl status tezos-florencenet-{s}.service")
+  '';
+})


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: we're providing systemd services for `tezos-node` and tezos daemons in the native packages, but there are no nixos modules for them.

Solution: added nixos modules for `tezos-node`, `tezos-signer`, `tezos-baker-<proto>`, `tezos-accuser-<proto>`, and `tezos-endorser-<proto>`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #107 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).