### PR TITLE
[#148] Use new aliases in baking article

### DIFF
--- a/docs/baking.md
+++ b/docs/baking.md
@@ -96,31 +96,14 @@ the smallest and the fastest mode that is sufficient for baking (you can read mo
 
 All commands within the service are run under the `tezos` user.
 
+The `tezos-node` package provides `tezos-node-<network>` aliases that are equivalent to
+`tezos-node --data-dir <DATA_DIR from the tezos-node-<network>.service>`.
+These aliases can be used instead of providing `--data-dir` option to the `tezos-node`
+invocations manually.
+
 In order to import the snapshot, run the following command:
 ```
-sudo -u tezos tezos-node snapshot import --data-dir /var/lib/tezos/node-<network>/ <path to the snapshot file>
-```
-
-#### Troubleshooting node snapshot import
-
-Snapshot import requires that the `tezos-node` data directory doesn't contain the `context` and `store` folders.
-Remove them if you're getting an error about their presence.
-
-In case you're getting an error similar to:
-```
-tezos-node: Error:
-              Invalid block BLjutMj47caB
-                Failed to validate the economic-protocol content of the block: Error:
-                                                                                Invalid signature for block BLjutMj47caB. Expected: tz1Na5QB98cDA.
-```
-
-you should init/update config in the data directory to match the desired network
-before importing the snapshot. To do that, run one of the following commands
-(depending on whether the config in the given data directory was initialized previously):
-```
-sudo -u tezos tezos-node config init --data-dir /var/lib/tezos/node-<network> --network <network>
-#or
-sudo -u tezos tezos-node config update --data-dir /var/lib/tezos/node-<network> --network <network>
+sudo -u tezos tezos-node-<network> snapshot import <path to the snapshot file>
 ```
 
 ### Starting the node

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -86,7 +86,6 @@ In order to run a baker locally, you'll need a fully-synced local `tezos-node`.
 
 The fastest way to bootstrap the node is to import a snapshot.
 Snapshots can be downloaded from the following websites:
-* [Tulip Snapshots](https://snapshots.tulip.tools/#/)
 * [Tezos Giganode Snapshots](https://snapshots-tezos.giganode.io/)
 * [XTZ-Shots](https://xtz-shots.io/)
 


### PR DESCRIPTION
## Description
Problem: Providing data-dir manually to the `tezos-node` commands is a
bit inconvenient.

Solution: Suggest using tezos-node-<network> aliases instead of
providing data directory option manually.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #148 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
