### PR TITLE
[#162] Fix shebangs in startup scripts

### DIFF
--- a/docker/package/scripts/tezos-accuser-start
+++ b/docker/package/scripts/tezos-accuser-start
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #

--- a/docker/package/scripts/tezos-baker-start
+++ b/docker/package/scripts/tezos-baker-start
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #

--- a/docker/package/scripts/tezos-endorser-start
+++ b/docker/package/scripts/tezos-endorser-start
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #

--- a/docker/package/scripts/tezos-node-start
+++ b/docker/package/scripts/tezos-node-start
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #

--- a/docker/package/scripts/tezos-signer-start
+++ b/docker/package/scripts/tezos-signer-start
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #


### PR DESCRIPTION
## Description
Problem: Startup scripts currently use '#!/usr/bin/bash' shebangs.
However, some of the distros may have different bath to the bash
interpreter, thus startup script may fail on them.

Soluton: Use '#!/usr/bin/env bash' instead, so that the path to the bash
interpreter is fetched from the current environment.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #162

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
