### PR TITLE
Mention mirrored taps in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,22 @@ Run `./tezos-client` or add it to your PATH to be able to run it anywhere.
 <a name="macos"></a>
 ## Brew tap for macOS
 
-If you're using macOS and `brew`, you can install Tezos binaries from the tap
-provided by this repository. In order to do that run the following:
+If you're using macOS and `brew`, you can install Tezos binaries from the taps provided
+by this repository. There are two taps: one for the latest stable release of Tezos and
+one for the latest release candidate of Tezos.
+
+In order to use latest stable version run the following:
 ```
-brew tap serokell/tezos-packaging https://github.com/serokell/tezos-packaging.git
+brew tap serokell/tezos-packaging-stable https://github.com/serokell/tezos-packaging-stable.git
+```
+
+In order to use latest release candidate version run the following:
+```
+brew tap serokell/tezos-packaging-rc https://github.com/serokell/tezos-packaging-rc.git
+```
+
+Once the desired tap is selected, you can install the chosen package, e.g.:
+```
 brew install tezos-client
 ```
 


### PR DESCRIPTION
## Description
Problem: We'd like to have an ability to install both latest stable
version and latest release candidate brew formulas on the macOS.
However, brew tap uses master branch of the repo by default and it
cannot be changed.

Solution: Create two mirrors of the tezos-packaging repo, one mirror for
the latest stable release and one mirror for the latest release
candidate release, thus users may use one of these repos as a brew tap
and install desired stable or release candidate formulas. Mention this
capability in the README.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

https://issues.serokell.io/issue/TM-535

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
