### PR TITLE
Add v8.3-1 bottles hashes

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -27,7 +27,8 @@ class TezosAccuser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser008Ptedo2zk.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "ba583a1be59cc9534e1ac8b0ea8ce1b2efe2b6b594e0309b400b66df8d281a45"
+    sha256 cellar: :any, catalina: "9dde0ba35f95603ae646d505dfe4963741c7b7fe2cd5bca5bd3bd07fb05a3153"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,7 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "e4fad99a9c56947bc79262c90ab5898e1b0fa44907f94e9d99c688270c6e64ea"
+    sha256 cellar: :any, catalina: "58fefe9df07b8be276cfcfd7b30ee3594a043701b9dd81700e9a4fcec4ac089f"
   end
 
   def make_deps

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -27,7 +27,8 @@ class TezosBaker008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker008Ptedo2zk.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "bec3c4b1f6a3bfd1d1773d9b97d5e27c736b4581afe61a204538f4afccd17992"
+    sha256 cellar: :any, catalina: "f6dabfd606c41694b011bbff010bb579775d9ea466ec957429e1a4beb57a3cc0"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,7 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "3671c5de0b1b4a03368f142fb959b5e11f399509fb0f6f96efaa993646ae4a2d"
+    sha256 cellar: :any, catalina: "66309596374d91be40433af2999d27d17b70a1338a5dc9b1b5fe53082f07d8ef"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,7 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "edf793105a6be06820d9ae6edb4dd9f39f950566f36a3e35494c610a2b7de20b"
+    sha256 cellar: :any, catalina: "dcc140efb40c89eb5dd0cb86acd863a61db30f70a735a4e58ddcaf5699ce5b4c"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -28,7 +28,8 @@ class TezosEndorser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser008Ptedo2zk.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "8546395f93b2604903dc3bcd810f8d2d142a529e16a75d1390bdab5294d21d60"
+    sha256 cellar: :any, catalina: "e811604abb479b5cede599fb8e1d1cceaf38e68f6676d0140bddddd266ce3f0b"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,7 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "a43b5208113f0905f967074dcea1e211194649e702f534fbe719d86724832b28"
+    sha256 cellar: :any, catalina: "52331f9122e04f58da6658b43ac9ea28b97831060f2f4e16b55874ba6ce0d387"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,7 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "ad55f82f28e78ea71d26e5586ea058e38492e306b140e4c7b479d75db4a4be26"
+    sha256 cellar: :any, catalina: "2825f8cdf9d0ed0a9d50c112e044162205bf14ae5381201c8f6c2c6b26b7f524"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,7 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
-    cellar :any
+    sha256 cellar: :any, mojave: "dea1f1f2213f1a2b2ecd82296d5a98cc764a6980c48c1e92d0daa8ae4264111b"
+    sha256 cellar: :any, catalina: "6596cc0baeb6893225a5e8e78f3c030ed54c48deb1732cae1d9f9cb21e00185a"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: Bottles for mojave and catalina were built and uploaded to the
v8.3-1 github release. These bottles now should be used in the formulas.

Solution: Update bottles hashes in the formulas.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
