### PR TITLE
Update brew formula bottle hashes to v9.0

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -27,6 +27,8 @@ class TezosAccuser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "9993353f5a712f1d76158f55a659a89dd89f62e362793a0806eab2146d79f415"
+    sha256 cellar: :any, catalina: "a2af0961c4828d9be2a0b5ff4ed726b1d9017f7193bc3903b2e32950aeaa27c4"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "ceb2cd370a1b4298285132f1ae08e73f893e5d4535af33b885ac9333220b394b"
+    sha256 cellar: :any, catalina: "87cca2b88850ed34e3e6d9c5397320b47205c8d0bbb09260fcc1dc18aeeff3c8"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "0f3af887bbc737866f2e9aae5db015972ff0eef49e3f19680cacfec7b89336d2"
+    sha256 cellar: :any, catalina: "f3a908257821cfdc2750a9dec1d60e034353002c508ead420ad3c09fbd0569bc"
   end
 
   def make_deps

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -27,6 +27,8 @@ class TezosBaker008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "572db756093404f117be4cd330ad7321292e2be13eec6e278ef066439ca6fa55"
+    sha256 cellar: :any, catalina: "cc6c60a9bd1b83ce31965b4136cbc12588f49063b2922cd0176ae2244c77708c"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "860038bc9089176b9474f3931ab84b7d903e065c510701f2f905cc614d0737ee"
+    sha256 cellar: :any, catalina: "147d05628af33f8f8f15dbb2619daf88b3d7a734919565c9a1f03c2937f04833"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "ec08557ecfb3c16663f99e64a748e057f7ddff06c64001e775ab5035c55b51c3"
+    sha256 cellar: :any, catalina: "999d8894d609fe42a0ebdd742ab8950b63b8fc4af899b2c92e9edacd1daf37d3"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "a2aa2714b751523aa7a229e78f1af48bf372a9096c41f82bfca6b407d518a9eb"
+    sha256 cellar: :any, catalina: "bf0932005e708db38f5ddb8e8bdef55c73a75358936658c0eadef5ea67f70cf2"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -28,6 +28,8 @@ class TezosEndorser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "5c9b9fa0f337019f2fde7ffe845765428b03513496e3e0b3306806f82a06d3b7"
+    sha256 cellar: :any, catalina: "8a314d81c340a2f5f9c6ff422b08f01626e81bfb002b6a0e81c144ed9a1dbae9"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "f360bb4ee60a2e01d7e2be556f0349f8b10732cddb1ad2ee6a421bae8996123b"
+    sha256 cellar: :any, catalina: "99979219c99516716014e8f1c4cbeecba165eb71839d81153c2a1a0baeefa5e3"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "d3d38ba2227123bcad357a2cb17c6c2cf8623025a9adca43faa3bf61ed722693"
+    sha256 cellar: :any, catalina: "df91778e5ccd2873edf3ec4904035af596f623f8226cb0ab44c9764d5797b005"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "97fefdeb7fa066a9d51b5831d2bd788fde3ccc1ffb8e2392ddb9d7271915b045"
+    sha256 cellar: :any, catalina: "04d53dde65f592a65700e9a3a20e778ef91c5dfe3269e2d92cc65b2255a69370"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "d5cb15d4b93d342b081bbd779ff3a7e4cd0d511fa34469a4483320ff8fe748c6"
+    sha256 cellar: :any, catalina: "d5d68250a7429128aaf979cee9e60a48e94e380d21fb9d3c969c2e7aea6d5fa8"
   end
 
   def make_deps


### PR DESCRIPTION
New v9.0 bottles have been built for brew, this adds their hashes in the formulas.

## Description

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
