### PR TITLE
[#176] Support password-protected keys

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -9,19 +9,24 @@ from typing import List, Dict
 # There are more possible fields, but only these are used by tezos services
 class Service:
     def __init__(self, exec_start: str, state_directory:str, user: str,
-                 exec_start_pre: str=None, timeout_start_sec: str=None,
-                 environment_file: str=None, environment: List[str]=[],
-                 remain_after_exit: bool=False, type_: str=None, restart: str=None):
+                 exec_start_pre: str=None, exec_start_post: str=None,
+                 exec_stop_post: str=None,
+                 timeout_start_sec: str=None, environment_file: str=None, environment: List[str]=[],
+                 remain_after_exit: bool=False, type_: str=None, restart: str=None,
+                 keyring_mode: str=None):
         self.environment_file = environment_file
         self.environment = environment
         self.exec_start = exec_start
         self.exec_start_pre = exec_start_pre
+        self.exec_start_post = exec_start_post
+        self.exec_stop_post = exec_stop_post
         self.timeout_start_sec = timeout_start_sec
         self.state_directory = state_directory
         self.user = user
         self.remain_after_exit = remain_after_exit
         self.type_ = type_
         self.restart = restart
+        self.keyring_mode = keyring_mode
 
 class Unit:
     def __init__(self, after: List[str], description: str, requires: List[str]=[],
@@ -441,6 +446,15 @@ def print_service_file(service_file: ServiceFile, out):
     environment = "".join(map(lambda x: f"Environment=\"{x}\"\n", service_file.service.environment))
     environment_file = "" if service_file.service.environment_file is None else f"EnvironmentFile={service_file.service.environment_file}"
     wanted_by = "".join(map(lambda x: f"WantedBy=\"{x}\"\n", service_file.install.wanted_by))
+    exec_start_pres = \
+        "\n".join(f"ExecStartPre={x}" for x in service_file.service.exec_start_pre) \
+            if service_file.service.exec_start_pre is not None else ""
+    exec_start_posts = \
+        "\n".join(f"ExecStartPost={x}" for x in service_file.service.exec_start_post) \
+            if service_file.service.exec_start_post is not None else ""
+    exec_stop_posts = \
+        "\n".join(f"ExecStopPost={x}" for x in service_file.service.exec_stop_post) \
+            if service_file.service.exec_stop_post is not None else ""
     file_contents = f'''# SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
@@ -449,15 +463,18 @@ def print_service_file(service_file: ServiceFile, out):
 [Service]
 {environment_file}
 {environment}
-{f"ExecStartPre={service_file.service.exec_start_pre}" if service_file.service.exec_start_pre is not None else ""}
+{exec_start_pres}
 {f"TimeoutStartSec={service_file.service.timeout_start_sec}" if service_file.service.timeout_start_sec is not None else ""}
 ExecStart={service_file.service.exec_start}
+{exec_start_posts}
+{exec_stop_posts}
 StateDirectory={service_file.service.state_directory}
 User={service_file.service.user}
 Group={service_file.service.user}
 {"RemainAfterExit=yes" if service_file.service.remain_after_exit else ""}
 {f"Type={service_file.service.type_}" if service_file.service.type_ is not None else ""}
 {f"Restart={service_file.service.restart}" if service_file.service.restart is not None else ""}
+{f"KeyringMode={service_file.service.keyring_mode}" if service_file.service.keyring_mode is not None else ""}
 [Install]
 {wanted_by}
 '''
@@ -481,14 +498,17 @@ class TezosBakingServicesPackage(AbstractPackage):
                     service_file=ServiceFile(
                         Unit(after=["network.target"],
                              description=f"Tezos baking instance for {network}"),
-                        Service(exec_start="true", user="tezos", state_directory="tezos",
+                        Service(exec_start="/usr/bin/tezos-baking-start", user="tezos", state_directory="tezos",
                                 environment_file=f"/etc/default/tezos-baking-{network}",
-                                exec_start_pre="/usr/bin/tezos-baking-prestart",
-                                remain_after_exit=True, type_="oneshot"),
+                                exec_start_pre=["+/usr/bin/setfacl -m u:tezos:rwx /run/systemd/ask-password",
+                                                "/usr/bin/tezos-baking-prestart"],
+                                exec_stop_post=["+/usr/bin/setfacl -x u:tezos /run/systemd/ask-password"],
+                                remain_after_exit=True, type_="oneshot", keyring_mode="shared"),
                         Install(wanted_by=["multi-user.target"])
                     ),
                     suffix=network,
                     config_file="tezos-baking.conf",
+                    startup_script="tezos-baking-start",
                     prestart_script="tezos-baking-prestart"
                 )
             )

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -251,7 +251,7 @@ for proto in active_protocols:
                                         daemon_postinst_common + gen_daemon_specific_postinst(f"tezos-baker-{proto}") \
                                             + ledger_udev_postinst,
                                      postrm_steps=gen_daemon_specific_postrm(f"tezos-baker-{proto}"),
-                                     additional_native_deps=["tezos-sapling-params", "acl"]))
+                                     additional_native_deps=["tezos-sapling-params", "tezos-client", "acl"]))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script=accuser_startup_script.split('/')[-1],
@@ -282,7 +282,7 @@ for proto in active_protocols:
                                         daemon_postinst_common + gen_daemon_specific_postinst(f"tezos-endorser-{proto}") \
                                             + ledger_udev_postinst,
                                      postrm_steps=gen_daemon_specific_postrm(f"tezos-endorser-{proto}"),
-                                     additional_native_deps=["acl"]))
+                                     additional_native_deps=["tezos-client", "acl"]))
 
 packages.append(TezosSaplingParamsPackage())
 packages.append(TezosBakingServicesPackage(

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -69,7 +69,7 @@ packages = [
     OpamBasedPackage("tezos-client",
                      "CLI client for interacting with tezos blockchain",
                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                     requires_sapling_params=True,
+                     additional_native_deps=["tezos-sapling-params"],
                      postinst_steps=ledger_udev_postinst),
     OpamBasedPackage("tezos-admin-client",
                      "Administration tool for the node",
@@ -143,9 +143,9 @@ packages.append(OpamBasedPackage("tezos-node",
                                      "tezos-embedded-protocol-005-PsBABY5H",
                                      "tezos-embedded-protocol-005-PsBabyM1",
                                      "tezos-embedded-protocol-006-PsCARTHA"],
-                                 requires_sapling_params=True,
                                  postinst_steps=node_postinst_steps,
-                                 postrm_steps=node_postrm_steps))
+                                 postrm_steps=node_postrm_steps,
+                                 additional_native_deps=["tezos-sapling-params"]))
 
 active_protocols = json.load(open(f"{os.path.dirname( __file__)}/../../protocols.json", "r"))["active"]
 
@@ -247,11 +247,11 @@ for proto in active_protocols:
                                                   instances=daemons_instances)],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                                     requires_sapling_params=True,
                                      postinst_steps= \
                                         daemon_postinst_common + gen_daemon_specific_postinst(f"tezos-baker-{proto}") \
                                             + ledger_udev_postinst,
-                                     postrm_steps=gen_daemon_specific_postrm(f"tezos-baker-{proto}")))
+                                     postrm_steps=gen_daemon_specific_postrm(f"tezos-baker-{proto}"),
+                                     additional_native_deps=["tezos-sapling-params", "acl"]))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script=accuser_startup_script.split('/')[-1],
@@ -281,7 +281,8 @@ for proto in active_protocols:
                                      postinst_steps= \
                                         daemon_postinst_common + gen_daemon_specific_postinst(f"tezos-endorser-{proto}") \
                                             + ledger_udev_postinst,
-                                     postrm_steps=gen_daemon_specific_postrm(f"tezos-endorser-{proto}")))
+                                     postrm_steps=gen_daemon_specific_postrm(f"tezos-endorser-{proto}"),
+                                     additional_native_deps=["acl"]))
 
 packages.append(TezosSaplingParamsPackage())
 packages.append(TezosBakingServicesPackage(

--- a/docker/package/scripts/tezos-baker-start
+++ b/docker/package/scripts/tezos-baker-start
@@ -8,6 +8,7 @@ set -euo pipefail
 
 # $PROTOCOL should be defined in the system unit environment
 baker="/usr/bin/tezos-baker-$PROTOCOL"
+tezos_client="/usr/bin/tezos-client"
 
 baker_dir="$DATA_DIR"
 
@@ -25,9 +26,18 @@ else
 fi
 
 launch_baker() {
-    exec "$baker" \
-         --base-dir "$baker_dir" --endpoint "$NODE_RPC_ENDPOINT" \
-         run with local node "$NODE_DATA_DIR" "$@"
+    if [[ -n ${1-} ]]; then
+        key_type="$("$tezos_client" show address "$BAKER_ADDRESS_ALIAS" -S | grep "Secret Key:" | cut -d':' -f2-2 | xargs)"
+    fi
+    if [[ ${key_type:-} == "encrypted" ]]; then
+        password="$(systemd-ask-password --keyname="tezos-$BAKER_ADDRESS_ALIAS" --accept-cached \
+            "Enter password for $BAKER_ADDRESS_ALIAS key:")"
+        "$baker" --base-dir "$baker_dir" --endpoint "$NODE_RPC_ENDPOINT" \
+            run with local node "$NODE_DATA_DIR" "$@" <<< "$password" &
+    else
+        "$baker" --base-dir "$baker_dir" --endpoint "$NODE_RPC_ENDPOINT" \
+            run with local node "$NODE_DATA_DIR" "$@" &
+    fi
 }
 
 if [[ -z "$BAKER_ADDRESS_ALIAS" ]]; then

--- a/docker/package/scripts/tezos-baking-start
+++ b/docker/package/scripts/tezos-baking-start
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+set -euo pipefail
+
+tezos_client="/usr/bin/tezos-client"
+
+key_type="$("$tezos_client" show address "$BAKER_ADDRESS_ALIAS" -S | grep "Secret Key:" | cut -d':' -f2-2 | xargs)"
+
+if [[ $key_type == "encrypted" ]]; then
+    systemd-ask-password --keyname="tezos-$BAKER_ADDRESS_ALIAS" --no-output \
+        "Enter password for $BAKER_ADDRESS_ALIAS key:"
+fi

--- a/docker/package/scripts/tezos-endorser-start
+++ b/docker/package/scripts/tezos-endorser-start
@@ -8,6 +8,7 @@ set -euo pipefail
 
 # $PROTOCOL should be defined in the system unit environment
 endorser="/usr/bin/tezos-endorser-$PROTOCOL"
+tezos_client="/usr/bin/tezos-client"
 
 endorser_dir="$DATA_DIR"
 
@@ -25,9 +26,19 @@ else
 fi
 
 launch_endorser() {
-    exec "$endorser" --base-dir "$endorser_dir" \
-         --endpoint "$NODE_RPC_ENDPOINT" \
-         run "$@"
+    if [[ -n ${1-} ]]; then
+        key_type="$("$tezos_client" show address "$BAKER_ADDRESS_ALIAS" -S | grep "Secret Key:" | cut -d':' -f2-2 | xargs)"
+    fi
+    if [[ ${key_type:-} == "encrypted" ]]; then
+        password="$(systemd-ask-password --keyname="tezos-$BAKER_ADDRESS_ALIAS" --accept-cached \
+            "Enter password for $BAKER_ADDRESS_ALIAS key:")"
+        "$endorser" --base-dir "$endorser_dir" --endpoint "$NODE_RPC_ENDPOINT" \
+             run "$@" <<< "$password" &
+    else
+        "$endorser" --base-dir "$endorser_dir" \
+             --endpoint "$NODE_RPC_ENDPOINT" \
+             run "$@" &
+    fi
 }
 
 if [[ -z "$BAKER_ADDRESS_ALIAS" ]]; then


### PR DESCRIPTION
## Description
Problem: Existing systemd services doesn't work with password-protected
keys.

Solution: Support them using systemd-ask-password.

To test locally:
```
sudo add-apt-repository ppa:rvem/tezos-experiments-1
sudo apt-get update
sudo apt-get install tezos-baking

sudo -u tezos tezos-client gen keys baker --encrypted
# new-style baking service
sudo systemctl start tezos-baking-florencenet
systemctl status tezos-baker-009-psfloren@florencenet
systemctl status tezos-endorser-009-psfloren@florencenet
# old-style services
sudo systemctl start tezos-node-florencenet
sudo systemctl start tezos-baker-009-psfloren
sudo systemctl start tezos-endorser-009-psfloren
systemctl status tezos-baker-009-psfloren
systemctl status tezos-endorser-009-psfloren
```
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #176 (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
