### PR TITLE
Update brew bottles hashes

### DIFF
--- a/Formula/tezos-accuser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-accuser-008-PtEdo2Zk.rb
@@ -27,6 +27,8 @@ class TezosAccuser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "698024b3eda8944248af407e8519e05ae015208bc46964cd3cc823d392f9869f"
+    sha256 cellar: :any, catalina: "503a482b7c4d1c9fb83e610718e01d182705d9f0a8405bd68a5feaef648bb62f"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "b9906f66690c90af6dd716e8981cfed7c1da72904c44f2720bb4d28ec23f2de8"
+    sha256 cellar: :any, catalina: "6c506d633967c3c5ad39deb483871e03f5218fad4508aab821546a5395f9a5b8"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "373c146b8989d8937154da0cca4c3cab51088ac5c3becf7a045e062a9aaaa370"
+    sha256 cellar: :any, catalina: "28a92df0b2b152eb60b488dd3cc912dd96215eaa696eceb7b269041d63c93c1a"
   end
 
   def make_deps

--- a/Formula/tezos-baker-008-PtEdo2Zk.rb
+++ b/Formula/tezos-baker-008-PtEdo2Zk.rb
@@ -27,6 +27,8 @@ class TezosBaker008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "659c0b0a8fc58fcb8d652923d42efd092617a345f5df0eed7886c4128c996a7d"
+    sha256 cellar: :any, catalina: "6cccd75d7d53af524d8f856eb9707f1a9cc8c262d0cd8e51ff2133912d712c04"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "8f317703aff2a8612c40dc1c224598486d964dbf57003b70c1c535dfc195325c"
+    sha256 cellar: :any, catalina: "8825c66454aa26641e101dde3a505195182afd87b0d72831ed10dd5c7124ad5e"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "efcfb8e3215d35734fc6a58b19d2cf072487db6376d45c4eba3e07a1bed37039"
+    sha256 cellar: :any, catalina: "a70f34680c071b48e6d308cb69324b4a88bfddc131324f405a8f508b5765af4b"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "7fcb15085a501af648391e1c798be78da54c66e5a2296ded80ff607fedca9987"
+    sha256 cellar: :any, catalina: "4fb1cba11bc2adc04661dbc730ec1da4d774d4b5ff46473a77ca13cd0b752074"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-008-PtEdo2Zk.rb
+++ b/Formula/tezos-endorser-008-PtEdo2Zk.rb
@@ -28,6 +28,8 @@ class TezosEndorser008Ptedo2zk < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser008Ptedo2zk.version}/"
+    sha256 cellar: :any, mojave: "897ae817057dc3f7e66d80b6378ddc7b8becb99877e4064cf48ba7649d0d2ac2"
+    sha256 cellar: :any, catalina: "2b42134dd6ec6a1dcfad27d9584cb3b82a8788c4a1171d88f630d80707cef04e"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "7ff3835a461aa9e59f5ca6f8b95cc5d62381d9186c38d7ddacc8c1c56d355899"
+    sha256 cellar: :any, catalina: "05c1116010981dea5627e2418b03f1744d35ed896ce224b01aa23722b3a6662a"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "87086776cd387cddef59c641a3cfb8083536c66d8e4c1bae663cd42372a038d4"
+    sha256 cellar: :any, catalina: "57cd589c9fce9583146926941c503c439d0303186f65f84ef9b8d09e16b24244"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "1fbfa0a0157a18ba70ee04929d09ca99011afa47e0c518078fdc94cdc232f3bb"
+    sha256 cellar: :any, catalina: "ddd3c83f729bce04cc151a7b8a1335cbf34189bb653ec535d70dc8d716ddb60b"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "00d7071d2fdc7054d33820c80321f06dc5700bebc4943582da9299d201f30c1a"
+    sha256 cellar: :any, catalina: "f96b524272ff42621323e6fe02e29cb1b53bf8bdfe4e62998936951b2c0df17d"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: Brew formulas have been updated to v9.1 and new bottles
are available, but their hashes are not in the formulas yet.

Solution: Update brew bottle hashes for updated formulas.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
