### PR TITLE
[#193] Don't use WantedBy in parts of baking services

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: WantedBy rule requires services to be enabled in order to take
effect. Enabling also makes services start on system start-up, which is
quite unpleasant.

Solution: Don't use WantedBy and don't enable services in the
post-installation stage. Use Requires rule in the baking services to list
dependencies instead.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
