### PR TITLE
[#195] Dynamically generate pipeline via nix

### DIFF
--- a/.buildkite/filter-pipeline.nix
+++ b/.buildkite/filter-pipeline.nix
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+{ git_diff }:
+let
+  pkgs = (import ../. {}).pkgs;
+  pipeline = import ./pipeline.nix;
+  inherit (pkgs) lib;
+  inherit (lib) any crossLists filter splitString;
+
+  splitted_diff = (splitString "\n" git_diff);
+
+  filter_steps = { steps, diff }: filter (step:
+      if ! step ? only_changes
+      then true
+      else
+        let
+          only_changes = step.only_changes;
+          bool_list = crossLists
+            (diff_element: regex: builtins.match regex diff_element != null)
+            [ diff only_changes ];
+        in any (x: x) bool_list
+    ) steps;
+
+  remove_only_changes_attr =
+    step: if builtins.isString step then step else builtins.removeAttrs step ["only_changes"];
+
+  filter_pipeline = { pipeline, diff }:
+    pipeline // { steps = map remove_only_changes_attr (filter_steps { inherit (pipeline) steps; inherit diff; }); };
+
+in pkgs.writeText "pipeline.yml"
+  (builtins.toJSON (filter_pipeline
+    { pipeline = pipeline; diff = splitted_diff; }
+  ))

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -66,7 +66,7 @@ in
         "eval \"$SET_VERSION\""
         "cd docker"
         "./docker-static-build.sh"
-        "nix run -f.. pkgs.upx -c upx tezos-*"
+        "upx tezos-*"
         "for f in ./tezos-*; do mv mv \"\$f\" \"\$f-arm64\"; done"
       ];
       artifact_paths = [

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+let
+  native_packaging_changes_regexes = [
+    "docker\/package/\.*"
+    "docker\/docker-tezos-packages\.sh"
+    "meta\.json"
+    "protocols\.json"
+    "nix\/nix\/sources\.json"
+  ];
+  static_binaries_changes_regexes = [
+    "docker\/build/\.*"
+    "docker\/docker-static-build\.sh"
+    "nix\/nix\/sources\.json"
+    "meta\.json"
+    "protocols\.json"
+  ];
+  nix_changes_regexes = [
+    ".*\.nix"
+    "protocols\.json"
+  ];
+  brew_changes_regexes = [
+    "Formula\/.*\.rb"
+  ];
+in
+{
+  env = {
+    SET_VERSION = "export TEZOS_VERSION=\"$(cat nix/nix/sources.json | jq -r '.tezos.ref' | cut -d'/' -f3)\"";
+  };
+  steps = [
+    { label = "reuse lint";
+      command= "nix run -f . pkgs.reuse -c reuse lint";
+    }
+    { label = "check trailing whitespace";
+      command= ".buildkite/check-trailing-whitespace.sh";
+    }
+    { label = "crossref-verify";
+      command = "nix run -f https://github.com/serokell/crossref-verifier/archive/68a1f9d25b6e7835fea8299b18a3e6c61dbb2a5c.tar.gz -c crossref-verify";
+      soft_fail = true;
+    }
+    { label = "build via nix";
+      command = "nix-build ./nix -A binaries -o binaries";
+      branches = "!master";
+      only_changes = nix_changes_regexes;
+    }
+    { label = "test nix-built binaries";
+      command = "nix-build tests/tezos-nix-binaries.nix --no-out-link";
+      only_changes = nix_changes_regexes;
+    }
+    { label = "build via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        "cd docker"
+        "./docker-static-build.sh"
+        "nix run -f.. pkgs.upx -c upx tezos-*"
+      ];
+      artifact_paths = [
+        "./docker/tezos-*"
+      ];
+      agents = { queue = "docker"; };
+      only_changes = static_binaries_changes_regexes;
+    }
+    { label = "build arm via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        "cd docker"
+        "./docker-static-build.sh"
+        "nix run -f.. pkgs.upx -c upx tezos-*"
+        "for f in ./tezos-*; do mv mv \"\$f\" \"\$f-arm64\"; done"
+      ];
+      artifact_paths = [
+        "./docker/tezos-*"
+      ];
+      agents = { queue = "arm64-build"; };
+      only_changes = static_binaries_changes_regexes;
+    }
+    { label = "check brew formulas";
+      commands = [
+        # Check all formulas except 'tezos.rb' because it's a base class for all other formulas
+        "find ./Formula -type f -name \"*.rb\" -exec ruby -c {} +"
+        # All formulas share the same source URL inherited by the Tezos class, so it's fine
+        # to fetch sources for only one formula
+        "brew fetch -s ./Formula/tezos-client.rb"
+      ];
+      agents = { queue = "x86_64-darwin"; };
+      only_changes = brew_changes_regexes;
+    }
+    "wait"
+    { label = "test docker-built binaries";
+      commands = [
+        "buildkite-agent artifact download \"docker/*\" . --step \"build via docker\""
+        "chmod +x ./docker/*"
+        "nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker"
+      ];
+      branches = "!master";
+      only_changes = static_binaries_changes_regexes;
+    }
+    { label = "test deb source packages via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        "./docker/docker-tezos-packages.sh --os ubuntu --type source"
+      ];
+      artifact_paths = [
+        "./out/*"
+      ];
+      branches = "!master";
+      timeout_in_minutes = 60;
+      agents = { queue = "docker"; };
+      only_changes = native_packaging_changes_regexes;
+    }
+    { label = "test deb binary packages via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        # Building all binary packages will take significant amount of time, so we build only one
+        # in order to ensure package generation sanity
+        "./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-008-PtEdo2Zk"
+        "rm -rf out"
+      ];
+      artifact_paths = [
+        "./out/*"
+      ];
+      # It takes much time to build binary package, so we do it only on master
+      branches = "master";
+      timeout_in_minutes = 90;
+      agents = { queue = "docker"; };
+      only_changes = native_packaging_changes_regexes;
+    }
+    { label = "test rpm source packages via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        "./docker/docker-tezos-packages.sh --os fedora --type source"
+      ];
+      artifact_paths = [
+        "./out/*"
+      ];
+      branches = "!master";
+      timeout_in_minutes = 60;
+      agents = { queue = "docker"; };
+      only_changes = native_packaging_changes_regexes;
+    }
+    { label = "test r binary packages via docker";
+      commands = [
+        "eval \"$SET_VERSION\""
+        # Building all binary packages will take significant amount of time, so we build only one
+        # in order to ensure package generation sanity
+        "./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-008-PtEdo2Zk"
+        "rm -rf out"
+      ];
+      artifact_paths = [
+        "./out/*"
+      ];
+      # It takes much time to build binary package, so we do it only on master
+      branches = "master";
+      timeout_in_minutes = 90;
+      agents = { queue = "docker"; };
+      only_changes = native_packaging_changes_regexes;
+    }
+    "wait"
+    { label = "create auto pre-release";
+      commands = [
+        "mkdir binaries"
+        "mkdir arm-binaries"
+        "buildkite-agent artifact download \"docker/*\" binaries --step \"build via docker\""
+        "buildkite-agent artifact download \"docker/*\" arm-binaries --step \"build arm via docker\""
+        "./scripts/autorelease.sh"
+      ];
+      branches = "master";
+      only_changes = static_binaries_changes_regexes ++ brew_changes_regexes;
+    }
+  ];
+}

--- a/.buildkite/pipeline.nix
+++ b/.buildkite/pipeline.nix
@@ -67,7 +67,7 @@ in
         "cd docker"
         "./docker-static-build.sh"
         "upx tezos-*"
-        "for f in ./tezos-*; do mv mv \"\$f\" \"\$f-arm64\"; done"
+        "for f in ./tezos-*; do mv \"\$f\" \"\$f-arm64\"; done"
       ];
       artifact_paths = [
         "./docker/tezos-*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,50 +69,50 @@ steps:
    - nix-build tests/tezos-binaries.nix --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
 
- - label: test deb source packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
-   artifact_paths:
-     - ./out/*
-   branches: "!master"
-   timeout_in_minutes: 60
-   agents:
-     queue: "docker"
- - label: test deb binary packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   # Building all binary packages will take significant amount of time, so we build only one
-   # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-008-PtEdo2Zk
-   - rm -rf out
-   # It takes much time to build binary package, so we do it only on master
-   branches: "master"
-   timeout_in_minutes: 90
-   agents:
-     queue: "docker"
- - label: test rpm source packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   - ./docker/docker-tezos-packages.sh --os fedora --type source
-   artifact_paths:
-     - ./out/*
-   branches: "!master"
-   timeout_in_minutes: 60
-   agents:
-     queue: "docker"
- - label: test rpm binary packages via docker
-   commands:
-   - eval "$SET_VERSION"
-   # Building all binary packages will take significant amount of time, so we build only one
-   # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-008-PtEdo2Zk
-   - rm -rf out
-   # It takes much time to build binary package, so we do it only on master
-   branches: "master"
-   timeout_in_minutes: 90
-   agents:
-     queue: "docker"
+#  - label: test deb source packages via docker
+#    commands:
+#    - eval "$SET_VERSION"
+#    - ./docker/docker-tezos-packages.sh --os ubuntu --type source
+#    artifact_paths:
+#      - ./out/*
+#    branches: "!master"
+#    timeout_in_minutes: 60
+#    agents:
+#      queue: "docker"
+#  - label: test deb binary packages via docker
+#    commands:
+#    - eval "$SET_VERSION"
+#    # Building all binary packages will take significant amount of time, so we build only one
+#    # in order to ensure package generation sanity
+#    - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-008-PtEdo2Zk
+#    - rm -rf out
+#    # It takes much time to build binary package, so we do it only on master
+#    branches: "master"
+#    timeout_in_minutes: 90
+#    agents:
+#      queue: "docker"
+#  - label: test rpm source packages via docker
+#    commands:
+#    - eval "$SET_VERSION"
+#    - ./docker/docker-tezos-packages.sh --os fedora --type source
+#    artifact_paths:
+#      - ./out/*
+#    branches: "!master"
+#    timeout_in_minutes: 60
+#    agents:
+#      queue: "docker"
+#  - label: test rpm binary packages via docker
+#    commands:
+#    - eval "$SET_VERSION"
+#    # Building all binary packages will take significant amount of time, so we build only one
+#    # in order to ensure package generation sanity
+#    - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-008-PtEdo2Zk
+#    - rm -rf out
+#    # It takes much time to build binary package, so we do it only on master
+#    branches: "master"
+#    timeout_in_minutes: 90
+#    agents:
+#      queue: "docker"
 
  - wait
  - label: create auto pre-release

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -53,3 +53,4 @@ class TezosClient < Formula
                      "tezos-client"
   end
 end
+

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -12,3 +12,4 @@ COPY ./build/static_libs.patch /static.patch
 ARG TEZOS_VERSION
 COPY ./build/build-tezos.sh /build-tezos.sh
 RUN /build-tezos.sh ${TEZOS_VERSION}
+

--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -22,3 +22,4 @@ COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
 ENTRYPOINT ["python3", "-m", "package.package_generator"]
+


### PR DESCRIPTION
## Description
Problem: Some of the ci steps take a huge amount of time. We run them on
any changes even when the changes don't affect any of them.

Solution: Make it possible to provide regexes, which will define paths,
whose changes will trigger step to run. In order to do that pipeline was
defined as a nix attrset. This attrset later supposed to be filtered
basing on the output of 'git diff origin/master...HEAD --name-only'.
The files from diff list are matched against the regexes from the
pipeline config. If the step doesn't match any of them, then it isn't
included in the resulting generated pipeline config.

To generate pipeline config locally run:
```
nix-build .buildkite/filter-pipeline.nix --argstr git_diff "$(git diff origin/master...HEAD --name-only)"
```

~Note, that this PR is currently draft and changes from it don't affect the existing CI configuration,
because it requires some changes in the [pipeline configuration on buildkite website](https://buildkite.com/serokell/tezos-packaging/steps), these changes will break CI in all other branches.~

Existing `.buildkite/pipeline.yml` should be removed before merging as well as the old `buildkite-agent pipeline upload` step
from the pipeline configuration on the website.

<!--

Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #195

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
