### PR TITLE
[#198] Fix ledger udev rules addition from the post-installation stage

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -69,7 +69,7 @@ packages = [
     OpamBasedPackage("tezos-client",
                      "CLI client for interacting with tezos blockchain",
                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
-                     additional_native_deps=["tezos-sapling-params"],
+                     additional_native_deps=["tezos-sapling-params", "udev"],
                      postinst_steps=ledger_udev_postinst),
     OpamBasedPackage("tezos-admin-client",
                      "Administration tool for the node",
@@ -77,6 +77,7 @@ packages = [
     OpamBasedPackage("tezos-signer",
                      "A client to remotely sign operations or blocks",
                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                     additional_native_deps=["udev"],
                      systemd_units=signer_units,
                      postinst_steps=ledger_udev_postinst),
     OpamBasedPackage("tezos-codec",
@@ -234,7 +235,7 @@ for proto in active_protocols:
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
                                      postinst_steps= daemon_postinst_common + ledger_udev_postinst,
-                                     additional_native_deps=["tezos-sapling-params", "tezos-client", "acl"]))
+                                     additional_native_deps=["tezos-sapling-params", "tezos-client", "acl", "udev"]))
     packages.append(OpamBasedPackage(f"tezos-accuser-{proto}", "Daemon for accusing",
                                      [SystemdUnit(service_file=service_file_accuser,
                                                   startup_script=accuser_startup_script.split('/')[-1],
@@ -246,6 +247,7 @@ for proto in active_protocols:
                                                   instances=daemons_instances)],
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
+                                     additional_native_deps=["udev"],
                                      postinst_steps= daemon_postinst_common + ledger_udev_postinst))
     packages.append(OpamBasedPackage(f"tezos-endorser-{proto}", "Daemon for endorsing",
                                      [SystemdUnit(service_file=service_file_endorser,
@@ -259,7 +261,7 @@ for proto in active_protocols:
                                      proto,
                                      optional_opam_deps=["tls", "ledgerwallet-tezos"],
                                      postinst_steps= daemon_postinst_common + ledger_udev_postinst,
-                                     additional_native_deps=["tezos-client", "acl"]))
+                                     additional_native_deps=["tezos-client", "acl", "udev"]))
 
 packages.append(TezosSaplingParamsPackage())
 packages.append(TezosBakingServicesPackage(

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -7,7 +7,7 @@ from .model import Service, ServiceFile, SystemdUnit, Unit, Install, OpamBasedPa
 
 networks = ["mainnet", "edo2net", "florencenet"]
 networks_protos = {
-    "mainnet": ["008-PtEdo2Zk", "009-PsFLoren"],
+    "mainnet": ["009-PsFLoren"],
     "edo2net": ["008-PtEdo2Zk"],
     "florencenet": ["009-PsFLoren"]
 }

--- a/docker/package/scripts/udev-rules
+++ b/docker/package/scripts/udev-rules
@@ -5,7 +5,12 @@
 # This snippet is based on https://github.com/LedgerHQ/udev-rules/blob/master/add_udev_rules.sh with the changes
 # that are fixing https://github.com/LedgerHQ/udev-rules/issues/5, so that provided rules work on the Raspberry Pi OS
 # Ubuntu 18.04
-cat <<EOF > /etc/udev/rules.d/20-hw1.rules
+
+# Don't add udev rules in case the package is installed inside either docker or podman container.
+# Otherwise, post-installation script will fail due to inability to non-zero exit code of the
+# 'udevadm control --reload-rules' call
+if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ]; then
+    cat <<EOF > /etc/udev/rules.d/20-hw1.rules
 # HW.1 / Nano
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
 # Blue
@@ -20,5 +25,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0003|3000|3001|30
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004|4000|4001|4002|4003|4004|4005|4006|4007|4008|4009|400a|400b|400c|400d|400e|400f|4010|4011|4012|4013|4014|4015|4016|4017|4018|4019|401a|401b|401c|401d|401e|401f", TAG+="uaccess", TAG+="udev-acl". MODE="0660", GROUP="plugdev"
 EOF
 
-udevadm trigger
-udevadm control --reload-rules
+    udevadm trigger
+    udevadm control --reload-rules
+fi

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "2",
+    "release": "3",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
There are a bunch of problem with the existing script:
1) `udev` may be absent and thus `/etc/udev/rules.d` as well as `udevadm` won't be present
2) `udevadm` doesn't fully work inside the containers

This PR provides two fixes:
1) Packages that use udev post-installation script now depend on the `udev` package.
2) Script checks whether we're inside the container and don't add udev rules in case we're inside it.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #198 (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
