### PR TITLE
[#195] Hotfix binary packages steps

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -115,7 +115,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-008-PtEdo2Zk
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-009-PsFLoren
    - rm -rf out
    # It takes much time to build binary package, so we do it only on master
    branches: "master"
@@ -139,7 +139,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-008-PtEdo2Zk
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-009-PsFLoren
    - rm -rf out
    # It takes much time to build binary package, so we do it only on master
    branches: "master"


### PR DESCRIPTION
## Description
Problem: 008 protocol was disabled in #200. However, CI still tries to
build native packages for 008 daemon binaries. The update from #200 was
lost in #197:(

Solution: Build 009 daemons binary packages.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #195

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
