### PR TITLE
[#202] Don't install udev rules inside WSL

### DIFF
--- a/docker/package/scripts/udev-rules
+++ b/docker/package/scripts/udev-rules
@@ -6,10 +6,11 @@
 # that are fixing https://github.com/LedgerHQ/udev-rules/issues/5, so that provided rules work on the Raspberry Pi OS
 # Ubuntu 18.04
 
-# Don't add udev rules in case the package is installed inside either docker or podman container.
+# Don't add udev rules in case the package is installed inside either docker or podman container
+# or WSL (since it doesn't fully support udev and libusb at the moment).
 # Otherwise, post-installation script will fail due to inability to non-zero exit code of the
 # 'udevadm control --reload-rules' call
-if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ]; then
+if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ] && ! grep -qEi "(Microsoft|WSL)" /proc/sys/kernel/osrelease ; then
     cat <<EOF > /etc/udev/rules.d/20-hw1.rules
 # HW.1 / Nano
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"


### PR DESCRIPTION
## Description
Problem: udev and libusb aren't fully supported in the WSL, thus an
attempt to update udev rules for a usb device fails, which leads to
inablitity of installation of our native packages.

Solution: Check if we're inside the WSL (by checking the contents of
/proc/sys/kernel/osrelease) and don't install udev rules if we're inside
it.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #202  (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
