### PR TITLE
[#195] Provide key attributes for dependency steps

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -32,6 +32,8 @@ steps:
    # nix builds are usually cached, so we don't care about only_changes setting for it
 
  - label: build-via-docker
+   # this step is used as a dependency, so we're defining 'key' explicitely
+   key: build-via-docker
    commands:
    - eval "$SET_VERSION"
    - cd docker
@@ -49,6 +51,8 @@ steps:
    - nix/nix/sources.json
  # arm builer is an ubuntu machine without nix
  - label: build-arm-via-docker
+   # this step is used as a dependency, so we're defining 'key' explicitely
+   key: build-arm-via-docker
    commands:
    - eval "$SET_VERSION"
    - cd docker

--- a/tests/buildkite/golden/pipeline-A.yml
+++ b/tests/buildkite/golden/pipeline-A.yml
@@ -1,27 +1,36 @@
 steps:
-- label: A
+- key: A
+  label: A
 - depends_on:
   - A
+  key: B
   label: B
 - depends_on:
   - A
+  key: C
   label: C
 - depends_on:
   - B
+  key: D
   label: D
 - depends_on:
   - C
+  key: E
   label: E
 - depends_on:
   - D
+  key: F
   label: F
 - depends_on:
   - E
   - D
+  key: G
   label: G
 - depends_on:
   - E
+  key: H
   label: H
 - depends_on:
   - A
+  key: X
   label: X

--- a/tests/buildkite/golden/pipeline-C.yml
+++ b/tests/buildkite/golden/pipeline-C.yml
@@ -1,28 +1,37 @@
 steps:
-- label: A
+- key: A
+  label: A
 - depends_on:
   - A
+  key: B
   label: B
 - depends_on:
   - A
+  key: C
   label: C
 - depends_on:
   - B
+  key: D
   label: D
 - depends_on:
   - C
+  key: E
   label: E
 - depends_on:
   - D
+  key: F
   label: F
   skip: skipped due to lack of changes
 - depends_on:
   - E
   - D
+  key: G
   label: G
 - depends_on:
   - E
+  key: H
   label: H
 - depends_on:
   - A
+  key: X
   label: X

--- a/tests/buildkite/golden/pipeline-G.yml
+++ b/tests/buildkite/golden/pipeline-G.yml
@@ -1,29 +1,38 @@
 steps:
-- label: A
+- key: A
+  label: A
 - depends_on:
   - A
+  key: B
   label: B
 - depends_on:
   - A
+  key: C
   label: C
 - depends_on:
   - B
+  key: D
   label: D
 - depends_on:
   - C
+  key: E
   label: E
 - depends_on:
   - D
+  key: F
   label: F
   skip: skipped due to lack of changes
 - depends_on:
   - E
   - D
+  key: G
   label: G
 - depends_on:
   - E
+  key: H
   label: H
   skip: skipped due to lack of changes
 - depends_on:
   - A
+  key: X
   label: X

--- a/tests/buildkite/golden/pipeline-X.yml
+++ b/tests/buildkite/golden/pipeline-X.yml
@@ -1,34 +1,43 @@
 steps:
-- label: A
+- key: A
+  label: A
 - depends_on:
   - A
+  key: B
   label: B
   skip: skipped due to lack of changes
 - depends_on:
   - A
+  key: C
   label: C
   skip: skipped due to lack of changes
 - depends_on:
   - B
+  key: D
   label: D
   skip: skipped due to lack of changes
 - depends_on:
   - C
+  key: E
   label: E
   skip: skipped due to lack of changes
 - depends_on:
   - D
+  key: F
   label: F
   skip: skipped due to lack of changes
 - depends_on:
   - E
   - D
+  key: G
   label: G
   skip: skipped due to lack of changes
 - depends_on:
   - E
+  key: H
   label: H
   skip: skipped due to lack of changes
 - depends_on:
   - A
+  key: X
   label: X

--- a/tests/buildkite/pipeline-raw.yml
+++ b/tests/buildkite/pipeline-raw.yml
@@ -4,44 +4,53 @@
 
 steps:
   - label: A
+    key: A
     only_changes:
     - A
   - label: B
+    key: B
     depends_on:
     - A
     only_changes:
     - B
   - label: C
+    key: C
     depends_on:
     - A
     only_changes:
     - C
   - label: D
+    key: D
     depends_on:
     - B
     only_changes:
     - B
   - label: E
+    key: E
     depends_on:
     - C
     only_changes:
     - E
   - label: F
+    key: F
     depends_on:
     - D
     only_changes:
     - F
   - label: G
+    key: G
     depends_on:
     - E
     - D
     only_changes:
     - G
   - label: H
+    key: H
     depends_on:
     - E
     only_changes:
     - H
   - label: X
+    key: X
     depends_on:
     - A


### PR DESCRIPTION
## Description
Problem: Turned out buildkite uses 'key' attribute in order to determine
steps dependencies instead of using 'label'.

Solution: Explicitly add keys to steps that used as a dependency.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #195

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
