### PR TITLE
[#210] Add tezos user to plugdev group

### DIFF
--- a/docker/package/scripts/udev-rules
+++ b/docker/package/scripts/udev-rules
@@ -28,4 +28,5 @@ EOF
 
     udevadm trigger
     udevadm control --reload-rules
+    usermod -a -G plugdev tezos || true
 fi


### PR DESCRIPTION
## Description
Problem: Ledger interaction with the udev rules provided by the packages
work only for users from the plugdev group. 'tezos' user doesn't belong
to it by default.

Solution: Add it to the required group after udev rules addition in the
post-installtion script.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #210 (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
