### PR TITLE
[#212] Ubuntu 21.04 support

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -215,7 +215,7 @@ class OpamBasedPackage(AbstractPackage):
         subprocess.run(["tar", "-zxf", f"{opam_package}-bundle.tar.gz"], check=True)
         os.rename(f"{opam_package}-bundle", out_dir)
 
-    def gen_control_file(self, deps, out):
+    def gen_control_file(self, deps, ubuntu_version, out):
         str_build_deps = ", ".join(deps)
         str_additional_native_deps = ", ".join(self.additional_native_deps)
         file_contents = f"""
@@ -223,7 +223,7 @@ Source: {self.name.lower()}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, {str_build_deps}
+Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev, {str_build_deps}
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
@@ -367,13 +367,13 @@ class TezosSaplingParamsPackage(AbstractPackage):
             ]
         )
 
-    def gen_control_file(self, deps, out):
+    def gen_control_file(self, deps, ubuntu_version, out):
         file_contents = f"""
 Source: {self.name}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, wget
+Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev, wget
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
@@ -503,7 +503,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     def fetch_sources(self, out_dir):
         os.makedirs(out_dir)
 
-    def gen_control_file(self, deps, out):
+    def gen_control_file(self, deps, ubuntu_version, out):
         run_deps = ", ".join(
             ["acl", "tezos-client", "tezos-node"]
             + sum(
@@ -522,7 +522,7 @@ Source: {self.name}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev
+Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -60,7 +60,12 @@ build_deps = [
 ]
 common_deps = run_deps + build_deps
 
-ubuntu_versions = ["bionic", "focal", "groovy"]  # 18.04  # 20.04  # 20.10
+ubuntu_versions = [
+    "bionic",  # 18.04
+    "focal",  # 20.04
+    "groovy",  # 20.10
+    "hirsute",  # 21.04
+]
 
 pwd = os.getcwd()
 home = os.environ["HOME"]

--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -76,7 +76,7 @@ def build_ubuntu_package(
         pkg.gen_rules("debian/rules")
         pkg.gen_postinst("debian/postinst")
         pkg.gen_postrm("debian/postrm")
-        pkg.gen_control_file(build_deps, "debian/control")
+        pkg.gen_control_file(build_deps, ubuntu_version, "debian/control")
         pkg.gen_license("debian/copyright")
         subprocess.run(
             "rm debian/*.ex debian/*.EX debian/README*", shell=True, check=True


### PR DESCRIPTION
## Description
Problem: Currently we support 18.04, 20.04 and 20.10. However, 21.04 was
released in the April and community lacks Tezos packages for it.

Solution: Add 21.04 (aka hirsute) to the list of supported ubuntu
versions.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #212 (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
