### PR TITLE
Add v9.2 bottles hashes

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "0d04e9e1878db26a6e0926650b0e9f611e67afdbd009c612caa1f5f834d27cbe"
+    sha256 cellar: :any, catalina: "28450616af65a9d97ecc3725f729d9af24e29c71a5ac2c91e3ea9b6c4e0b91b8"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "ae671f1f843bbd2f6b2a384526f76e8a496bd076217cd85bc2b2726716531118"
+    sha256 cellar: :any, catalina: "fc41f5475855cc3032afc6ee7ba3ef969d2db41394d0bf4ef8a1cc5dc04ff1cd"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "d75aeab27fac3762c6b0728bf3d9fc417694db820a9f2292517fde10e8e1bf17"
+    sha256 cellar: :any, catalina: "aad125c5894cdd75413fe45d66b6812a28f0764d4ce4a427dcbd583ddd7eb183"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "9fc313190e500ce7440d1b69037a4684dc3dd8ddfdbd04395ef02334fafd77bb"
+    sha256 cellar: :any, catalina: "6d24fa54ddcc2e95edc0bc35810e98aacc3fd015cc29d6dd40e3a376f3a0af00"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "6f15111cd07b7e07c13b39460ea938732846f174bb085e8d693f15587bb59bd0"
+    sha256 cellar: :any, catalina: "77bfad0d2def00744911e9b127c98ca4280e7bf0c2e3eb758efe946ed9439bab"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "60c89c31056225d5e9c055ac7c21a08f3294fa787bcd66164546c80aa32f0ae8"
+    sha256 cellar: :any, catalina: "57750599c8ab37365ebd05ca0dd151dd8ecb2033321a1782f4e2620a9f7fbe74"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "312d9d7f9d8e9a2b6476e807973839674cddf888e664c48bddc730e1256417ca"
+    sha256 cellar: :any, catalina: "07e7150f7019b80de668c17f52846c9bb0ae33dbcfb493511b80e6f404ea58fe"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "179779a4da49d046f94d2d214c499d2906b7a267b74f85b01d5edaf53308bba5"
+    sha256 cellar: :any, catalina: "3ea366692a1f64966e538661e65ef9d93b7dde04409a3c8da68947203fc8e889"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "ad331bc281968ec5d60f1790134d39f9b41277b38ee79f9f18c4e2a7bf5a54f6"
+    sha256 cellar: :any, catalina: "c44bcf36243e30f1b660db268d45696cfd7bff76fa53e8a3ca689c439a35cac0"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "8af82462c209a329d509c4407e04b414c87eff652f926d74113de8ad03aa66b0"
+    sha256 cellar: :any, catalina: "99e380d29164ff0f78bcb5e27928f732d427a5715a4400c7adf07cf726478695"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "e0eb3aac39dd5c16def3c71db1318f19677d4d61128ee41c49c56c565018aaa5"
+    sha256 cellar: :any, catalina: "55a7a5f6df2068fa2e9bcae5496ebc740924d3196bc1f3fb31e1223887f61e71"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "2f55c53a6baa0fca4638c021957258522bc5a39d03fdf8db1a27157dff481bea"
+    sha256 cellar: :any, catalina: "17a10543e78da1bde5d43134dcf60ef49d7133831ff28926a9fb84ee40b8079a"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: v9.2-1 was released, brew formulas lack hashes for bottles with
precompiled binaries.

Solution: Add bottles hashes for mojave and catalina macOS versions.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
