### PR TITLE
[#215] Use 10 compatibility level in ubuntu pkgs

### DIFF
--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -71,7 +71,7 @@ def build_ubuntu_package(
                 )
                 shutil.copy(source_path, dest_path)
         with open("debian/compat", "w") as f:
-            f.write("9")
+            f.write("10")
         pkg.gen_install("debian/install")
         pkg.gen_rules("debian/rules")
         pkg.gen_postinst("debian/postinst")

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: Systemd services don't restart during the package upgrade,
thus users may miss service updates in case they didn't restart their
services manually.

Solution: Use 10 compatibility level for Ubuntu packages. In this
level services are restarted after upgrade by default. See
'--restart-after-upgrade' option description in
https://manpages.debian.org/testing/debhelper/dh_installsystemd.1.en.html.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #215 (issue will be resolved once updated packages are published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
