### PR TITLE
[#222] Modify the wizard to query between setup

### DIFF
--- a/docker/package/tezos_baking_wizard.py
+++ b/docker/package/tezos_baking_wizard.py
@@ -15,6 +15,48 @@ import re, textwrap
 import urllib.request
 from typing import List
 
+
+# Global options
+
+networks = {
+    "mainnet": "Main Tezos network",
+    "florencenet": "Test network using version 009 of Tezos protocol (Florence)",
+    "granadanet": "Test network using version 010 of Tezos protocol (Granada)",
+}
+
+modes = {
+    "baking": "Set up and start all services for baking: "
+    "tezos-node, tezos-baker, and tezos-endorser.",
+    "node": "Only bootstrap and run the Tezos node.",
+}
+
+snapshot_import_modes = {
+    "download rolling": "Import rolling snapshot from xtz-shots.io (recommended)",
+    "download full": "Import full snapshot from xtz-shots.io",
+    "file": "Import snapshot from a file",
+    "url": "Import snapshot from a url",
+    "skip": "Skip snapshot import and synchronize with the network from scratch",
+}
+
+key_import_modes = {
+    "ledger": "From a ledger",
+    "secret-key": "Either the unencrypted or password-encrypted secret key for your address",
+    "json": "Faucet JSON file from https://faucet.tzalpha.net/",
+}
+
+systemd_enable = {
+    "yes": "Enable the services, running them both now and on every boot",
+    "no": "Start the services this time only",
+}
+
+
+# Regexes
+
+ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
+secret_key_regex = b"(encrypted|unencrypted):(?:\w{54}|\w{88})"
+address_regex = b"tz1\w{33}"
+
+
 # Input validators
 
 
@@ -51,6 +93,17 @@ def required_field_validator(input):
     return input
 
 
+# The input has to be valid to at least one of the two passed validators.
+def or_validator(validator1, validator2):
+    def _validator(input):
+        try:
+            return validator1(input)
+        except:
+            return validator2(input)
+
+    return _validator
+
+
 # Runs the input through the passed validator, allowing for possible alteration,
 # but doesn't raise an exception if it doesn't validate to allow for custom options, too.
 def or_custom_validator(validator):
@@ -63,6 +116,32 @@ def or_custom_validator(validator):
         return result
 
     return _validator
+
+
+# To be validated, the input should adhere to the Tezos secret key format:
+# {encrypted, unencrypted}:<base58 encoded string with length 54 or 88>
+def secret_key_validator(input):
+    match = re.match(secret_key_regex.decode("utf-8"), input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the Tezos secret key: "
+            "{{encrypted, unencrypted}:<base58 encoded string with length 54 or 88>}"
+            "\nPlease check the input and try again."
+        )
+    return input
+
+
+# To be validated, the input should adhere to the ledger URL format:
+# ledger://<four mnemonic words separated by dashes>/<curve>/[a-z0-9']+/[a-z0-9']+
+def ledger_url_validator(input):
+    match = re.match(ledger_regex.decode("utf-8"), input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the ledger URL: "
+            "ledger://<four mnemonic words separated by dashes>/<curve>/[a-z0-9']+/[a-z0-9']+"
+            "\nPlease check the input and try again."
+        )
+    return input
 
 
 class Validator:
@@ -79,12 +158,6 @@ class Validator:
                 return self.validator(input)
 
 
-# Regexes
-
-ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
-secret_key_regex = b"(encrypted|unencrypted):\w+"
-address_regex = b"tz1\w{33}"
-
 # Wizard CLI utility
 
 
@@ -93,7 +166,7 @@ def proc_call(cmd):
 
 
 def fetch_snapshot(url):
-    print("Downloading the snapshot from ", url)
+    print("Downloading the snapshot from", url)
     filename = "/tmp/tezos_node.snapshot"
     urllib.request.urlretrieve(url, filename, progressbar_hook)
     print()
@@ -103,7 +176,7 @@ def fetch_snapshot(url):
 def progressbar_hook(chunk_number, chunk_size, total_size):
     done = chunk_number * chunk_size
     percent = min(int(done * 100 / total_size), 100)
-    print("Progress: ", percent, "%, ", int(done / (1024 * 1024)), "MB", end="\r")
+    print("Progress:", percent, "%,", int(done / (1024 * 1024)), "MB", end="\r")
 
 
 def color(input, colorcode):
@@ -117,8 +190,10 @@ def yes_or_no(prompt, default=None):
         if not answer and default is not None:
             answer = default
         if answer in ["y", "yes"]:
+            print()
             return True
         elif answer in ["n", "no"]:
+            print()
             return False
         else:
             print(color("Please provide a 'yes' or 'no' answer.", "\x1b[1;31m"))
@@ -171,7 +246,6 @@ class Step:
         default: str = "1",
         options=None,
         validator=None,
-        reqs=lambda _vs: True,
     ):
         self.id = id
         self.prompt = prompt
@@ -179,7 +253,6 @@ class Step:
         self.default = default
         self.options = options
         self.validator = validator
-        self.reqs = reqs
 
     def pprint_options(self):
         i = 1
@@ -210,166 +283,126 @@ class Step:
                 i += 1
 
 
-def run_wizard():
-    print("Tezos Baking Wizard")
-    print()
-    print(
-        "Welcome, this wizard will help you to set up the infrastructure to interact with the Tezos blockchain."
+# Steps
+
+network_query = Step(
+    id="network",
+    prompt="Which Tezos network would you like to use?\nCurrently supported:",
+    help="The selected network will be used to set up all required services.\n"
+    "The currently supported protocols are 009-PsFLoren (used on florencenet and mainnet)\n"
+    "and 010-PtGRANAD (granadanet).\nKeep in mind that you must select the test network "
+    "(either florencenet or granadanet) if you plan on baking with a faucet JSON file.",
+    options=networks,
+    validator=Validator(enum_range_validator(networks)),
+)
+
+service_mode_query = Step(
+    id="mode",
+    prompt="Do you want to set up baking or to run the standalone node?",
+    help="By default, tezos-baking provides predefined services for running baking instances "
+    "on different networks.\nSometimes, however, you might want to only run the Tezos node.\n"
+    "When this option is chosen, this wizard will help you bootstrap tezos-node only.",
+    options=modes,
+    validator=Validator(enum_range_validator(modes)),
+)
+
+systemd_mode_query = Step(
+    id="systemd_mode",
+    prompt="Would you like your setup to automatically start on boot?",
+    help="Starting the service will make it available just for this session, great\n"
+    "if you want to experiment. Enabling it will make it start on every boot.",
+    options=systemd_enable,
+    validator=Validator(enum_range_validator(systemd_enable)),
+)
+
+snapshot_mode_query = Step(
+    id="snapshot",
+    prompt="The Tezos node can take a significant time to bootstrap from scratch.\n"
+    "Bootstrapping from a snapshot is suggested instead.\n"
+    "How would you like to proceed?",
+    help="A fully-synced local tezos-node is required for running a baking instance.\n"
+    "By default, service with tezos-node will start to bootstrap from scratch,\n"
+    "which will take a significant amount of time.\nIn order to avoid this, we suggest "
+    "bootstrapping from a snapshot instead.\n\n"
+    "Snapshots can be downloaded from the following websites:\n"
+    "Tezos Giganode Snapshots - https://snapshots-tezos.giganode.io/ \n"
+    "XTZ-Shots - https://xtz-shots.io/ \n\n"
+    "We recommend to use rolling snapshots. This is the smallest and the fastest mode\n"
+    "that is sufficient for baking (you can read more about other tezos-node history modes here:\n"
+    "https://tezos.gitlab.io/user/history_modes.html#history-modes ).\n",
+    options=snapshot_import_modes,
+    validator=Validator(enum_range_validator(snapshot_import_modes)),
+)
+
+snapshot_file_query = Step(
+    id="snapshot_file",
+    prompt="Provide the path to the tezos-node snapshot file.",
+    help="You have indicated wanting to import the snapshot from a file.\n"
+    "You can download the snapshot yourself e.g. from XTZ-Shots or Tezos Giganode Snapshots.",
+    validator=Validator(filepath_validator),
+)
+
+snapshot_url_query = Step(
+    id="snapshot_url",
+    prompt="Provide the url of the tezos-node snapshot file.",
+    help="You have indicated wanting to import the snapshot from a custom url.\n"
+    "You can use e.g. links to XTZ-Shots or Tezos Giganode Snapshots resources.",
+)
+
+# We define the step as a function to disallow choosing json baking on mainnet
+def get_key_mode_query(modes):
+    return Step(
+        id="key_import_mode",
+        prompt="How do you want to import the baker key?",
+        help="To register the baker, its secret key needs to be imported to the data "
+        "directory first.\nBy default tezos-baking-<network>.service will use the 'baker' "
+        "alias\nfor the key that will be used for baking and endorsing.\n"
+        "If you want to test baking with a faucet file, "
+        "make sure you have chosen a test network like " + list(networks.keys())[1],
+        options=modes,
+        validator=Validator(enum_range_validator(modes)),
     )
-    print(
-        "In order to run a baking instance, you'll need the following Tezos binaries:\n",
-        "tezos-client, tezos-node, tezos-baker-<proto>, tezos-endorser-<proto>.\n",
-        "If you have installed tezos-baking, these binaries are already installed.",
-    )
-    print(
-        "To access help and possible options for each question, type in 'help' or '?'."
-    )
-    print("Type in 'exit' to quit.")
-    print()
 
-    networks = {
-        "mainnet": "Main Tezos network",
-        "florencenet": "Test network using version 009 of Tezos protocol (Florence)",
-        "granadanet": "Test network using version 010 of Tezos protocol (Granada)",
-    }
 
-    modes = {
-        "baker": "Set up and start all services for baking: "
-        "tezos-node, tezos-baker, and tezos-endorser.",
-        "node": "Only bootstrap and run the Tezos node.",
-    }
+secret_key_query = Step(
+    id="secret_key",
+    prompt="Provide either the unencrypted or password-encrypted secret key for your address.",
+    help="The format is 'unencrypted:edsk...' for the unencrypted key, or 'encrypted:edesk...'"
+    "for the encrypted key.",
+    validator=Validator([required_field_validator, secret_key_validator]),
+)
 
-    snapshot_import_modes = {
-        "download rolling": "Import rolling snapshot from xtz-shots.io (recommended)",
-        "download full": "Import full snapshot from xtz-shots.io",
-        "file": "Import snapshot from a file",
-        "url": "Import snapshot from a url",
-        "skip": "Skip snapshot import and synchronize with the network from scratch",
-    }
+json_filepath_query = Step(
+    id="json_filepath",
+    prompt="Provide the path to your downloaded faucet JSON file.",
+    help="Download the faucet JSON file from https://faucet.tzalpha.net/.\n"
+    "The file will contain the 'mnemonic' and 'secret' fields.",
+    validator=Validator([required_field_validator, filepath_validator]),
+)
 
-    key_import_modes = {
-        "ledger": "From a ledger",
-        "secret-key": "Either the unencrypted or password-encrypted secret key for your address",
-        "json": "Faucet JSON file from https://faucet.tzalpha.net/",
-    }
-
-    systemd_enable = {
-        "yes": "Enable and start the service, running it both now and on every boot",
-        "no": "Start the service this time only",
-    }
-
-    values = {}
-
-    steps = [
-        Step(
-            id="network",
-            prompt="Which Tezos network would you like to use?\nCurrently supported:",
-            help="The selected network will be used to set up all required services.\n"
-            "The currently supported protocols are 009-PsFLoren (used on florencenet and mainnet) \n"
-            "and 010-PtGRANAD (granadanet).\nKeep in mind that you must select the test network "
-            "(either florencenet or granadanet) if you plan on baking with a faucet JSON file.",
-            options=networks,
-            validator=Validator(enum_range_validator(networks)),
-        ),
-        Step(
-            id="mode",
-            prompt="Do you want to set up baking or to run the standalone node?",
-            help="By default, tezos-baking provides predefined services for running baking instances "
-            "on different networks.\nSometimes, however, you might want to only run the Tezos node.\n"
-            "When this option is chosen, this wizard will help you bootstrap tezos-node only.",
-            options=modes,
-            validator=Validator(enum_range_validator(modes)),
-        ),
-        Step(
-            id="systemd_mode",
-            prompt="Would you like your setup to automatically start on boot?",
-            help="Starting the service will make it available just for this session, great\n"
-            "if you want to experiment. Enabling it will make it start on every boot.",
-            options=systemd_enable,
-            validator=Validator(enum_range_validator(systemd_enable)),
-        ),
-        Step(
-            id="snapshot",
-            prompt="The Tezos node can take a significant time to bootstrap from scratch.\n"
-            "Bootstrapping from a snapshot is suggested instead.\n"
-            "How would you like to proceed?",
-            help="A fully-synced local tezos-node is required for running a baking instance.\n"
-            "By default, service with tezos-node will start to bootstrap from scratch,\n"
-            "which will take a significant amount of time.\nIn order to avoid this, we suggest "
-            "bootstrapping from a snapshot instead.\n\n"
-            "Snapshots can be downloaded from the following websites:\n"
-            "Tezos Giganode Snapshots - https://snapshots-tezos.giganode.io/ \n"
-            "XTZ-Shots - https://xtz-shots.io/ \n\n"
-            "We recommend to use rolling snapshots. This is the smallest and the fastest mode\n"
-            "that is sufficient for baking (you can read more about other tezos-node history modes here:\n"
-            "https://tezos.gitlab.io/user/history_modes.html#history-modes ).\n"
-            "All commands within the service are run under the 'tezos' user.",
-            options=snapshot_import_modes,
-            validator=Validator(enum_range_validator(snapshot_import_modes)),
-        ),
-        Step(
-            id="snapshot_file",
-            prompt="Provide the path to the tezos-node snapshot file.",
-            help="You have indicated wanting to import the snapshot from a file.\n"
-            "You can download the snapshot yourself e.g. from XTZ-Shots or Tezos Giganode Snapshots.",
-            validator=Validator(filepath_validator),
-            reqs=lambda vs: vs["snapshot"] == "file",
-        ),
-        Step(
-            id="snapshot_url",
-            prompt="Provide the url of the tezos-node snapshot file.",
-            help="You have indicated wanting to import the snapshot from a custom url.\n"
-            "You can use e.g. links to XTZ-Shots or Tezos Giganode Snapshots resources.",
-            reqs=lambda vs: vs["snapshot"] == "url",
-        ),
-        Step(
-            id="key_import_mode",
-            prompt="How do you want to import the baker key?",
-            help="To register the baker, its secret key needs to be imported to the data "
-            "directory first.\nBy default tezos-baking-<network>.service will use the 'baker' "
-            "alias\nfor the key that will be used for baking and endorsing.\n"
-            "If you want to test baking with a faucet file, make sure you have chosen a test network like "
-            + list(networks.keys())[1],
-            options=key_import_modes,
-            validator=Validator(enum_range_validator(key_import_modes)),
-            reqs=lambda vs: vs["mode"] == "baker",
-        ),
-        Step(
-            id="ledger_url",
-            prompt="Provide the ledger URL for importing the baker secret key stored on a ledger.",
-            help="Your ledger URL should look something like <ledger://<mnemonic>/ed25519/0'/1'>",
-            default=None,
-            options=list_connected_ledgers(),
-            validator=Validator(
-                [
-                    required_field_validator,
-                    or_custom_validator(enum_range_validator(list_connected_ledgers())),
-                ]
+ledger_url_query = Step(
+    id="ledger_url",
+    prompt="Provide the ledger URL for importing the baker secret key stored on a ledger.\n"
+    "You can choose one of the suggested options or provide your own ledger URL.",
+    help="Your ledger URL should look something like <ledger://<mnemonic>/ed25519/0'/1'>",
+    default=None,
+    options=list_connected_ledgers(),
+    validator=Validator(
+        [
+            required_field_validator,
+            or_validator(
+                enum_range_validator(list_connected_ledgers()), ledger_url_validator
             ),
-            reqs=lambda vs: vs["mode"] == "baker" and vs["key_import_mode"] == "ledger",
-        ),
-        Step(
-            id="secret_key",
-            prompt="Provide either the unencrypted or password-encrypted secret key for your address.",
-            help="The format is 'unencrypted:edsk...' for the unencrypted key, or 'encrypted:edesk...'"
-            "for the encrypted key.",
-            validator=Validator(required_field_validator),
-            reqs=lambda vs: vs["mode"] == "baker"
-            and vs["key_import_mode"] == "secret-key",
-        ),
-        Step(
-            id="json_filepath",
-            prompt="Provide the path to your downloaded faucet JSON file.",
-            help="Download the faucet JSON file from https://faucet.tzalpha.net/.\n"
-            "The file will contain the 'mnemonic' and 'secret' fields.",
-            validator=Validator([required_field_validator, filepath_validator]),
-            reqs=lambda vs: vs["mode"] == "baker" and vs["key_import_mode"] == "json",
-        ),
-    ]
+        ]
+    ),
+)
 
-    for step in steps:
-        if not step.reqs(values):
-            continue
+
+class Setup:
+    def __init__(self, config={}):
+        self.config = config
+
+    def query_step(self, step: Step):
 
         validated = False
         while not validated:
@@ -378,8 +411,7 @@ def run_wizard():
             answer = input("> ").strip()
 
             if answer.lower() in ["quit", "exit"]:
-                print("Exiting Tezos Baking Wizard")
-                return None
+                raise KeyboardInterrupt
             elif answer.lower() in ["help", "?"]:
                 print(step.help)
                 print()
@@ -388,41 +420,13 @@ def run_wizard():
                     answer = step.default
 
                 try:
-                    answer = step.validator.validate(answer)
+                    if step.validator is not None:
+                        answer = step.validator.validate(answer)
                 except ValueError as e:
                     print(color("Validation error: " + str(e), "\x1b[1;31m"))
                 else:
                     validated = True
-                    values[step.id] = answer
-
-    return values
-
-
-class Setup:
-    def __init__(self, config):
-        self.config = config
-
-    # Check if an account with the 'baker' alias already exists, and ask the user
-    # if it can be overwritten.
-    def check_baker_account(self, cmd):
-        output = subprocess.run(shlex.split(cmd), capture_output=True)
-        if output.returncode and re.search(
-            b"The secret_key alias baker already exists.", output.stderr
-        ):
-            value_regex = b"(?:" + ledger_regex + b")|(?:" + secret_key_regex + b")"
-            value = re.search(value_regex, output.stderr).group(0)
-            address = subprocess.run(
-                shlex.split("sudo -u tezos tezos-client show address baker"),
-                capture_output=True,
-            )
-            if address.returncode == 0:
-                address = re.search(address_regex, address.stdout).group(0)
-            print("An account with the 'baker' alias already exists.")
-            print("Its current value is ", value.decode("utf-8"))
-            print("With a corresponding address: ", address.decode("utf-8"))
-
-            if yes_or_no("Should it be replaced with the new import? <y/N> ", "no"):
-                proc_call(cmd + " --force")
+                    self.config[step.id] = answer
 
     # Check if there is already some blockchain data in the tezos-node data directory,
     # and ask the user if it can be overwritten.
@@ -454,23 +458,68 @@ class Setup:
     # Importing the snapshot for Node bootstrapping
     def import_snapshot(self):
         do_import = self.check_blockchain_data()
+        valid_choice = False
 
-        if do_import:
+        while do_import and not valid_choice:
+
+            self.query_step(snapshot_mode_query)
 
             snapshot_file = ""
+
             if self.config["snapshot"] == "skip":
                 return
             elif self.config["snapshot"] == "file":
+                self.query_step(snapshot_file_query)
                 snapshot_file = self.config["snapshot_file"]
             elif self.config["snapshot"] == "url":
+                self.query_step(snapshot_url_query)
                 url = self.config["snapshot_url"]
-                snapshot_file = fetch_snapshot(url)
+                try:
+                    snapshot_file = fetch_snapshot(url)
+                except ValueError:
+                    print()
+                    print("The snapshot URL you provided is unavailable.")
+                    print("Please check the URL again or choose another option.")
+                    print()
+                    continue
+                except urllib.error.URLError:
+                    print()
+                    print("The snapshot URL you provided is unavailable.")
+                    print("Please check the URL again or choose another option.")
+                    print()
+                    continue
             elif self.config["snapshot"] == "download rolling":
                 url = "https://" + self.config["network"] + ".xtz-shots.io/rolling"
-                snapshot_file = fetch_snapshot(url)
+                try:
+                    snapshot_file = fetch_snapshot(url)
+                except urllib.error.URLError:
+                    print()
+                    print(
+                        "The snapshot download option you chose is unavailable, "
+                        "possibly because the protocol is very new."
+                    )
+                    print(
+                        "Please check your internet connection or choose another option."
+                    )
+                    print()
+                    continue
             elif self.config["snapshot"] == "download full":
                 url = "https://" + self.config["network"] + ".xtz-shots.io/full"
-                snapshot_file = fetch_snapshot(url)
+                try:
+                    snapshot_file = fetch_snapshot(url)
+                except urllib.error.URLError:
+                    print()
+                    print(
+                        "The snapshot download option you chose is unavailable, "
+                        "possibly because the protocol is very new."
+                    )
+                    print(
+                        "Please check your internet connection or choose another option."
+                    )
+                    print()
+                    continue
+
+            valid_choice = True
 
             proc_call(
                 "sudo -u tezos tezos-node-"
@@ -513,38 +562,91 @@ class Setup:
         print()
         print("The Tezos node bootstrapped successfully.")
 
+    # Check if an account with the 'baker' alias already exists, and ask the user
+    # if it can be overwritten.
+    def check_baker_account(self):
+        address = subprocess.run(
+            shlex.split("sudo -u tezos tezos-client show address baker --show-secret"),
+            capture_output=True,
+        )
+        if address.returncode == 0:
+            value_regex = b"(?:" + ledger_regex + b")|(?:" + secret_key_regex + b")"
+            value = re.search(value_regex, address.stdout).group(0)
+            address = re.search(address_regex, address.stdout).group(0)
+            print()
+            print("An account with the 'baker' alias already exists.")
+            print("Its current value is", value.decode("utf-8"))
+            print("With a corresponding address:", address.decode("utf-8"))
+
+            return yes_or_no(
+                "Would you like to import a new key and replace this one? <y/N> ", "no"
+            )
+        else:
+            return True
+
     # Importing the baker key
     def import_baker_key(self):
-        if self.config["key_import_mode"] == "secret-key":
-            self.check_baker_account(
-                "sudo -u tezos tezos-client import secret key baker "
-                + self.config["secret_key"]
-            )
-        elif self.config["key_import_mode"] == "json":
-            self.check_baker_account(
-                "sudo -u tezos tezos-client activate account baker with "
-                + self.config["json_filepath"]
-            )
 
-        else:
-            print()
-            input("Please open the Tezos Baking app on your ledger, then hit Enter.")
-            self.check_baker_account(
-                "sudo -u tezos tezos-client import secret key baker "
-                + self.config["ledger_url"]
-            )
-            proc_call("sudo -u tezos tezos-client setup ledger to bake for baker")
+        replace_baker_key = self.check_baker_account()
+
+        if replace_baker_key:
+            if self.config["network"] == "mainnet":
+                key_import_modes.pop("json", None)
+
+            key_mode_query = get_key_mode_query(key_import_modes)
+
+            valid_choice = False
+            while not valid_choice:
+
+                try:
+                    self.query_step(key_mode_query)
+
+                    if self.config["key_import_mode"] == "secret-key":
+                        self.query_step(secret_key_query)
+                        proc_call(
+                            "sudo -u tezos tezos-client import secret key baker "
+                            + self.config["secret_key"]
+                            + " --force"
+                        )
+                    elif self.config["key_import_mode"] == "json":
+                        self.query_step(json_filepath_query)
+                        proc_call(
+                            "sudo -u tezos tezos-client activate account baker with "
+                            + self.config["json_filepath"]
+                            + " --force"
+                        )
+
+                    else:
+                        self.query_step(ledger_url_query)
+
+                        print()
+                        input(
+                            "Please open the Tezos Baking app on your ledger, then hit Enter."
+                        )
+                        proc_call(
+                            "sudo -u tezos tezos-client import secret key baker "
+                            + self.config["ledger_url"]
+                            + " --force"
+                        )
+                        proc_call(
+                            "sudo -u tezos tezos-client setup ledger to bake for baker"
+                        )
+
+                except EOFError:
+                    raise EOFError
+                except Exception as e:
+                    print("Something went wrong when calling tezos-client:")
+                    print(str(e))
+                    print()
+                    print("Please check your input and try again.")
+                else:
+                    valid_choice = True
 
     def register_baker(self):
         print()
-        if self.config["key_import_mode"] == "ledger":
-            input(
-                "Please open the Tezos Baking or Tezos Wallet app on your ledger, then hit Enter."
-            )
-
         proc_call("sudo -u tezos tezos-client register key baker as delegate")
         print(
-            "You can check a blockchain explorer (e.g. https://tzkt.io/ or https://tzstats.com/) "
+            "You can check a blockchain explorer (e.g. https://tzkt.io/ or https://tzstats.com/)\n"
             "to see the baker status and baking rights of your account."
         )
 
@@ -552,14 +654,6 @@ class Setup:
         self.systemctl_start_action("baking")
 
     def systemctl_start_action(self, service):
-        if self.config["systemd_mode"] == "yes":
-            proc_call(
-                "sudo systemctl enable tezos-"
-                + service
-                + "-"
-                + self.config["network"]
-                + ".service"
-            )
         proc_call(
             "sudo systemctl start tezos-"
             + service
@@ -568,43 +662,107 @@ class Setup:
             + ".service"
         )
 
+    def systemctl_enable(self):
+        if self.config["systemd_mode"] == "yes":
+            print(
+                "Enabling the tezos-{}-{}.service".format(
+                    self.config["mode"], self.config["network"]
+                )
+            )
+            proc_call(
+                "sudo systemctl enable tezos-"
+                + self.config["mode"]
+                + "-"
+                + self.config["network"]
+                + ".service"
+            )
+        else:
+            print("The services won't restart on boot.")
 
-def run_setup(cfg):
+    def run_setup(self):
 
-    if cfg is not None:
-        setup = Setup(cfg)
+        print("Tezos Baking Wizard")
+        print()
+        print(
+            "Welcome, this wizard will help you to set up the infrastructure",
+            "to interact with the Tezos blockchain.",
+        )
+        print(
+            "In order to run a baking instance, you'll need the following Tezos binaries:\n",
+            "tezos-client, tezos-node, tezos-baker-<proto>, tezos-endorser-<proto>.\n",
+            "If you have installed tezos-baking, these binaries are already installed.",
+        )
+        print("All commands within the service are run under the 'tezos' user.")
+        print()
+        print(
+            "To access help and possible options for each question, type in 'help' or '?'."
+        )
+        print("Type in 'exit' to quit.")
+        print()
+
+        self.query_step(network_query)
+        self.query_step(service_mode_query)
 
         print("Trying to bootstrap tezos-node")
-        setup.bootstrap_node()
+        self.bootstrap_node()
 
-        if cfg["mode"] == "node":
-            return
+        if self.config["mode"] == "baking":
+            executed = False
+            while not executed:
+                print()
+                print("Importing the baker key")
+                self.import_baker_key()
 
-        print("Importing the baker key")
-        setup.import_baker_key()
+                print()
+                print("Registering the baker")
+                try:
+                    self.register_baker()
+                except EOFError:
+                    raise EOFError
+                except Exception as e:
+                    print("Something went wrong when calling tezos-client:")
+                    print(str(e))
+                    print()
+                    print("Going back to the previous step.")
+                    print("Please check your input and try again.")
+                    continue
+                executed = True
 
-        print("Registering the baker")
-        setup.register_baker()
+            print()
+            print("Starting the baking instance")
+            self.start_baking()
 
-        print("Start baking instance")
-        setup.start_baking()
+        print()
+        self.query_step(systemd_mode_query)
+        self.systemctl_enable()
 
+        print()
         print(
             "Congratulations! All required Tezos infrastructure services should now be started."
-            " You can show logs for all the services using the 'tezos' user by running: "
-            "journalctl -f _UID=$(id tezos -u)"
         )
+        print(
+            "You can show logs for all the services using the 'tezos' user by running:"
+        )
+        print("journalctl -f _UID=$(id tezos -u)")
 
-        if cfg["mode"] == "baker":
+        if self.config["mode"] == "baking":
             print()
             print("To stop the baking instance, run:")
-            print("sudo systemctl stop tezos-baking-" + cfg["network"] + ".service")
+            print(
+                "sudo systemctl stop tezos-baking-"
+                + self.config["network"]
+                + ".service"
+            )
 
             print()
             print(
                 "If you previously enabled the baking service and want to disable it, run:"
             )
-            print("sudo systemctl disable tezos-baking-" + cfg["network"] + ".service")
+            print(
+                "sudo systemctl disable tezos-baking-"
+                + self.config["network"]
+                + ".service"
+            )
 
 
 if __name__ == "__main__":
@@ -612,35 +770,33 @@ if __name__ == "__main__":
     readline.set_completer_delims(" ")
 
     try:
-        cfg = run_wizard()
+        setup = Setup()
+        setup.run_setup()
     except KeyboardInterrupt:
-        print()
-        print("Exiting Tezos Baking Wizard")
+        if "network" in setup.config:
+            proc_call(
+                "sudo systemctl stop tezos-baking-"
+                + setup.config["network"]
+                + ".service"
+            )
+        print("Exiting the Tezos Baking Wizard.")
         sys.exit(1)
     except EOFError:
-        print()
-        print("Exiting Tezos Baking Wizard")
+        if "network" in setup.config:
+            proc_call(
+                "sudo systemctl stop tezos-baking-"
+                + setup.config["network"]
+                + ".service"
+            )
+        print("Exiting the Tezos Baking Wizard.")
         sys.exit(1)
     except Exception as e:
-        print("Error in Tezos Baking Wizard, exiting.")
-        logfile = "tezos_baking_wizard.log"
-        with open(logfile, "a") as f:
-            f.write(str(e) + "\n")
-        print("The error has been logged to", os.path.abspath(logfile))
-        sys.exit(1)
-
-    try:
-        run_setup(cfg)
-    except KeyboardInterrupt:
-        proc_call("sudo systemctl stop tezos-baking-" + cfg["network"] + ".service")
-        print("Error in Tezos Baking setup, exiting.")
-        sys.exit(1)
-    except EOFError:
-        proc_call("sudo systemctl stop tezos-baking-" + cfg["network"] + ".service")
-        print("Error in Tezos Baking setup, exiting.")
-        sys.exit(1)
-    except Exception as e:
-        proc_call("sudo systemctl stop tezos-baking-" + cfg["network"] + ".service")
+        if "network" in setup.config:
+            proc_call(
+                "sudo systemctl stop tezos-baking-"
+                + setup.config["network"]
+                + ".service"
+            )
         print("Error in Tezos Baking setup, exiting.")
         logfile = "tezos_baking_wizard.log"
         with open(logfile, "a") as f:


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: right now the Tezos Baking Wizard queries all configuration
options from the user all at once, before running the setup. This
has several undesirable ramifications, such as the inability to
re-query an option chosen by accident, or to address transient errors,
as well as asking some information unnecessarily.

Solution: updated the wizard to interleave queries and setup steps,
only asking the information when necessary and retrying failed options.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #222, resolves #219 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
