### PR TITLE
[#218] Enhanced ledger interaction

### DIFF
--- a/docker/package/tezos_baking_wizard.py
+++ b/docker/package/tezos_baking_wizard.py
@@ -54,7 +54,7 @@ systemd_enable = {
 
 ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
 secret_key_regex = b"(encrypted|unencrypted):(?:\w{54}|\w{88})"
-address_regex = b"tz1\w{33}"
+address_regex = b"tz[123]\w{33}"
 
 
 # Input validators


### PR DESCRIPTION
## Description
Problem: Currently we show only ledger URLs for addresses that are store
on the ledgers, which is not very convenient when one has to choose the
desired key.

Solution: Also show the address that corresponds to the given URL and the
balance of this address.

Currently based on #224.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #218

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
