### PR TITLE
[#226] Add PR template for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -22,7 +22,7 @@ Resolves #
 
 #### Related changes (conditional)
 
-- [ ] I checked whether I should update the [README](../tree/master/README.md)
+- [ ] I checked whether I should update the [README](../../tree/master/README.md)
 
 - [ ] I checked whether native packaging works, i.e. native binary packages
   can be successfully built.

--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -1,0 +1,67 @@
+## Description
+
+This PR introduces a new <!-- insert new version here --> release in tezos-packaging.
+
+<!-- Depending on the type of the release some of the points below can be ommited.
+
+E.g. in case we introduce a new changes to our native packages, it's not necessary to bump
+used Tezos sources, create a new release in this repository and update brew formulas.
+
+Note that opam-repository is usually updated with some delay, so CI may fail
+due to lack of updated opam Tezos packages. In such case feel free to comment
+out native-packaging-related CI steps from the pipeline until the opam-repository
+is updated.
+-->
+
+<!-- List issues which are going to be resolved in the new packages from this
+release. Write 'None' if there are no related issues.
+
+For example:
+Follows #202, #210
+-->
+
+Follows #
+
+### Changes related to the creation of a release (conditional)
+
+- [ ] I updated Tezos sources and opam-repository (if needed) revisions in [sources.json](../../tree/master/nix/nix/sources.json).
+- [ ] I removed old bottles hashes from the brew formulas in [Formula directory](../../tree/master/Formula).
+- [ ] I updated `url :tag` and `version`s in brew formulas..
+- [ ] I updated release number in [meta.json](../../tree/master/meta.json).
+
+#### In case the new Tezos release provides a new protocol and corresponding testnet
+
+- [ ] I supported new protocol in [protocols.json](../../tree/master/protocols.json).
+- [ ] I supported new protocol and testnet in native packaging.
+- [ ] I supported new protocol and testnet in brew formulas.
+- [ ] I added tests for the new protocol and testnet.
+
+### Things to do after this release PR is merged
+
+<!--
+Some of the changes are done after the new release is created, consider following
+and checking unfinished points in the merged release PR using this template.
+-->
+
+#### Create a new release in this repository
+
+- [ ] I created a new release that is based on the latest autorelease created by the CI.
+
+#### Update brew bottles and repository mirrors
+
+- [ ] I compiled brew bottles using [`build-bottles.sh`](../../tree/scripts/build-bottles.sh) script and uploaded them to the created release.
+- [ ] I added new bottles sha256 hashes to the brew formulas.
+- [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
+      [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.
+
+#### Publish new native packages
+
+Once [opam-repository](https://opam.ocaml.org/packages/) is updated with the new version of Tezos packages.
+
+- [ ] I published new Ubuntu packages, see [these instructions](../../tree/master/docker#source-packages-and-publishing-them-on-launchpad-ppa).
+- [ ] I published new Fedora packages, see [these instructions](../../tree/master/docker#srcrpm-packages).
+
+#### Update documentation
+
+- [ ] I updated [README.md](../../tree/master/README.md).
+- [ ] I updated [baking doc](../../tree/master/docs/baking.md).


### PR DESCRIPTION
## Description
Problem: The process of creating a new release in Tezos packaging
consists of many steps and it's quite important to not miss any of them.
Since the process of creating a new release usually consist of multiple
PRs, it'll be nice to have a place where we can track the things that
was done and needs to be done in the nearest future.

Solution: Add PR template that is supposed to be used when we're
intending to create a new release. This PR will be used to track the
progress of the new release.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #226

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
