### PR TITLE
[#226] Improve template a bit more

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -28,6 +28,7 @@ Follows #
 - [ ] I removed old bottles hashes from the brew formulas in [Formula directory](../../tree/master/Formula).
 - [ ] I updated `url :tag` and `version`s in brew formulas..
 - [ ] I updated release number in [meta.json](../../tree/master/meta.json).
+- [ ] I removed native-packaging-related steps from CI in case opam-repository wasn't updated yet.
 
 #### In case the new Tezos release provides a new protocol and corresponding testnet
 
@@ -46,10 +47,12 @@ and checking unfinished points in the merged release PR using this template.
 #### Create a new release in this repository
 
 - [ ] I created a new release that is based on the latest autorelease created by the CI.
+- [ ] I enabled native-packaging-related CI steps after opam-repository got updated.
 
 #### Update brew bottles and repository mirrors
 
-- [ ] I compiled brew bottles using [`build-bottles.sh`](../../tree/scripts/build-bottles.sh) script and uploaded them to the created release.
+- [ ] I compiled brew bottles for all required macOS versions using [`build-bottles.sh`](../../tree/scripts/build-bottles.sh)
+      script and uploaded them to the created release. Note that for this you'll need a macOS machine running each required version.
 - [ ] I added new bottles sha256 hashes to the brew formulas.
 - [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
       [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.


### PR DESCRIPTION
## Description
Problem:
* It's non-obvious that one should build brew bottles for macOS
  using macOS machine.
* Also it's non-obvious that one should comment out
  native-packaging-related CI steps in case opam-repository
  wasn't updated and we need to create a new release urgently.

Solution: Clarify point about bottles building and add two more points
for enabling and disabling native-packaging-related CI steps.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #226

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).