### PR TITLE
v9.3 bottle hashes

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "a21f5058c6eea3a506f6ceb43fef7fdc629605b217310ec133a73fe1b1a6c0b9"
+    sha256 cellar: :any, catalina: "4ca8299efb7c0e252eeb4f6ec7c0add4939f551f42154e8e52699f4f574241b0"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "81459f2f87f132b7d13e8473993f4223adf869280887df51542e4be3de1d987d"
+    sha256 cellar: :any, catalina: "47e03869afaba0bbff30d87c36fda6d0b37cbe30c00d05469995c72afaf2b037"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "1fc2d1d2234b8d6e90bb035aaf0a0d562bb9dc21add471ce439e1bb5f5df9ea0"
+    sha256 cellar: :any, catalina: "e24bc106953b7223268e8abd347c758b425a08e884696e027e476b428bb930bf"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "14c43e2c9b7513a97fabd018cfb35d498a0ac35f198e74c706eb92db3c4861b7"
+    sha256 cellar: :any, catalina: "cff999977a96d0fd12d1a39738a2643f5988b72177a9b035505689842357de3d"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "a998c6123f5829670f1ab300465acf08002562e2eee1fdc2b2393bc0261b3018"
+    sha256 cellar: :any, catalina: "eb38204cab82ace41f2bc72a0a6782b301c6703c3bd6316edc98b105d0d366db"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "6fded8acb60d148d6c64d51309f883f8a7b14fa7a389d51e938ea7f41db67a3d"
+    sha256 cellar: :any, catalina: "73f842efbfcce6fd2dda429431dfe2eca576ab0137abb69150e8823f841cc6e8"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "f2aa14883f719ddbb465ef1452377b255b3359146a14d2855ce9ae05c9c97c6b"
+    sha256 cellar: :any, catalina: "777a047db949405c03a9d9d299c5d17c5e5cf619175875298962e523ce087c45"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "fbaaaf570060d4894b56b6eebb92d91834d886342a059871bc146424b4d6baad"
+    sha256 cellar: :any, catalina: "cdc43d0a55ede36cee9ebeb9d3c6363eab648359b128603dea6ea375b8052ec9"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "c90ca7cc6d62103d2b6d6488ad2f4a336b6f58a297dc94766be83ee687a1494a"
+    sha256 cellar: :any, catalina: "d08540ceda863465fbe39bdf3eb57bc3bf9ed414b0148de2adf30b856c3c0b40"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "371ee8d6cd7f1863013680815d077729fb59a7709e420e6fa5f9e69ad3eef157"
+    sha256 cellar: :any, catalina: "e62a5201340eb5a6a5eec370f97867699bf59be13f4bc2bf482b68e21c248fa1"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "48773847c79118a0ed0794d201dce381b8c6fc933bd480821502df1698239f95"
+    sha256 cellar: :any, catalina: "c71e97f2272ad1979aa1e5a03c2caa590a8b71a11a90507d8184a0a310008b03"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "2f98c01cd6d7d09e9cf507ab2b195efcfd3dbce42e14ca6d1ccbb831765c8ee1"
+    sha256 cellar: :any, catalina: "6ed5761d6cd9e546187f8d7a2c718a13425d39898918f2b79a3abf85e2f31760"
   end
 
   def make_deps

--- a/scripts/build-bottles.sh
+++ b/scripts/build-bottles.sh
@@ -12,9 +12,9 @@ build_bottle () {
 }
 
 # tezos-sapling-params is used as a dependency for some of the formulas
-# so we handle it separately
-brew install --formula --build-bottle ./Formula/tezos-sapling-params.rb
-brew bottle --force-core-tap --no-rebuild ./Formula/tezos-sapling-params.rb
+# so we handle it separately.
+# We don't build the bottle for it because it is never updated over time.
+brew install --formula ./Formula/tezos-sapling-params.rb
 
 # we don't bottle meta-formulas that contains only services
 build_bottle ./Formula/tezos-accuser-009-PsFLoren.rb


### PR DESCRIPTION
## Description
Problem: v9.3-1 was released, but hashes of the new bottles have not been added to the brew formulas yet.

Solution: added the bottle hashes for Mojave and Catalina macOS versions.

Also removed building the bottle for `tezos-sapling-params` from the bottle building script.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
None, follows #228 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
