### PR TITLE
[#231] Publish fedora packages via copr-cli

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -20,6 +20,8 @@ steps:
    only_changes:
    - .buildkite/filter-pipeline.py
    - tests/buildkite/.*
+ - label: build utils
+   command: nix-build nix/util/* --no-out-link
 
  - label: build via nix
    commands:

--- a/docker/README.md
+++ b/docker/README.md
@@ -171,7 +171,7 @@ In order to install `.rpm` package run the following command:
 sudo yum localinstall <path to rpm file>
 ```
 
-### `.src.rpm` packages
+### `.src.rpm` packages and publishing them on Copr
 
 In order to build source packages run the following commands:
 ```
@@ -187,4 +187,10 @@ rpm --add-sign out/*.src.rpm
 ```
 Note, that in order to sign them, you'll need gpg key to be set up in `~/.rpmmacros`.
 
-Resulting `.src.rpm` packages can be either built locally or submitted to the Copr.
+Signed package can be submitted to the Copr repository via `copr-cli`.
+Read more about setting up `copr-cli` [here](https://developer.fedoraproject.org/deployment/copr/copr-cli.html).
+
+In order to submit source package for building run the following command:
+```
+copr-cli build Serokell/Tezos --nowait <path to '.src.rpm' file>
+```

--- a/nix/util/copr-cli.nix
+++ b/nix/util/copr-cli.nix
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+let
+  pkgs = import ../build/pkgs.nix { };
+  common-src = builtins.fetchTarball {
+    url = "https://pagure.io/copr/copr/archive/copr-cli-1.94-1/copr-copr-cli-1.94-1.tar.gz";
+    sha256 = "0p6mrir6xhp9mi52dicd4j183bjvxlqdh03w57s7l22fcmrhsz26";
+  };
+  python-copr = pkgs.python36Packages.buildPythonApplication {
+    propagatedBuildInputs = with pkgs.python36Packages;
+      [ requests-toolbelt requests marshmallow six munch ];
+    src = "${common-src}/python";
+    name = "copr";
+    version = "1.109";
+  };
+in pkgs.python36Packages.buildPythonApplication rec {
+  propagatedBuildInputs = with pkgs.python36Packages;
+    [ requests humanize jinja2 simplejson python-copr ];
+  src = "${common-src}/cli";
+  name = "copr-cli";
+  version = "1.94.1";
+  doCheck = false;
+}

--- a/nix/util/dput.nix
+++ b/nix/util/dput.nix
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+let
+  pkgs = import ../build/pkgs.nix { };
+in pkgs.python36Packages.buildPythonApplication rec {
+  propagatedBuildInputs = with pkgs.python36Packages;
+    [ debian gpgme pygpgme testscenarios pkgs.gpgme setuptools ];
+  src = builtins.fetchTarball {
+    url = "https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/dput/1.1.0ubuntu1/dput_1.1.0ubuntu1.tar.xz";
+    sha256 = "1dgmyhmpnw71y1qs9z6npi9m46qh2vjs5g2vvaj1ak57333w2f7d";
+  };
+  name = "dput";
+  version = "1.1.0";
+  doCheck = false;
+}


### PR DESCRIPTION
## Description
Problem: Currently publishing instructions for Fedora tells to upload
.src.rpm packages via Copr website. However, it's not very convenient.
Moreover, there is 'copr-cli' utility that can submit builds from the
terminal.

Solution: Update instructions to use 'copr-cli' for publishing Fedora
packages to Copr.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #231

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
