### PR TITLE
Enable native-packaging back

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -100,59 +100,59 @@ steps:
    # files from nix/ are massively used in tests ifrastructure
    - nix/.*
 
-# - label: test deb source packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
-#   artifact_paths:
-#     - ./out/*
-#   branches: "!master"
-#   timeout_in_minutes: 60
-#   agents:
-#     queue: "docker"
-#   only_changes: &native_packaging_changes_regexes
-#   - docker/package/.*
-#   - docker/docker-tezos-packages.sh
-#   - meta.json
-#   - protocols.json
-#   - nix/nix/sources.json
-# - label: test deb binary packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   # Building all binary packages will take significant amount of time, so we build only one
-#   # in order to ensure package generation sanity
-#   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-009-PsFLoren
-#   - rm -rf out
-#   # It takes much time to build binary package, so we do it only on master
-#   branches: "master"
-#   timeout_in_minutes: 90
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
-# - label: test rpm source packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   - ./docker/docker-tezos-packages.sh --os fedora --type source
-#   artifact_paths:
-#     - ./out/*
-#   branches: "!master"
-#   timeout_in_minutes: 60
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
-# - label: test rpm binary packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   # Building all binary packages will take significant amount of time, so we build only one
-#   # in order to ensure package generation sanity
-#   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-009-PsFLoren
-#   - rm -rf out
-#   # It takes much time to build binary package, so we do it only on master
-#   branches: "master"
-#   timeout_in_minutes: 90
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
+ - label: test deb source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 60
+   agents:
+     queue: "docker"
+   only_changes: &native_packaging_changes_regexes
+   - docker/package/.*
+   - docker/docker-tezos-packages.sh
+   - meta.json
+   - protocols.json
+   - nix/nix/sources.json
+ - label: test deb binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-009-PsFLoren
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
+ - label: test rpm source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os fedora --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 60
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
+ - label: test rpm binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-009-PsFLoren
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
 
  - label: create auto pre-release
    commands:


### PR DESCRIPTION
## Description

Problem: we have previously disabled the CI steps having to do with
native packaging, as the opam-repository has not been updated with
the new tezos release. Now it's up-to-date again.

Solution: enable the relevant CI steps yet again.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #228

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
