### PR TITLE
Add v10.0-rc1-1 brew bottle hashes

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "10f03a9e2ec96bc4c57ddd7e6ad0ad1932566a4ce40c3aded80547171aa865e6"
+    sha256 cellar: :any, catalina: "00188a4c251f17b998f5c32120e2ea940089d647e1fc4854bd76e1b543a6ca5b"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "ec82013b1e1da0648f6a83c070c37b8f1e72d57f1eada87abfca52764a86b18c"
+    sha256 cellar: :any, catalina: "f244a31bed531116739b2cc08c0d9d0eaeedd2ec33dddbd44cb9c2128b00e8f4"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "951206775fe8105376fd056c5cade69e236926de6e1fb9b4653d2ef4bb1a4738"
+    sha256 cellar: :any, catalina: "f5532228fc62c1890e391901a49fd6e5d48c5eb53d3aff305b0b2c9387adc473"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "14c447ddf7acc3b73a460116d9ce9b3e07160c2571d870cf0a0ddaed93cdb898"
+    sha256 cellar: :any, catalina: "1729d5ed70095f6eb7db3f5325aac916e10156108d7943832ccc151246f7e74a"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "554d3af36a7caa239e45df427c566c7dc12fe976f592cd9d0c4ed52e2b12c98f"
+    sha256 cellar: :any, catalina: "dde04a8b114f6aa009e6d25b4fdd136f1e75b08f6e7b154d3280319fd169f65e"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "efd58c8fd8c83078848429adcfada0cb657d4284e3e96a447144b4a61738855e"
+    sha256 cellar: :any, catalina: "f572ddf16c9868ff06c583d4a99a2a9cecead1fe2762046656591fccb8240ce7"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "6a5e5e55f4019d2437ebf5b30817987732d9fcef1886035a32e58088e3b86ff0"
+    sha256 cellar: :any, catalina: "eceb4aeb3e690896887da6752962f3de630128d02f8b230dbf94c39b25571eee"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "22b533ffff167705f8920b6c005980b6f4f97290b154cd5381ff8f0410bf43fd"
+    sha256 cellar: :any, catalina: "c980696aa50be86cd27d8581c3e1920879f38ae957021ced1b8dcd433e6bbe63"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "2a6835e2d9261aed691cdd8077418b4302c438c0f7decf796797ad6a2351f36f"
+    sha256 cellar: :any, catalina: "75316a1dd1360a3f0f7f0fef91597e005c8caa6d3eb30d73a0e4c2b34d887548"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "5bf0e72cd496803a8a1ff5661f4d335767cf7cee769eed03c9cd024bc5ac8c12"
+    sha256 cellar: :any, catalina: "1247bb01ecee423e28f51ca98a8c6068bafb34bbe22535fc3a5f8c9d3499c783"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "881ec24e96306fca5798ffbe812b8a60ae904988d46d4c73fd1f43aa8448c102"
+    sha256 cellar: :any, catalina: "8099089e1c68f06f9866da60a32421ed53757dbf32a29ffd4692f19cf488cd03"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "ac0e5c7af9a8bef3223a7bea7e92f8dffa574c5463cdc3f2c988c97dace272ca"
+    sha256 cellar: :any, catalina: "840879a07e50c46d6638e20beefc80fb24f29940c85cb5bc38778bb27c8d950e"
   end
 
   def make_deps


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: v10.0-rc1-1 was released, we need to add hashes of the new
bottles to the brew formulas.

Solution: added the bottle hashes for Mojave and Catalina.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #234 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
