### PR TITLE
[#231] Fix Copr project name

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -192,5 +192,5 @@ Read more about setting up `copr-cli` [here](https://developer.fedoraproject.org
 
 In order to submit source package for building run the following command:
 ```
-copr-cli build Serokell/Tezos --nowait <path to '.src.rpm' file>
+copr-cli build @Serokell/Tezos --nowait <path to '.src.rpm' file>
 ```


### PR DESCRIPTION
## Description
Problem: `Serokell/Tezos` project doesn't exist on Copr.

Solution: Use `@Serokell/Tezos` instead.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #231

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).