### PR TITLE
Add bottles hashes for v9.4 formulas

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "254268b627fc7631dae8d0e34d3d5dcfefb140b0bb25a8a84c2f4be4faadd700"
+    sha256 cellar: :any, catalina: "6e98393d2bebeeffb8301e51ea23ab9610062644134e6e7bcee6cdbc0968b290"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "9b4ddddbb979b4c11f3e53decc6687a06171d06405d6be5281d9b20af1de34a2"
+    sha256 cellar: :any, catalina: "b7d4893ce285d58a8f66e128d660e7f3d8106b990b571af5f364bc607141d2ed"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "1fe91e1f7f98a42ff0e09978bdfcf48d30031b7c837a8878a391b1f147470622"
+    sha256 cellar: :any, catalina: "c95e31d8d77bfe04020fee4a30c32f46bab6d1412ae2220c92a5084f834cd6ef"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "b3827685f4756ce537fb35df86a3f1e44634eef967d3f6d3e191d11935eba314"
+    sha256 cellar: :any, catalina: "7c77b945a0bfc2e0701093a751df3733a2b792f8ce6ca8837a85d2668ed53b23"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "0faa8e7ac68db9fd14806e39e654a7f1967c51058149647f65ab2cc087f71b8e"
+    sha256 cellar: :any, catalina: "22b2feb303c0dee574bad47cd038d6d222648f65c1f364f55294864cf725f05c"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "3fea2a971103bb9706179b1b7d14177e344efde0967e212fb285e24a3b777a1f"
+    sha256 cellar: :any, catalina: "4519015a1101739fe0af661e5b387bc368b98ad20709e8cb0ae09a0fd7a54357"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "402498d8679bdc88c05c35164cf73febe8b0eeeb26fa36308467f7966353ab44"
+    sha256 cellar: :any, catalina: "6f83dcdf9b11ff61119dc89536d9d25db5d8968c9309a8b70358d80f1cc72508"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "7f2baf83c1ec2b42e59b40e050be7a3b566eb40b82395b95fc5b2887f45af03e"
+    sha256 cellar: :any, catalina: "f66162ec30777189ad95156aae9731399d7145b13e1e5a115b5544422624f527"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "23e207dd247040abe4b8148934f86c376bfc15fe14743c332f85f80d338886be"
+    sha256 cellar: :any, catalina: "3a9c0ee7f407051ee646ba220cae1c774d49f99946af029aad84f4517e19dceb"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "ccba11ac26a99be73abd711f5306dba1c46f61758e815221ab086a82afc06a4a"
+    sha256 cellar: :any, catalina: "5cfcda0946cd83af0bfbc00393b3107194cfb6cd43a25ef6da70422c5d4c9d2b"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "5e96fd1b329b3b0908d664721305c4d6b21d232cbe0faff296558ec9feb05b3b"
+    sha256 cellar: :any, catalina: "25417433e87410a2ff72b71b639929758587e87f1ec787b1f268a12cccb4953c"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "b850fbe206e0ac42f9bca33142f92ae2ef80dfb104ce05da549f7113b9c05a9f"
+    sha256 cellar: :any, catalina: "3c0c5ce0b700e2398f2632f475c227e69e71d45de38f7f89654d0e700b2f4946"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: We've built and added v9.4 bottles to the corresponding
release.

Solution: Update hashes, so that it's possible to fetch bottles for
Mojave and Catalina.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #238

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
