### PR TITLE
[#231] Add a note about dput config

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -115,10 +115,22 @@ Once these files are updated, they should be signed using `debsign`.
 debsign ../out/*.changes
 ```
 
+If you're not running `dput` on Ubuntu, you'll need to provide a config for it.
+Sample config can be found [here](./.dput.cf). Put the contents of this config
+into `~/.dput.cf`. In case you already have a config, add the following piece
+to it for the further convenience:
+```
+[tezos-serokell]
+fqdn			= ppa.launchpad.net
+method			= ftp
+incoming		= ~serokell/ubuntu/tezos
+login			= anonymous
+```
+
 Signed files now can be submitted to Launchpad PPA. In order to do that run the following
 command for each `.changes` file:
 ```
-dput ppa:serokell/tezos ../out/<package>.changes
+dput tezos-serokell ../out/<package>.changes
 ```
 
 #### Updating release in scope of the same upstream version

--- a/docker/package/.dput.cf
+++ b/docker/package/.dput.cf
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+[DEFAULT]
+login			= *
+method			= ftp
+hash			= md5
+allow_unsigned_uploads	= 0
+allow_dcut		= 0
+run_lintian		= 0
+run_dinstall		= 0
+check_version		= 0
+scp_compress		= 0
+post_upload_command	=
+pre_upload_command	=
+passive_ftp		= 1
+default_host_main	=
+allowed_distributions	= (?!UNRELEASED)
+
+[tezos-serokell]
+fqdn			= ppa.launchpad.net
+method			= ftp
+incoming		= ~serokell/ubuntu/tezos
+login			= anonymous


### PR DESCRIPTION

## Description
Problem: If one is running dput not on Ubuntu, it has to provide config
to it manually.

Solution: Add a note about it to the packaging README along with the
suggested default config.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #231

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
