### PR TITLE
[#243] Improve progress reporting in baking wizard

### DIFF
--- a/docker/package/tezos_baking_wizard.py
+++ b/docker/package/tezos_baking_wizard.py
@@ -622,7 +622,14 @@ class Setup:
 
         self.import_snapshot()
 
+        print(
+            "Starting the node service. This is expected to take some "
+            "time, as the node needs a node identity to be generated."
+        )
+
         self.systemctl_start_action("node")
+
+        print("Waiting for the node service to start...")
 
         while True:
             rpc_address = self.config["node_rpc_addr"]
@@ -630,8 +637,10 @@ class Setup:
                 urllib.request.urlopen(rpc_address + "/version")
                 break
             except urllib.error.URLError:
-                print("...Waiting for the node service to start...")
                 proc_call("sleep 1")
+
+        print("Generated node identity and started the service.")
+        print("Waiting for the node to bootstrap...")
 
         proc_call(
             "sudo -u tezos tezos-client --endpoint " + rpc_address + " bootstrapped"


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: currently in the baking wizard, there's a confusing pause
in the output after importing the snapshot.

Solution: added an extra output explaining what needs to be done and
what has already transpired. Removed the message repeating every second.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #243 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
