### PR TITLE
[#244] Set high watermark explicitly

### DIFF
--- a/docker/package/tezos_baking_wizard.py
+++ b/docker/package/tezos_baking_wizard.py
@@ -13,6 +13,7 @@ import os, sys, subprocess, shlex
 import readline
 import re, textwrap
 import urllib.request
+import json
 from typing import List
 
 
@@ -497,6 +498,12 @@ class Setup:
             + self.config["node_rpc_addr"]
         )
 
+    def get_current_head_level(self):
+        response = urllib.request.urlopen(
+            self.config["node_rpc_addr"] + "/chains/main/blocks/head/header"
+        )
+        return str(json.load(response)["level"])
+
     # Check if there is already some blockchain data in the tezos-node data directory,
     # and ask the user if it can be overwritten.
     def check_blockchain_data(self):
@@ -736,6 +743,8 @@ class Setup:
                             + tezos_client_options
                             + " setup ledger to bake for "
                             + baker_alias
+                            + " --main-hwm "
+                            + self.get_current_head_level()
                         )
 
                 except EOFError:


### PR DESCRIPTION
## Description
Problem: 'tezos-client setup ledger to baker' doesn't update high
watermark by default and thus bakes and endorsements can be missed in
case we switch from a network with higher number of blocks to the network
with lower number of blocks.

Solution: Provide current level as high watermark explicitly.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #244 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
