### PR TITLE
[#201] Rename the CLI wizard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -2,7 +2,7 @@
 
 This PR introduces a new <!-- insert new version here --> release in tezos-packaging.
 
-<!-- Depending on the type of the release some of the points below can be ommited.
+<!-- Depending on the type of the release some of the points below can be omitted.
 
 E.g. in case we introduce a new changes to our native packages, it's not necessary to bump
 used Tezos sources, create a new release in this repository and update brew formulas.
@@ -24,15 +24,16 @@ Follows #
 
 ### Changes related to the creation of a release (conditional)
 
-- [ ] I updated Tezos sources and opam-repository (if needed) revisions in [sources.json](../../tree/master/nix/nix/sources.json).
-- [ ] I removed old bottles hashes from the brew formulas in [Formula directory](../../tree/master/Formula).
-- [ ] I updated `url :tag` and `version`s in brew formulas..
-- [ ] I updated release number in [meta.json](../../tree/master/meta.json).
+- [ ] I updated Tezos sources and opam-repository (if needed) revisions in [sources.json](/serokell/tezos-packaging/tree/master/nix/nix/sources.json).
+- [ ] I removed old bottles hashes from the brew formulas in [Formula directory](/serokell/tezos-packaging/tree/master/Formula).
+- [ ] I updated `url :tag` and `version`s in brew formulas.
+- [ ] I updated release number in [meta.json](/serokell/tezos-packaging/tree/master/meta.json).
+- [ ] If the native release version was updated, I reset the `letter_version` in [model.py](/serokell/tezos-packaging/tree/master/docker/package/model.py).
 - [ ] I removed native-packaging-related steps from CI in case opam-repository wasn't updated yet.
 
 #### In case the new Tezos release provides a new protocol and corresponding testnet
 
-- [ ] I supported new protocol in [protocols.json](../../tree/master/protocols.json).
+- [ ] I supported new protocol in [protocols.json](/serokell/tezos-packaging/tree/master/protocols.json).
 - [ ] I supported new protocol and testnet in native packaging.
 - [ ] I supported new protocol and testnet in brew formulas.
 - [ ] I added tests for the new protocol and testnet.
@@ -51,8 +52,9 @@ and checking unfinished points in the merged release PR using this template.
 
 #### Update brew bottles and repository mirrors
 
-- [ ] I compiled brew bottles for all required macOS versions using [`build-bottles.sh`](../../tree/scripts/build-bottles.sh)
-      script and uploaded them to the created release. Note that for this you'll need a macOS machine running each required version.
+- [ ] I compiled brew bottles for all required macOS versions using [`build-bottles.sh`](/serokell/tezos-packaging/tree/scripts/build-bottles.sh)
+      script and uploaded them to the created release.
+      Note that for this you'll need a macOS machine running each required version.
 - [ ] I added new bottles sha256 hashes to the brew formulas.
 - [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
       [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.
@@ -61,10 +63,10 @@ and checking unfinished points in the merged release PR using this template.
 
 Once [opam-repository](https://opam.ocaml.org/packages/) is updated with the new version of Tezos packages.
 
-- [ ] I published new Ubuntu packages, see [these instructions](../../tree/master/docker#source-packages-and-publishing-them-on-launchpad-ppa).
-- [ ] I published new Fedora packages, see [these instructions](../../tree/master/docker#srcrpm-packages).
+- [ ] I published new Ubuntu packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#source-packages-and-publishing-them-on-launchpad-ppa).
+- [ ] I published new Fedora packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#srcrpm-packages).
 
 #### Update documentation
 
-- [ ] I updated [README.md](../../tree/master/README.md).
-- [ ] I updated [baking doc](../../tree/master/docs/baking.md).
+- [ ] I updated [README.md](/serokell/tezos-packaging/tree/master/README.md).
+- [ ] I updated [baking doc](/serokell/tezos-packaging/tree/master/docs/baking.md).

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -502,7 +502,7 @@ class TezosBakingServicesPackage(AbstractPackage):
 
     def fetch_sources(self, out_dir):
         os.makedirs(out_dir)
-        shutil.copy(f"{os.path.dirname(__file__)}/tezos_baking_wizard.py", out_dir)
+        shutil.copy(f"{os.path.dirname(__file__)}/tezos_setup_wizard.py", out_dir)
 
     def gen_control_file(self, deps, ubuntu_version, out):
         run_deps = ", ".join(
@@ -589,13 +589,13 @@ BINDIR=/usr/bin
 
 tezos-baking:
 
-tezos-baking-wizard:
-	mv $(CURDIR)/tezos_baking_wizard.py $(CURDIR)/tezos-baking-wizard
-	chmod +x $(CURDIR)/tezos-baking-wizard
+tezos-setup-wizard:
+	mv $(CURDIR)/tezos_setup_wizard.py $(CURDIR)/tezos-setup-wizard
+	chmod +x $(CURDIR)/tezos-setup-wizard
 
-install: tezos-baking tezos-baking-wizard
+install: tezos-baking tezos-setup-wizard
 	mkdir -p $(DESTDIR)$(BINDIR)
-	cp $(CURDIR)/tezos-baking-wizard $(DESTDIR)$(BINDIR)/tezos-baking-wizard
+	cp $(CURDIR)/tezos-setup-wizard $(DESTDIR)$(BINDIR)/tezos-setup-wizard
 """
         with open(out, "w") as f:
             f.write(file_contents)

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -4,9 +4,9 @@
 
 import os, subprocess
 import shutil
+from copy import deepcopy
 from abc import abstractmethod
 from typing import List, Dict
-
 
 from .meta import PackagesMeta
 from .systemd import (
@@ -446,6 +446,13 @@ install: tezos-sapling-params
 
 
 class TezosBakingServicesPackage(AbstractPackage):
+
+    # Sometimes we need to update the tezos-baking package inbetween
+    # native releases, so we append an extra letter to the version of
+    # the package.
+    # This should be reset to "" whenever the native version is bumped.
+    letter_version = "a"
+
     def __init__(
         self,
         target_networks: List[str],
@@ -454,7 +461,8 @@ class TezosBakingServicesPackage(AbstractPackage):
     ):
         self.name = "tezos-baking"
         self.desc = "Package that provides systemd services that orchestrate other services from Tezos packages"
-        self.meta = meta
+        self.meta = deepcopy(meta)
+        self.meta.version = self.meta.version + self.letter_version
         self.target_protos = set()
         for network in target_networks:
             for proto in network_protos[network]:

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -804,7 +804,7 @@ class Setup:
 
     def run_setup(self):
 
-        print("Tezos Baking Wizard")
+        print("Tezos Setup Wizard")
         print()
         print(
             "Welcome, this wizard will help you to set up the infrastructure",
@@ -903,7 +903,7 @@ if __name__ == "__main__":
                 + setup.config["network"]
                 + ".service"
             )
-        print("Exiting the Tezos Baking Wizard.")
+        print("Exiting the Tezos Setup Wizard.")
         sys.exit(1)
     except EOFError:
         if "network" in setup.config:
@@ -912,7 +912,7 @@ if __name__ == "__main__":
                 + setup.config["network"]
                 + ".service"
             )
-        print("Exiting the Tezos Baking Wizard.")
+        print("Exiting the Tezos Setup Wizard.")
         sys.exit(1)
     except Exception as e:
         if "network" in setup.config:
@@ -921,8 +921,8 @@ if __name__ == "__main__":
                 + setup.config["network"]
                 + ".service"
             )
-        print("Error in Tezos Baking setup, exiting.")
-        logfile = "tezos_baking_wizard.log"
+        print("Error in Tezos Setup Wizard, exiting.")
+        logfile = "tezos_setup_wizard.log"
         with open(logfile, "a") as f:
             f.write(str(e) + "\n")
         print("The error has been logged to", os.path.abspath(logfile))


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: the CLI wizard we provide can be used to set up a baking
instance or just the Tezos node, but we call it `tezos-baking-wizard`.
This name is a bit confusing.

Solution: renamed the wizard to `tezos-setup-wizard`.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves part of #201 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
