### PR TITLE
[#251] Fix ambiguous anchors in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ different networks, you can read more about this in [this article](https://tezos
 
 * [Getting binaries](#getting-binaries).
   * [Ubuntu](#ubuntu)
-  * [Raspberry Pi OS](#raspberyy)
+  * [Raspberry Pi OS](#raspberry-pi-os)
   * [Fedora](#fedora)
-  * [Other Linux distros](#linux)
-  * [macOS](#macOS)
+  * [Other Linux distros](#static-binaries-and-other-linux-distros)
+  * [macOS](#macos)
 * [Setting up a node and/or baking on Ubuntu](#baking-on-ubuntu).
 * [Building instructions](#building).
 * [Contribution](#contribution).
@@ -44,22 +44,18 @@ different networks, you can read more about this in [this article](https://tezos
 
 The following distributions are supported by the `tezos-packaging`:
 
-<a name="ubuntu"></a>
 ### [Ubuntu](./docs/distros/ubuntu.md)
 
 Native Ubuntu packages that can be installed with `apt-get` from a PPA.
 
-<a name="raspberry"></a>
 ### [Raspberry Pi OS](./docs/distros/ubuntu.md#raspberry)
 
-Some Raspverry systems also support packages that can be installed using `apt-get`.
+Some Raspberry systems also support packages that can be installed using `apt-get`.
 
-<a name="fedora"></a>
 ### [Fedora](./docs/distros/fedora.md)
 
 Native Fedora packages that can be installed using using `dnf` or `yum`.
 
-<a name="linux"></a>
 ### [Static binaries and other linux distros](https://github.com/serokell/tezos-packaging/releases/latest)
 
 Prebuilt static binaries can be downloaded directly from the [latest release](https://github.com/serokell/tezos-packaging/releases/latest).
@@ -67,7 +63,6 @@ Prebuilt static binaries can be downloaded directly from the [latest release](ht
 You can also use `systemd` services for running some of the Tezos binaries in the background.
 For more information about these services, refer to [this doc](./docs/systemd.md#generic-linux).
 
-<a name="macos"></a>
 ### [macOS](./docs/distros/macos.md)
 
 `brew` formulae and taps for stable releases and release candidates.


### PR DESCRIPTION

## Description
Problem: There are some ambiguous anchors that make crossref-verify
unhappy.

Solution: Remove them and use automatically generated anchors instead.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Fixup for #251

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
