### PR TITLE
Add bottle hashes for v10.0-rc2

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "a7cfc73f78a6109e766009352bb5211be43eab5a30732bb056fcf39f70786770"
+    sha256 cellar: :any, catalina: "728ba08bdffdf9b26fff322eb1beaec16708c122aa97d2cfec3b6e2e89c04a58"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "7987efc4723795bbd907ae5170bef5355255dbbf6b0085814f62955b864f2e78"
+    sha256 cellar: :any, catalina: "38bc18b2f693059a3890295829af56406cb08cd6d5a1f40ba795bdb17e720716"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "43de6befe483a49c855678ce35f3e03683bca125e9f91a2d49064c26548262be"
+    sha256 cellar: :any, catalina: "70e0b0f87559aa41d3f0bad72bbeb82152a9463a2c8a883f1f08ce89e969c6e0"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "01ec537b88dc8082e186f6871bfb11c00179f4eb40a8cc99098eb0261c78ee74"
+    sha256 cellar: :any, catalina: "3082842c81781bb713621a00f4d46881db8805c5779d5643f3367bd4cf1e5879"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "50d602d8a9fc92999b3cafde96518bab1ca630f990b4177109256d8333bacfd6"
+    sha256 cellar: :any, catalina: "58ba515aee47a89c60a5bd7b80983123b2f7322c22cf86ffd60c02b5e34463b2"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "478035d419a5b88bda5f0f256b6b3e3db0929c9ac1be176cedd9b482b2b27188"
+    sha256 cellar: :any, catalina: "b26b668edc13666880e1747d580cf7af4a6ef04c712a7612e54dcb320e00580a"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "c19ff42486cfe9c136d1e12177fee7980f1f01b7f630761a56ab7017f918853e"
+    sha256 cellar: :any, catalina: "51b647c8c8928913fa1049ed47a19767e359b56319bcc9e8bc30f8e059a6d12d"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "b0d6718b7c7ebd8243e73628a99b021e3638ebdbc8446f4cd2f4f15e2039ff06"
+    sha256 cellar: :any, catalina: "26ccdcdfbb6f1005fa00f645ac7ee7d83966e9b468efe5e3b26d373729111a70"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "8112cc92155632c899286c60a6a2aa85b584eb51eb1d6f9f3f284f01b7504c3d"
+    sha256 cellar: :any, catalina: "2b5e22fd905c976739c1626a33489d4ac514cb1dda49a02b4b244b425c2fb549"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "e0a7a17c90a419396d112793070e40cde643cff868d23fca6b0683bba1016dea"
+    sha256 cellar: :any, catalina: "991679f68e1da46960f75a52171b37816f50de06aeebdc335482719cde300b63"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "8edec0ee1bd3b16c8d95fdfdf0562dd4bf886d7362100368590841a48de7435e"
+    sha256 cellar: :any, catalina: "fb01dfab1217c24bc3d062169c416dee6ca5e964457e1e623da5655097f4b640"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "fd53290ad7ca9c4b6b548c99c8dfcad4ad32c2464e3745121fe127189f4cdea8"
+    sha256 cellar: :any, catalina: "5ecbdc871b6695909177aaed9eee1aac87fdd8944326cd74d64fec260ba0f960"
   end
 
   def make_deps


### PR DESCRIPTION
## Description

Problem: v10.0-rc2 bottles have been built and added to the latest release.

Solution: added hashes for Mojave and Catalina to brew formulae.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #261 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
