### PR TITLE
Use stable opam-nix

### DIFF
--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "opam-nix": {
-        "branch": "rvem/optional-test-deps",
+        "branch": "master",
         "description": "A handy nix library to package OCaml software from OPAM repositories",
         "homepage": null,
-        "owner": "balsoft",
+        "owner": "serokell",
         "repo": "opam-nix",
-        "rev": "22dda0bb9661a7a1150f14f3ada497ddb4d8acdd",
-        "sha256": "02nj1fmggl0amrsn19r5dbnmm0amzbdyx0h1gd6czfbhfxb2acfw",
+        "rev": "bdd7e6730bdf0ea91ada3ebc68387424b087c9f8",
+        "sha256": "1wda717d6391vbgrp0vcv27pxfj4xy1511mssky8ll3iy7i851hn",
         "type": "tarball",
-        "url": "https://github.com/balsoft/opam-nix/archive/22dda0bb9661a7a1150f14f3ada497ddb4d8acdd.tar.gz",
+        "url": "https://github.com/serokell/opam-nix/archive/bdd7e6730bdf0ea91ada3ebc68387424b087c9f8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "opam-repository": {


### PR DESCRIPTION
## Description
Problem: PR in opam-nix was finally merged and now we can use its stable
version.

Solution: Use stable version of opam-nix from master branch.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
