### PR TITLE
Granada mainnet activation

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -451,7 +451,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = "a"
+    letter_version = "b"
 
     def __init__(
         self,

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -15,7 +15,7 @@ from .systemd import Service, ServiceFile, SystemdUnit, Unit, Install
 
 networks = ["mainnet", "florencenet", "granadanet"]
 networks_protos = {
-    "mainnet": ["009-PsFLoren"],
+    "mainnet": ["009-PsFLoren", "010-PtGRANAD"],
     "florencenet": ["009-PsFLoren"],
     "granadanet": ["010-PtGRANAD"],
 }

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: granada will be activated on mainnet very soon. We need to support an automatic switchover.

Solution: added `010-PtGRANAD` to the list of mainnet protocols.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
