### PR TITLE
[#267] Change suggested keyserver for checking

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -13,7 +13,7 @@ let
     All the other binaries target x86_64.
 
     Release artifacts are signed with the following key: 0x7EAF9B150ACE940CF8C008A0BF847A85AC7BF43E.
-    You can check it on http://keys.gnupg.net/.
+    You can check it on http://keyserver.ubuntu.com/.
 
     Descriptions for binaries included in this release:
     ${builtins.concatStringsSep "\n"


### PR DESCRIPTION
## Description
Problem: http://keys.gnupg.net/ seems to be dead. As a result users
cannot import the key and check releases artifacts.

Solution: Push key to a bunch of key servers and point to a working one
in the release message.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #267

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).