### PR TITLE
Add bottles hashes for v9.5

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "2e08dcff04997a400820216948958b3694e7aa5ef30e5b5647d23bd0b0c39f43"
+    sha256 cellar: :any, catalina: "35ce88b816ef36504270db24596c166d76510a99346f223a5564aa3e8e219fd3"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "c9f404944ec31ce477b0a7b99d5177f4708eae065e49dbe3941f7560f41f42f5"
+    sha256 cellar: :any, catalina: "1794eb62fdbf16d5b3f32552f262ff3bf7c518677e52b837388063c52db5daa2"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "d434bee13221dfcc0b85330d25a3cb91a12842a8e7435b174e101c4c6143e726"
+    sha256 cellar: :any, catalina: "c07960b53249f7dece49247bc700752d5765e80fa908994049d2cac22b83addc"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "c061a18b97913954910797b92dc622c89d14ac13a50dc3f806a8d3b2b07ca737"
+    sha256 cellar: :any, catalina: "438f181dda7e8519b71673ee916cc1381f2a5cfcc054d587b8910bd3a4da2805"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "53fa0ba24752bbfa4c824143cb90cf05609eff11af116d4dc6b0ccd63b92572e"
+    sha256 cellar: :any, catalina: "7bdfb2e9deaad76d8ce18aa6d9f7d9c19309fd15aa4a6fc985ca052d128dc327"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "696797b23a5dbf3473c41c3820d477638b116864fa90e145db4cd2dbb13fef78"
+    sha256 cellar: :any, catalina: "5b3d5bbe2615bc249706bd49a3fc22eee9b82047a5f6f6b1264bd9ce8ef575d0"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "4f9c9024e9d8e9eb766ef886c1af07c0fc4bbd696f58774670e8eef70a9868e9"
+    sha256 cellar: :any, catalina: "2c869a759e3972b4c5a47adf98e926773b9dc55d7aa03583908be90ada0ab7dd"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, mojave: "ab6928913c0664f6851b1107d6e54bdbf04d728b584bb3caab730eba5ebe46c2"
+    sha256 cellar: :any, catalina: "27dc146e3d5aee49a42787d92b50f13ed4cef23a4c4017ac234e32b522970f89"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "3814b110429d89257d7d44cfa8e1f24e9c8feb1fb1f4f41177e9ce8f138ce528"
+    sha256 cellar: :any, catalina: "b77f4c628aca357faf95081a33714eaf3282d558af8daba91e9a9408bdb7145e"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "a7ae4987b50f0e68578e951d39ac44054988b396d5d063573157abd7cf8a459e"
+    sha256 cellar: :any, catalina: "d8cabacf9e64328f88d520d973429063ccdd17aa97b091969ef21d3df302af59"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "62888b23d111b3d7ec4f181684f31e87a074ef17eb332266ff7cf4a28dc2a8ea"
+    sha256 cellar: :any, catalina: "9c7bcc58c252c0aa4f2ffd374508e99087acadc97e08c82fe433be9aa5d0205c"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "a91d5a33d657267a4bbe00405a323cd3eedac712e8d804ee0d6e1862f62ad9d8"
+    sha256 cellar: :any, catalina: "7abcac7bd53591b11a7134edbab68ffa3355cb81b8e75e7b7a1b236482ab41b4"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: Bottles for v9.5 was built and added to the latest release, but
formulae lack their hashes.

Solution: Add hashes for Mojave and Catalina bottles to them.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #266

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
