### PR TITLE
9.7 release

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -10,9 +10,9 @@ class TezosAccuser009Psfloren < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosAccuser010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -10,9 +10,9 @@ class TezosAdminClient < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -10,9 +10,9 @@ class TezosBaker009Psfloren < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosBaker010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -10,9 +10,9 @@ class TezosClient < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -10,9 +10,9 @@ class TezosCodec < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -10,9 +10,9 @@ class TezosEndorser009Psfloren < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosEndorser010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-node-florencenet.rb
+++ b/Formula/tezos-node-florencenet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeFlorencenet < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node-granadanet.rb
+++ b/Formula/tezos-node-granadanet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeGranadanet < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeMainnet < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -10,9 +10,9 @@ class TezosNode < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -10,9 +10,9 @@ class TezosSandbox < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttp < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttps < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerTcp < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerUnix < Formula
   url "file:///dev/null"
-  version "v9.6-1"
+  version "v9.7-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -10,9 +10,9 @@ class TezosSigner < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.6", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v9.7", :shallow => false
 
-  version "v9.6-1"
+  version "v9.7-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -60,9 +60,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "refs/tags/v9.6",
+        "ref": "refs/tags/v9.7",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "af8891d9a11fe9e96dd4e0d6a54f095ca4d6f23b",
+        "rev": "853629c2c4db0003b073cce0dddbfb69e73d3275",
         "type": "git"
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a new 9.7 release in tezos-packaging.

### Changes related to the creation of a release (conditional)

- [x] I updated Tezos sources and opam-repository (if needed) revisions in [sources.json](/serokell/tezos-packaging/tree/master/nix/nix/sources.json).
    The opam-repository revision should be the same as the one defined in
    [`tezos/tezos`](https://gitlab.com/tezos/tezos/-/blob/master/scripts/version.sh) for the relevant tag.
- [x] I removed old bottles hashes from the brew formulas in [Formula directory](/serokell/tezos-packaging/tree/master/Formula).
- [x] I updated `url :tag` and `version`s in brew formulas.
- [x] I updated release number in [meta.json](/serokell/tezos-packaging/tree/master/meta.json).
- [x] If the native release version was updated, I reset the `letter_version` in [model.py](/serokell/tezos-packaging/tree/master/docker/package/model.py).
- [x] I removed native-packaging-related steps from CI in case opam-repository wasn't updated yet.

#### In case the new Tezos release provides a new protocol and corresponding testnet

- [x] I supported new protocol in [protocols.json](/serokell/tezos-packaging/tree/master/protocols.json).
- [x] I supported new protocol and testnet in native packaging.
- [x] I supported new protocol and testnet in brew formulas.
- [x] I added tests for the new protocol and testnet.

### Things to do after this release PR is merged

#### Create a new release in this repository

- [ ] I created a new release that is based on the latest autorelease created by the CI.
- [ ] I enabled native-packaging-related CI steps after opam-repository got updated.

#### Update brew bottles and repository mirrors

- [ ] I compiled brew bottles for all required macOS versions using [`build-bottles.sh`](/serokell/tezos-packaging/tree/scripts/build-bottles.sh)
      script and uploaded them to the created release.
      Note that for this you'll need a macOS machine running each required version.
- [ ] I added new bottles sha256 hashes to the brew formulas.
- [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
      [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.

#### Publish new native packages

Once [opam-repository](https://opam.ocaml.org/packages/) is updated with the new version of Tezos packages.

- [ ] I published new Ubuntu packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#source-packages-and-publishing-them-on-launchpad-ppa).
- [ ] I published new Fedora packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#srcrpm-packages).

#### Update documentation

- [x] I updated [README.md](/serokell/tezos-packaging/tree/master/README.md).
- [x] I updated [baking doc](/serokell/tezos-packaging/tree/master/docs/baking.md).
