### PR TITLE
Add brew bottle hashes for v9.7

### DIFF
--- a/Formula/tezos-accuser-009-PsFLoren.rb
+++ b/Formula/tezos-accuser-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosAccuser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser009Psfloren.version}/"
+    sha256 cellar: :any, catalina: "4c425010a18cd5c5d2d9b2a2ca7676ec16c0599bfd02d14e3117e3930427ad59"
+    sha256 cellar: :any, mojave: "eeccf2cc71af74d19aefb313f709656ae1a629fe8987454cc4acf3e61a70e197"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, catalina: "42cc54452e56f4deffa9cec77878c83917fec4b7ccc5f30f2499083892500983"
+    sha256 cellar: :any, mojave: "a0b231e140fe5593a005888d9218abbbd96e7e6f1dc409d6238b686d3e9420ea"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, catalina: "153a87b42e3c317d709ccb09952eb53097efcb2fcb7d9e7764601822db8b709e"
+    sha256 cellar: :any, mojave: "face98241d6ac1548671f6762585ca2c4e596b3b46d027eed8b720f46b97edff"
   end
 
   def make_deps

--- a/Formula/tezos-baker-009-PsFLoren.rb
+++ b/Formula/tezos-baker-009-PsFLoren.rb
@@ -27,6 +27,8 @@ class TezosBaker009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker009Psfloren.version}/"
+    sha256 cellar: :any, catalina: "4a0e0f0f28995b4423b2dfcd3cb503522572796cc4af4205449c2eb578886764"
+    sha256 cellar: :any, mojave: "4e67a731854ebb0353b7fc1bc049851a7734c28bf5aff854b3c266490b763c00"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, catalina: "3e940115120ae7d693a89b07622d8ae370d0aeedc92560931081ab3db2ef0dfa"
+    sha256 cellar: :any, mojave: "3896bd4c1339fffbd59b9a498fc58cd942a60f22a802e3b4bc3d1c467a80976d"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, catalina: "b8a22c9f820dc9f7fd6a16699664bf0a0b85f04fac451a8af5a4d77e4d6ca2ac"
+    sha256 cellar: :any, mojave: "4db24bdc238e821fd21b1e62de26e1df66db14e78acd5a69db373da7c57f0c29"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, catalina: "f751d216fdc780dbc1efc86616958dbed979f65e5ff50af694e737bfb18bd8c8"
+    sha256 cellar: :any, mojave: "ab908e2b28e574ebff76d3f44907ec0c0107b9141c4082db547ee0dec42b8e1a"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-009-PsFLoren.rb
+++ b/Formula/tezos-endorser-009-PsFLoren.rb
@@ -28,6 +28,8 @@ class TezosEndorser009Psfloren < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser009Psfloren.version}/"
+    sha256 cellar: :any, catalina: "194dc41998cd5fc7b3fd38b2b4c2d7b8740de53846abcbc8078a8f6466419997"
+    sha256 cellar: :any, mojave: "ec2a569b632e3d29faee81e02dfd7c6b5f4a0bc132e5247ea922db74d193a587"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, catalina: "d154834be47a198dd7e97c2a4240495f0be162e202c706cf0e7bed085e2f8a01"
+    sha256 cellar: :any, mojave: "b57e18413dcc010e2a4c1a51b21db0c31918e4c7a39749691f9ef2150c2d3b8c"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, catalina: "4c5e6f1539d5722a33bff40c0554604d7c15740d532085ea1758327de7a60b79"
+    sha256 cellar: :any, mojave: "70fa0dfbb1b9d3f2fd16b246220952ed09c36056f679218a97dc925b24eab5a5"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, catalina: "721dc3c0e44b2620746fdfa465c9db639736f2284d68fb0ab6afabef606895da"
+    sha256 cellar: :any, mojave: "19264d5a79356934d2c5b5463dfb04386e89a7e5f999c12a5a5c877d92816188"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, catalina: "e399b8b774d72a0ce2ff42a8e5831c9b587a21de8e246c4805223cf22f6553eb"
+    sha256 cellar: :any, mojave: "fd48ee35d9deb08fa72b86486715799dfdccecdd34358fbae963162588a2a4e6"
   end
 
   def make_deps


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: v9.7 bottles have been built and added to the latest release, but their hashes are not yet in the formulae.

Solution: added hashes for Mojave and Catalina to brew formulae.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #271 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
