### PR TITLE
Use Github Actions for checking and building homebrew bottles

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -70,18 +70,6 @@ steps:
      queue: "arm64-build"
    only_changes: *static_binaries_changes_regexes
 
- - label: check brew formulas
-   commands:
-     # Check all formulas except 'tezos.rb' because it's a base class for all other formulas
-     - find ./Formula -type f -name "*.rb" -exec ruby -c {} +
-     # All formulas share the same source URL inherited by the Tezos class, so it's fine
-     # to fetch sources for only one formula
-     - brew fetch -s ./Formula/tezos-client.rb
-   agents:
-     queue: "x86_64-darwin"
-   only_changes:
-   - Formula/.*.rb
-
  - label: test nixos modules
    commands:
    - nix-build tests/tezos-modules.nix --no-out-link

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -1,0 +1,22 @@
+name: Build homebrew bottles
+on:
+  # Run when a release is tagged
+  push:
+    tags:
+      - "v*"
+jobs:
+  build-bottles:
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build bottles
+        run: ./scripts/build-bottles.sh
+
+      - name: Upload bottles to Github Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: homebrew-bottles
+          path: '*.bottle.*'
+

--- a/.github/workflows/check-formulas.yml
+++ b/.github/workflows/check-formulas.yml
@@ -1,0 +1,21 @@
+name: Check homebrew formulas
+on:
+  # Run on any push which changes related files
+  push:
+    paths:
+      - 'Formula/*.rb'
+      - '.github/workflows/check-formulas.yml'
+jobs:
+  check-formulas:
+    runs-on: macos-10.15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check formula syntax
+        run: ruby -c ./Formula/*.rb
+
+      - name: Check formula source
+        # All formulas share the same source URL, so it's fine to fetch sources
+        # for only one formula
+        run: brew fetch --formula -s ./Formula/tezos-client.rb


### PR DESCRIPTION
Replaces buildkite step for checking homebrew formulas with a Github Actions workflow, and adds another workflow to build and export bottles using catalina runners provided by github. Github does not provide mojave runners, so for mojave we'll still have to build bottles ourselves. And the bottles are only built on master branch because it takes a long time, but here's an example of the workflow running: https://github.com/serokell/tezos-packaging/runs/3260140954.

The bottles are exported as a workflow artifact and can be downloaded from the workflow page. It would be nice to attach them to the pre-release automatically, but I don't know if there is a simple way to do it, because releases are created from buildkite, and buildkite attaches some of its artifacts as well, so we can't really synchronize it with github actions.

Also, brew has a special `brew test-bot` command which we could use, it is intended for setting up a clean environment in CI and running all checks automatically, but I tried using it and it's not really convenient, because it does not give a clear way to configure what you want it to do. It's simpler to just run `brew install` in CI.

Related issue: https://issues.serokell.io/issue/TM-563.