### PR TITLE
Fix opam-repository sha256 in sources.json

### DIFF
--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -42,7 +42,7 @@
         "owner": "ocaml",
         "repo": "opam-repository",
         "rev": "d2b022bcd8e39f765da6df49a005a3bb88246097",
-        "sha256": "1rs30hqml5sx0j0v2w39r705lacyvb9nhn55fknmvhn18bj3vz9w",
+        "sha256": "07w0lm4y7kfbnph8fds8vhlbhnfxipbpj85fg6d6h04nppjcnzb3",
         "type": "tarball",
         "url": "https://github.com/ocaml/opam-repository/archive/d2b022bcd8e39f765da6df49a005a3bb88246097.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"


### PR DESCRIPTION
## Description

The sha256 for opam-repository appears to be incorrect. I'm not sure how it happened, but we need to fix it.

## Related issue(s)

None

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
