### PR TITLE
[#274] Package static binaries

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -88,59 +88,59 @@ steps:
    # files from nix/ are massively used in tests ifrastructure
    - nix/.*
 
-# - label: test deb source packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
-#   artifact_paths:
-#     - ./out/*
-#   branches: "!master"
-#   timeout_in_minutes: 60
-#   agents:
-#     queue: "docker"
-#   only_changes: &native_packaging_changes_regexes
-#   - docker/package/.*
-#   - docker/docker-tezos-packages.sh
-#   - meta.json
-#   - protocols.json
-#   - nix/nix/sources.json
-# - label: test deb binary packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   # Building all binary packages will take significant amount of time, so we build only one
-#   # in order to ensure package generation sanity
-#   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-010-PtGRANAD
-#   - rm -rf out
-#   # It takes much time to build binary package, so we do it only on master
-#   branches: "master"
-#   timeout_in_minutes: 90
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
-# - label: test rpm source packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   - ./docker/docker-tezos-packages.sh --os fedora --type source
-#   artifact_paths:
-#     - ./out/*
-#   branches: "!master"
-#   timeout_in_minutes: 60
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
-# - label: test rpm binary packages via docker
-#   commands:
-#   - eval "$SET_VERSION"
-#   # Building all binary packages will take significant amount of time, so we build only one
-#   # in order to ensure package generation sanity
-#   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-010-PtGRANAD
-#   - rm -rf out
-#   # It takes much time to build binary package, so we do it only on master
-#   branches: "master"
-#   timeout_in_minutes: 90
-#   agents:
-#     queue: "docker"
-#   only_changes: *native_packaging_changes_regexes
+ - label: test deb source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 60
+   agents:
+     queue: "docker"
+   only_changes: &native_packaging_changes_regexes
+   - docker/package/.*
+   - docker/docker-tezos-packages.sh
+   - meta.json
+   - protocols.json
+   - nix/nix/sources.json
+ - label: test deb binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-010-PtGRANAD
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
+ - label: test rpm source packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   - ./docker/docker-tezos-packages.sh --os fedora --type source
+   artifact_paths:
+     - ./out/*
+   branches: "!master"
+   timeout_in_minutes: 60
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
+ - label: test rpm binary packages via docker
+   commands:
+   - eval "$SET_VERSION"
+   # Building all binary packages will take significant amount of time, so we build only one
+   # in order to ensure package generation sanity
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-010-PtGRANAD
+   - rm -rf out
+   # It takes much time to build binary package, so we do it only on master
+   branches: "master"
+   timeout_in_minutes: 90
+   agents:
+     queue: "docker"
+   only_changes: *native_packaging_changes_regexes
 
  - label: create auto pre-release
    commands:

--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -4,8 +4,7 @@
 
 FROM fedora:32
 RUN dnf update -y
-RUN dnf install -y libev-devel gmp-devel hidapi-devel libffi-devel m4 perl pkg-config \
-  rpmdevtools python3 wget opam rsync which cargo
+RUN dnf install -y rpmdevtools wget
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging
@@ -13,10 +12,6 @@ COPY meta.json /tezos-packaging/meta.json
 COPY protocols.json /tezos-packaging/protocols.json
 WORKDIR /tezos-packaging/docker
 ENV OPAMROOT "/tezos-packaging/docker/opamroot"
-RUN opam init --bare --yes --disable-sandboxing
-RUN opam switch create ocaml-base-compiler.4.10.2
-RUN opam switch set ocaml-base-compiler.4.10.2
-RUN opam install opam-bundle=0.4 --yes
 COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts

--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -4,11 +4,7 @@
 
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN apt-get update && apt-get install -y libev-dev libgmp-dev libhidapi-dev libffi-dev m4 perl pkg-config \
-  debhelper dh-make dh-systemd devscripts autotools-dev python3 python3-distutils wget rsync
-RUN wget https://github.com/ocaml/opam/releases/download/2.0.8/opam-2.0.8-x86_64-linux -O /usr/bin/opam && chmod +x /usr/bin/opam
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository ppa:ubuntu-mozilla-security/rust-next -y && apt-get update && apt-get -y install cargo
+RUN apt-get update && apt-get install -y debhelper dh-make dh-systemd devscripts autotools-dev wget
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging
@@ -16,10 +12,6 @@ COPY meta.json /tezos-packaging/meta.json
 COPY protocols.json /tezos-packaging/protocols.json
 WORKDIR /tezos-packaging/docker
 ENV OPAMROOT "/tezos-packaging/docker/opamroot"
-RUN opam init --bare --yes --disable-sandboxing
-RUN opam switch create ocaml-base-compiler.4.10.2
-RUN opam switch set ocaml-base-compiler.4.10.2
-RUN opam install opam-bundle=0.4 --yes
 COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -43,21 +43,13 @@ else:
 package_to_build = args.package
 source_archive = args.sources
 
+# At the moment we package static binaries
 if is_ubuntu:
-    run_deps = ["libev-dev", "libgmp-dev", "libhidapi-dev", "libffi-dev"]
+    run_deps = []
 else:
-    run_deps = ["libev-devel", "gmp-devel", "hidapi-devel", "libffi-devel"]
-build_deps = [
-    "make",
-    "m4",
-    "perl",
-    "pkg-config",
-    "wget",
-    "unzip",
-    "rsync",
-    "gcc",
-    "cargo",
-]
+    run_deps = []
+build_deps = ["make", "wget"]
+
 common_deps = run_deps + build_deps
 
 ubuntu_versions = [


### PR DESCRIPTION
## Description
Problem: We don't want to rely on Tezos packages in the opam-repository
since it's getting updates with significant delays.

Solution: Package static binaries from our releases as a permanent
solution.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #274 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
