### PR TITLE
[#291] Automatic update node storage

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -168,7 +168,7 @@ def mk_node_unit(suffix, env, desc):
             environment=env,
             exec_start="/usr/bin/tezos-node-start",
             exec_start_pre=["/usr/bin/tezos-node-prestart"],
-            timeout_start_sec="450s",
+            timeout_start_sec="2400s",
             state_directory="tezos",
             user="tezos",
         ),

--- a/docker/package/scripts/tezos-node-prestart
+++ b/docker/package/scripts/tezos-node-prestart
@@ -8,6 +8,9 @@ set -euo pipefail
 
 node="/usr/bin/tezos-node"
 
+"$node" upgrade --data-dir "$DATA_DIR" storage
+rm -rf "$DATA_DIR/lmdb_store_to_remove"
+
 if [[ ! -f "$DATA_DIR/identity.json" ]]; then
     "$node" identity generate --data-dir "$DATA_DIR"
 fi


### PR DESCRIPTION
## Description
Problem: 9.* to 10.* upgrade requires a storage upgrade.
We want to automate this upgrade process.

Solution: Check the current storage version in the node service pre-start
script and perform an upgrade in case it's needed.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #291 (will be resolved, once corresponding updated package is published)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
