### PR TITLE
[#284] Add script automating bottle hash insertion

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -22,6 +22,10 @@ steps:
    - tests/buildkite/.*
  - label: build utils
    command: nix-build nix/util/* --no-out-link
+ - label: check auto-inserting bottle hashes
+   commands:
+   - cd tests/bottle-hashes/
+   - ./test-hash-insert.sh
 
  - label: build via nix
    commands:

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -1,0 +1,31 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script takes a directory where the bottles are stored as its argument.
+# Run it from the base directory (tezos-packaging).
+
+if [[ -d ./Formula ]]
+then
+    if [[ -d "$1" ]]
+    then
+        regex="(tezos-.*)-v.*\.(catalina|mojave)\.bottle\.tar\.gz"
+        for bottle in "$1"/tezos-*.bottle.tar.gz; do
+            if [[ $bottle =~ $regex ]]; then
+                bottle_hash=`sha256sum "$bottle" | cut -d " " -f 1`
+                formula_name="${BASH_REMATCH[1]}"
+                os="${BASH_REMATCH[2]}"
+
+                if [[ -f "./Formula/$formula_name.rb" ]]; then
+                    line="\    sha256 cellar: :any, $os: \"$bottle_hash\""
+                    sed -i "/root_url.*/a $line" ./Formula/$formula_name.rb
+                fi
+            fi
+        done
+    else
+        echo "The passed directory $1 does not exist."
+    fi
+else
+    echo "Please run this script from the base directory (tezos-packaging)."
+fi

--- a/tests/bottle-hashes/test-hash-insert.sh
+++ b/tests/bottle-hashes/test-hash-insert.sh
@@ -1,0 +1,82 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script tests ../../scripts/bottle-hashes.sh by generating
+# a dummy brew bottle, running bottle-hashes.sh on it, and checking
+# that the test brew formula now has the expected information.
+
+bottle_dir="./bottles"
+
+mkdir -p $bottle_dir
+mkdir -p ./Formula
+
+# Generate a dummy formula
+formula_name="tezos-hash-test"
+
+cat >./Formula/$formula_name.rb <<EOL
+class TezosHashTest < Formula
+  homepage "https://github.com/serokell/tezos-packaging"
+
+  url "https://github.com/serokell/tezos-packaging", :tag => "v0.0", :shallow => false
+
+  version "v0.0-1"
+
+  desc "Dummy formula to test automated bottle hash insertion"
+
+  bottle do
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosHashTest.version}/"
+  end
+
+  def install
+  end
+end
+EOL
+
+catalina_bottle="$formula_name-v0.0-0.catalina.bottle.tar.gz"
+mojave_bottle="$formula_name-v0.0-0.mojave.bottle.tar.gz"
+
+# Generate some dummy bottles
+dd if=/dev/urandom of=$bottle_dir/$catalina_bottle count=2000 status=none
+dd if=/dev/urandom of=$bottle_dir/$mojave_bottle count=2000 status=none
+
+# Run the hash inserting script
+../../scripts/bottle-hashes.sh $bottle_dir
+
+# Assert the info was inserted correctly
+catalina_hash="$(sha256sum $bottle_dir/$catalina_bottle | cut -d " " -f 1)"
+mojave_hash="$(sha256sum $bottle_dir/$mojave_bottle | cut -d " " -f 1)"
+
+expected_formula=$(cat << EOF
+class TezosHashTest < Formula
+  homepage "https://github.com/serokell/tezos-packaging"
+
+  url "https://github.com/serokell/tezos-packaging", :tag => "v0.0", :shallow => false
+
+  version "v0.0-1"
+
+  desc "Dummy formula to test automated bottle hash insertion"
+
+  bottle do
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosHashTest.version}/"
+    sha256 cellar: :any, mojave: "$mojave_hash"
+    sha256 cellar: :any, catalina: "$catalina_hash"
+  end
+
+  def install
+  end
+end
+EOF
+)
+
+if [[ $(< ./Formula/$formula_name.rb) != "$expected_formula" ]]; then
+    echo "bottle-hashes.sh did not produce the expected output. Expected:"
+    echo "$expected_formula"
+    echo -e "\nGot:"
+    cat ./Formula/$formula_name.rb
+    exit 1
+fi
+
+rm -r ./Formula
+rm -r ./bottles


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: every time after a new release, we build brew bottles,
and their SHA256 hashes should be added to the brew formulae.
Right now we do this manually, but it's a tedious and error-prone
process that would be nice to automate.

Solution: added a bash script that can do this. It takes a directory
where the bottle.tar.gz files are placed as its argument and inserts
the computed hash for the respective OS into the right formula.
It is supposed to be run from the base directory (tezos-packaging).

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #284 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
