### PR TITLE
Add brew bottle hashes for v10.1

### DIFF
--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "64179ce91fd3448d141cf8a5e3ca2bcbdc635cd4878af978025a5424a46e469f"
+    sha256 cellar: :any, catalina: "528626dee856551e823bec4b842ebdd0f8845876ce682897aa240c7a83ab4982"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "a4a6ac7883b335fb6a68dd91874f50cb2d5eaf742a290887bb291772bf7a8d52"
+    sha256 cellar: :any, catalina: "13ec405a5eff913adfd6b889ec50360242b201663ecb9226b73559e595d4cb62"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "389e7ed6281ac1ba96fb803b316e9576570ce4f748f0622b28ca6256e1581801"
+    sha256 cellar: :any, catalina: "aeb1ae3f4ea83c9e2748f1e334ec2b593983620ae8a75d7aac51f975a17b9b3b"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "e1460b388f585ee32a872794049298444b95cf004b3e83b7862622bccd975a6a"
+    sha256 cellar: :any, catalina: "c70ef3e990f7e183440792952af9f76eae80315dae1f1bf3fcef7a6e716c8bd7"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "50e954c8b12cb2546ceebaae4b1017464fe019e375d12e9eebb530aae6cf5766"
+    sha256 cellar: :any, catalina: "8defba198305e866140c24cd7fda0b26009bab2f0fb13092693fb81a5dec7552"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "208fff9729933a015bf32e0654514753b8190e7a1ba1dc62fbd837627a0bf6d8"
+    sha256 cellar: :any, catalina: "9daec205ac076986e4b35d51bd001c7622e7b51c2482c365818f053b8f0569fc"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "31454d57082c3a9aad50af24cdbe58f4fe9bc960cae4be0458a51daeced6b4ac"
+    sha256 cellar: :any, catalina: "799189451f71ed61918460ed0d64c1e4b465d3d9f4e5660a62ff5de48b6c6065"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "09c16afce90f3191a743108957e0b220daddcbcaee2196e4fa449024a4912fb7"
+    sha256 cellar: :any, catalina: "f0eb0c30bfa061822984fe6afecd6f0cf79f428bcb773c5ea4263347080eed68"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "fccdbd84e9e7edcb558bf7bc93e1e758eb71b4b897a68b8d54d3f9eba442c7a3"
+    sha256 cellar: :any, catalina: "89d34c38400ddc1ce34551e7e4883056c5eddad5db8a94618508c7538160019f"
   end
 
   def make_deps


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: v10.1 bottles have been built and added to the latest release, but their hashes are not yet in the formulae.

Solution: added hashes for Mojave and Catalina to brew formulae.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #294

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
