### PR TITLE
[#285] Build mojave bottles and attach bottles to releases in CI

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+steps:
+ - label: Build bottles
+   key: build-bottles
+   agents:
+     queue: "x86_64-darwin"
+   if: build.tag =~ /^v.*/
+   commands:
+   - ./scripts/build-bottles.sh
+   artifact_paths:
+     - '*.bottle.*'
+
+ - wait
+
+ - label: Attach bottles to the release
+   if: build.tag =~ /^v.*/
+   commands:
+   - buildkite-agent artifact download --step build-bottles "*" .
+   - nix-shell ./scripts/shell.nix
+       --run 'gh release upload "$BUILDKITE_TAG" *.bottle.*'

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+permissions:
+  # Restrict GITHUB_TOKEN permissions
+  contents: write
 jobs:
   build-bottles:
     runs-on: macos-10.15
@@ -19,4 +22,9 @@ jobs:
         with:
           name: homebrew-bottles
           path: '*.bottle.*'
+
+      - name: Attach bottles to the release
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh release upload "${GITHUB_REF#refs/tags/}" *.bottle.*
 


### PR DESCRIPTION
Problem: we build homebrew bottles for catalina in CI, but not for mojave. And the bottles have to be attached to the releases manually.

Solution: add buildkite pipeline which builds mojave bottles when a tag is pushed, and add automatic attachment for both catalina and mojave.

In buildkite it's a separate pipeline `tezos-packaging-tags`, which runs when a tag is pushed rather than a branch, it takes jobs from `.buildkite/pipeline-for-tags.yml` file.

Resolves #285