### PR TITLE
v10.2 release

### DIFF
--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosAccuser010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
-    sha256 cellar: :any, mojave: "64179ce91fd3448d141cf8a5e3ca2bcbdc635cd4878af978025a5424a46e469f"
-    sha256 cellar: :any, catalina: "528626dee856551e823bec4b842ebdd0f8845876ce682897aa240c7a83ab4982"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -10,9 +10,9 @@ class TezosAdminClient < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
-    sha256 cellar: :any, mojave: "a4a6ac7883b335fb6a68dd91874f50cb2d5eaf742a290887bb291772bf7a8d52"
-    sha256 cellar: :any, catalina: "13ec405a5eff913adfd6b889ec50360242b201663ecb9226b73559e595d4cb62"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosBaker010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
-    sha256 cellar: :any, mojave: "389e7ed6281ac1ba96fb803b316e9576570ce4f748f0622b28ca6256e1581801"
-    sha256 cellar: :any, catalina: "aeb1ae3f4ea83c9e2748f1e334ec2b593983620ae8a75d7aac51f975a17b9b3b"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -10,9 +10,9 @@ class TezosClient < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
-    sha256 cellar: :any, mojave: "e1460b388f585ee32a872794049298444b95cf004b3e83b7862622bccd975a6a"
-    sha256 cellar: :any, catalina: "c70ef3e990f7e183440792952af9f76eae80315dae1f1bf3fcef7a6e716c8bd7"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -10,9 +10,9 @@ class TezosCodec < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
-    sha256 cellar: :any, mojave: "50e954c8b12cb2546ceebaae4b1017464fe019e375d12e9eebb530aae6cf5766"
-    sha256 cellar: :any, catalina: "8defba198305e866140c24cd7fda0b26009bab2f0fb13092693fb81a5dec7552"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -10,9 +10,9 @@ class TezosEndorser010Ptgranad < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -28,8 +28,6 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
-    sha256 cellar: :any, mojave: "208fff9729933a015bf32e0654514753b8190e7a1ba1dc62fbd837627a0bf6d8"
-    sha256 cellar: :any, catalina: "9daec205ac076986e4b35d51bd001c7622e7b51c2482c365818f053b8f0569fc"
   end
 
   def make_deps

--- a/Formula/tezos-node-granadanet.rb
+++ b/Formula/tezos-node-granadanet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeGranadanet < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeMainnet < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -10,9 +10,9 @@ class TezosNode < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
-    sha256 cellar: :any, mojave: "31454d57082c3a9aad50af24cdbe58f4fe9bc960cae4be0458a51daeced6b4ac"
-    sha256 cellar: :any, catalina: "799189451f71ed61918460ed0d64c1e4b465d3d9f4e5660a62ff5de48b6c6065"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -10,9 +10,9 @@ class TezosSandbox < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
-    sha256 cellar: :any, mojave: "09c16afce90f3191a743108957e0b220daddcbcaee2196e4fa449024a4912fb7"
-    sha256 cellar: :any, catalina: "f0eb0c30bfa061822984fe6afecd6f0cf79f428bcb773c5ea4263347080eed68"
   end
 
   def make_deps

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttp < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttps < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerTcp < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerUnix < Formula
   url "file:///dev/null"
-  version "v10.1-1"
+  version "v10.2-1"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -10,9 +10,9 @@ class TezosSigner < Formula
   end
   homepage "https://gitlab.com/tezos/tezos"
 
-  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.1", :shallow => false
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v10.2", :shallow => false
 
-  version "v10.1-1"
+  version "v10.2-1"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
-    sha256 cellar: :any, mojave: "fccdbd84e9e7edcb558bf7bc93e1e758eb71b4b897a68b8d54d3f9eba442c7a3"
-    sha256 cellar: :any, catalina: "89d34c38400ddc1ce34551e7e4883056c5eddad5db8a94618508c7538160019f"
   end
 
   def make_deps

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -60,9 +60,9 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "tezos": {
-        "ref": "refs/tags/v10.1",
+        "ref": "refs/tags/v10.2",
         "repo": "https://gitlab.com/tezos/tezos",
-        "rev": "59524a1e8b0c41aab02ef2046d72a3db7a409803",
+        "rev": "5bfd311b701015381338e73a30c74415fa493c10",
         "type": "git"
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a new v10.2 release in tezos-packaging.

<!-- Depending on the type of the release some of the points below can be omitted.

E.g. in case we introduce a new changes to our native packages, it's not necessary to bump
used Tezos sources, create a new release in this repository and update brew formulas.
-->

<!-- List issues which are going to be resolved in the new packages from this
release. Write 'None' if there are no related issues.

For example:
Follows #202, #210
-->

Follows #

### Changes related to the creation of a release (conditional)

- [x] I updated Tezos sources and opam-repository (if needed) revisions in [sources.json](/serokell/tezos-packaging/tree/master/nix/nix/sources.json).
    The opam-repository revision should be the same as the one defined in
    [`tezos/tezos`](https://gitlab.com/tezos/tezos/-/blob/master/scripts/version.sh) for the relevant tag.
- [x] I removed old bottles hashes from the brew formulas in [Formula directory](/serokell/tezos-packaging/tree/master/Formula).
- [x] I updated `url :tag` and `version`s in brew formulas.
- [x] I updated release number in [meta.json](/serokell/tezos-packaging/tree/master/meta.json).
- [x] If the native release version was updated, I reset the `letter_version` in [model.py](/serokell/tezos-packaging/tree/master/docker/package/model.py).

#### In case the new Tezos release provides a new protocol and corresponding testnet

- [x] I supported new protocol in [protocols.json](/serokell/tezos-packaging/tree/master/protocols.json).
- [x] I supported new protocol and testnet in native packaging.
- [x] I supported new protocol and testnet in brew formulas.
- [x] I added tests for the new protocol and testnet.

### Things to do after this release PR is merged

<!--
Some of the changes are done after the new release is created, consider following
and checking unfinished points in the merged release PR using this template.
-->

#### Create a new release in this repository

- [ ] I created a new release that is based on the latest autorelease created by the CI.

#### Update brew bottles and repository mirrors

- [ ] I compiled brew bottles for all required macOS versions using [`build-bottles.sh`](/serokell/tezos-packaging/tree/scripts/build-bottles.sh)
      script and uploaded them to the created release.
      Note that for this you'll need a macOS machine running each required version.
- [ ] I added new bottles sha256 hashes to the brew formulas.
- [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
      [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.

#### Publish new native packages

- [ ] I published new Ubuntu packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#source-packages-and-publishing-them-on-launchpad-ppa).
- [ ] I published new Fedora packages, see [these instructions](/serokell/tezos-packaging/tree/master/docker#srcrpm-packages).

#### Update documentation

- [ ] I updated [README.md](/serokell/tezos-packaging/tree/master/README.md).
- [ ] I updated [baking doc](/serokell/tezos-packaging/tree/master/docs/baking.md).
