### PR TITLE
Add brew bottle hashes for v10.2

### DIFF
--- a/Formula/tezos-accuser-010-PtGRANAD.rb
+++ b/Formula/tezos-accuser-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosAccuser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "4ba3a76ae7db229c432039a84a2ca55fbdf93e37d49419201b81d96964eaf18a"
+    sha256 cellar: :any, catalina: "35659c58f1df616e046b836fa239a9d4b8ff47db954577606930c295d59146da"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -27,6 +27,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, mojave: "13d05a8d96a584d1b97e80289e39ead20a57188fa9814eab4d075f22a0642ba4"
+    sha256 cellar: :any, catalina: "c431c23f6b92d8690be76b5135ae1d8569017e3a4c4b01f0aa020d51ddbc6e8b"
   end
 
   def make_deps

--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -27,6 +27,8 @@ class TezosBaker010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "83402ddc80e97fbc6bfc23721776f3db8419f754da62b57aff544180320fb850"
+    sha256 cellar: :any, catalina: "f5846339abc701c3a65524c62eb70a41b0c354ffde5e6601cde3693024e50460"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,6 +27,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, mojave: "654ffbc594b11f563e97119af2aeb304d5a1351625ea2aa3648d1e253ee2d58a"
+    sha256 cellar: :any, catalina: "340b4a52e21a15b7f52c7785179c4226d6a8bc6957f12ba6f5ffb2455e150706"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -27,6 +27,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, mojave: "864e31f9720ceda7d1075e5282eb89aadb57e79903a1c950909be5538d0588a9"
+    sha256 cellar: :any, catalina: "6234e4ecc9453179b4393840459302214acb10661631f96558c0bb68ff31c9ac"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-010-PtGRANAD.rb
+++ b/Formula/tezos-endorser-010-PtGRANAD.rb
@@ -28,6 +28,8 @@ class TezosEndorser010Ptgranad < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser010Ptgranad.version}/"
+    sha256 cellar: :any, mojave: "a047be8cec6b9a03511313a55906462f9e1313efcf787f1b1072288b1d444a09"
+    sha256 cellar: :any, catalina: "c604ffec47910372a3a0c6442fa7090924d4d41eb64c5e1e00fef8c0068c9fc9"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -27,6 +27,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, mojave: "357de6612ea77969189d4f6ea4aa2c50caffcfd6170a3a8c2179c36ccf7f27aa"
+    sha256 cellar: :any, catalina: "48d629b964558f0831420d119699b8aaeed5b2397206946a6e5737f3ed4fb1e7"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -27,6 +27,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, mojave: "536f9184499a3fb993d510de1e88f3e09e2c161d64920f9f1875369d73150e72"
+    sha256 cellar: :any, catalina: "92e1d3123a088e3c897e9bf2f9ed1445007025015ad65c16ea8ea0b83706314c"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -27,6 +27,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, mojave: "9f4feec8809d70275f42c65055f0374f8895a6a35d4f2da65d09e2498547c6a8"
+    sha256 cellar: :any, catalina: "c3ea1246af5ed67feed4fe4bc57bed3bee879ee8b3af180fe80f98f1f2861558"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: v10.2 bottles have been built and added to the latest release,
but their hashes are not yet in the formulae.

Solution: added hashes for Mojave and Catalina to brew formulae.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #298

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
