### PR TITLE
[morley#664] Allow alpha protocol

### DIFF
--- a/nix/build/hacks.nix
+++ b/nix/build/hacks.nix
@@ -229,6 +229,9 @@ rec {
     propagatedBuildInputs = buildInputs;
   });
 
+  tezos-protocol-alpha = osuper.tezos-protocol-alpha.overrideAttrs (o : {
+    buildInputs = o.buildInputs ++ [ tezos-protocol-environment ];
+  });
   tezos-protocol-000-Ps9mPmXa = osuper.tezos-protocol-000-Ps9mPmXa.overrideAttrs (o : {
     buildInputs = o.buildInputs ++ [ tezos-protocol-environment ];
   });
@@ -277,6 +280,9 @@ rec {
   tezos-protocol-genesis = osuper.tezos-protocol-genesis.overrideAttrs (o : {
     buildInputs = o.buildInputs ++ [ tezos-protocol-environment ];
   });
+  tezos-protocol-plugin-alpha = osuper.tezos-protocol-plugin-alpha.overrideAttrs (o : {
+    buildInputs = o.buildInputs ++ [ tezos-protocol-environment ];
+  });
   tezos-protocol-plugin-007-PsDELPH1 = osuper.tezos-protocol-plugin-007-PsDELPH1.overrideAttrs (o : {
     buildInputs = o.buildInputs ++ [ tezos-protocol-environment ];
   });
@@ -294,6 +300,11 @@ rec {
   tezos-validator = osuper.tezos-validator.overrideAttrs
     (o: rec {
       buildInputs = o.buildInputs ++ [ librustzcash ];
+    });
+  tezos-protocol-alpha-parameters = osuper.tezos-protocol-alpha-parameters.overrideAttrs
+    (o: rec {
+      buildInputs = o.buildInputs ++ [ librustzcash ];
+      XDG_DATA_DIRS = "${zcash-params}:$XDG_DATA_DIRS";
     });
   tezos-protocol-006-PsCARTHA-parameters = osuper.tezos-protocol-006-PsCARTHA-parameters.overrideAttrs
     (o: rec {
@@ -332,7 +343,7 @@ rec {
 
   tezos-client = osuper.tezos-client.overrideAttrs
     (o: {
-      buildInputs = o.buildInputs ++ [ librustzcash self.makeWrapper ];
+      buildInputs = o.buildInputs ++ [ librustzcash self.makeWrapper tezos-client-alpha-commands-registration ];
       postInstall = "rm $bin/tezos-admin-client $bin/*.sh";
       postFixup = zcash-post-fixup o;
     });

--- a/protocols.json
+++ b/protocols.json
@@ -1,9 +1,9 @@
 {
   "ignored": [
-    "alpha",
     "demo-counter"
   ],
   "allowed": [
+    "alpha",
     "genesis",
     "genesis-carthagenet",
     "000-Ps9mPmXa",


### PR DESCRIPTION
## Description
Problem: Alpha protocol is now required to run 'tezos-client' in mockup
mode.

Solution: Allow it and adjust hacks.nix.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

https://gitlab.com/morley-framework/morley/-/issues/664
#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).