### PR TITLE
[#286] Automate bottle hashes PR

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -34,6 +34,15 @@ steps:
    - buildkite-agent artifact download "out/*" . --step build-source-packages
    - ./scripts/publish-native-packages.sh out
 
+ - label: Add Mojave bottle hashes to formulae
+   depends_on:
+   - "build-bottles"
+   if: build.tag =~ /^v.*/
+   commands:
+   - buildkite-agent artifact download --step build-bottles "*" .
+   - nix-shell ./scripts/shell.nix
+       --run './scripts/sync-bottle-hashes.sh "$BUILDKITE_TAG" "Mojave"'
+
  - label: Attach bottles to the release
    depends_on:
    - "build-bottles"

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -11,6 +11,14 @@ jobs:
   build-bottles:
     runs-on: macos-10.15
     steps:
+      - name: Install coreutils for macOS # for sha256sum
+        run: brew install coreutils
+
+      - name: Install GNU sed # for the other pipeline compatibility
+        run: |
+          brew install gnu-sed
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -23,8 +31,10 @@ jobs:
           name: homebrew-bottles
           path: '*.bottle.*'
 
+      - name: Add Catalina bottle hashes to formulae
+        run: ./scripts/sync-bottle-hashes.sh "${GITHUB_REF#refs/tags/}" "Catalina"
+
       - name: Attach bottles to the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: gh release upload "${GITHUB_REF#refs/tags/}" *.bottle.*
-

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -6,6 +6,8 @@
 # This script takes a directory where the bottles are stored as its argument.
 # Run it from the base directory (tezos-packaging).
 
+set -e
+
 if [[ -d ./Formula ]]
 then
     if [[ -d "$1" ]]

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -5,5 +5,5 @@
 { pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs { } }:
 with pkgs;
 mkShell {
-  buildInputs = [ gh git rename gnupg dput rpm debian-devscripts which util-linux perl ];
+  buildInputs = [ coreutils gnused gh git rename gnupg dput rpm debian-devscripts which util-linux perl ];
 }

--- a/scripts/sync-bottle-hashes.sh
+++ b/scripts/sync-bottle-hashes.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script takes the new tag and the OS name as its arguments
+# and handles git shenanigans related to syncing two pipelines over a common branch.
+
+set -e
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "Please call this script with the release tag and the OS name."
+    exit 1
+fi
+
+git config user.name "Serokell CI bot" # necessary for pushing
+git config user.email "hi@serokell.io"
+git fetch --all
+
+branch_name="auto/update-brew-formulae-$1"
+
+# Git doesn't have an easy way to check out a branch regardless of whether it exists.
+if ! git switch "$branch_name"; then
+    git switch -c "$branch_name"
+    git push --set-upstream origin "$branch_name"
+fi
+
+# Try to add hashes and push changes upstream. If there is a collision precisely at the time of
+# pushing, that means the other pipeline has raced this one to push. Reset to origin and try again.
+while : ; do
+    git fetch --all
+    git reset --hard origin/"$branch_name"
+    ./scripts/bottle-hashes.sh .
+    git commit -a -m "[Chore] Add $1 hashes to brew formulae"
+    ! git push || break
+done
+
+pr_body="Problem: we have built brew bottles for the new Octez release, but their hashes
+aren't in the formulae yet.
+
+Solution: added the hashes.
+"
+
+set +e
+
+# We create the PR with the first push, when the other pipeline hasn't finished yet.
+# That's why we 'set +e': one of the two times the command will fail.
+gh pr create -B master -t "[Chore] Add bottle hashes for $1" -b "$pr_body"
+
+exit 0

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script takes the new tag as its argument.
+# Run it from the base directory (tezos-packaging).
+
+if [[ -d ./Formula ]]
+then
+    regex="(v.*)-[0-9]*"
+    if [[ $1 =~ $regex ]]; then
+        tag="${BASH_REMATCH[0]}"
+        version="${BASH_REMATCH[1]}"
+        find ./Formula -type f \( -name 'tezos-*.rb' ! -name 'tezos-sapling-params.rb' \) \
+            -exec sed -i "s/version \"v.*\"/version \"$tag\"/g" {} \; \
+            -exec sed -i "s/:tag => \"v.*\"/:tag => \"$version\"/g" {} \; \
+            -exec sed -i "/catalina/d" {} \; \
+            -exec sed -i "/mojave/d" {} \;
+    else
+        echo "The argument does not look like a tag, which should have a form of 'v*-[0-9]*'"
+    fi
+else
+    echo "Please run this script from the base directory (tezos-packaging)."
+fi

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -3,6 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+# TODO: #288 use this script to automate releases PRs
 # This script takes the new tag as its argument.
 # Run it from the base directory (tezos-packaging).
 


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: we need to automate brew bottles-related processes further.
Right now we automatically build and attach the bottles to releases, and we have a script that computes and inserts their hashes to the respective formulae.
It's a natural next step to open the PRs from the CI.

Solution: added a step to each pipeline that should sync the hashes in a common branch, and then open a PR automatically.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #286 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
