### PR TITLE
Release candidate packages publishing instruction

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -121,16 +121,24 @@ into `~/.dput.cf`. In case you already have a config, add the following piece
 to it for the further convenience:
 ```
 [tezos-serokell]
-fqdn			= ppa.launchpad.net
-method			= ftp
-incoming		= ~serokell/ubuntu/tezos
-login			= anonymous
+fqdn        = ppa.launchpad.net
+method      = ftp
+incoming    = ~serokell/ubuntu/tezos
+login       = anonymous
+
+[tezos-rc-serokell]
+fqdn        = ppa.launchpad.net
+method      = ftp
+incoming    = ~serokell/ubuntu/tezos-rc
+login       = anonymous
 ```
 
 Signed files now can be submitted to Launchpad PPA. In order to do that run the following
 command for each `.changes` file:
 ```
 dput tezos-serokell ../out/<package>.changes
+# or tezos-rc-serokell in case the corresponding upstream version is release-candidate
+dput tezos-rc-serokell ../out/<package>.changes
 ```
 
 #### Updating release in scope of the same upstream version
@@ -205,4 +213,6 @@ Read more about setting up `copr-cli` [here](https://developer.fedoraproject.org
 In order to submit source package for building run the following command:
 ```
 copr-cli build @Serokell/Tezos --nowait <path to '.src.rpm' file>
+# or @Serokell/Tezos-rc in case the corresponding upstream version is release-candidate
+copr-cli build @Serokell/Tezos-rc --nowait <path to '.src.rpm' file>
 ```

--- a/docker/package/.dput.cf
+++ b/docker/package/.dput.cf
@@ -23,3 +23,9 @@ fqdn			= ppa.launchpad.net
 method			= ftp
 incoming		= ~serokell/ubuntu/tezos
 login			= anonymous
+
+[tezos-rc-serokell]
+fqdn			= ppa.launchpad.net
+method			= ftp
+incoming		= ~serokell/ubuntu/tezos-rc
+login			= anonymous

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -54,6 +54,12 @@ On Ubuntu:
 sudo add-apt-repository ppa:serokell/tezos
 ```
 
+Alternatively, use packages with release-candidate Tezos binaries:
+```
+# Or use PPA with release-candidate Tezos binaries
+sudo add-apt-repository ppa:serokell/tezos
+```
+
 On Raspberry Pi OS:
 
 ```

--- a/docs/distros/fedora.md
+++ b/docs/distros/fedora.md
@@ -20,6 +20,18 @@ sudo yum install tezos-baker-010-PtGRANAD
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
+## Using release-candidate packages
+
+In order to use packages with the latest release-candidate Tezos binaries,
+use `@Serokell/Tezos-rc` project:
+```
+# use dnf
+sudo dnf copr enable @Serokell/Tezos-rc
+
+# or use yum
+sudo yum copr enable @Serokell/Tezos-rc
+```
+
 ## Systemd services from Fedora packages
 
 Some of the packages provide background `systemd` services, you can read more about them

--- a/docs/distros/ubuntu.md
+++ b/docs/distros/ubuntu.md
@@ -16,6 +16,14 @@ sudo apt-get install tezos-baker-010-ptgranad
 ```
 Once you install such packages the commands `tezos-*` will be available.
 
+## Using release-candidate packages
+
+In order to use packages with the latest release-candidate Tezos binaries,
+use `ppa:serokell/tezos-rc` PPA:
+```
+sudo add-apt-repository ppa:serokell/tezos-rc && sudo apt-get update
+```
+
 ## `tezos-baking` package
 
 As an addition, `tezos-baking` package provides `tezos-baking-<network>` services that orchestrate


### PR DESCRIPTION
## Description
Problem: Native Ubuntu and Fedora packages that we provide no longer
depend on opam-repository and depend only on the upstream repository,
thus we're now able to publish native packages for release-candidate
releases as well.

Solution: Corresponding PPA and Copr project were created, instructions
were updated to mention them in the publishing instructions.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

https://issues.serokell.io/issue/TM-536

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
