### PR TITLE
[#288] Automatic upstream updates

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -51,3 +51,8 @@ steps:
    - buildkite-agent artifact download --step build-bottles "*" .
    - nix-shell ./scripts/shell.nix
        --run 'gh release upload "$BUILDKITE_TAG" *.bottle.*'
+
+ - label: Check for new Tezos release
+   if: build.source == "schedule" && build.branch == "master"
+   commands:
+   - nix-shell ./scripts/shell.nix --run ./scripts/update-tezos.sh

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,15 +36,10 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "opam-repository": {
-        "branch": "master",
-        "description": "Tezos opam-repository fork.",
-        "owner": "tezos",
-        "repo": "opam-repository",
+        "ref": "master",
+        "repo": "https://gitlab.com/tezos/opam-repository",
         "rev": "393349af19bb54e3cb790ac8ef54a72adc71aecf",
-        "sha256": "1b89v9488qq0nxjbr249h8mcm6fgz6dyz6ph83gkf3yi83mpqcv0",
-        "type": "tarball",
-        "url": "https://gitlab.com/tezos/opam-repository/-/archive/393349af19bb54e3cb790ac8ef54a72adc71aecf.tar.gz",
-        "url_template": "https://gitlab.com/<owner>/<repo>/-/archive/<rev>.tar.gz"
+        "type": "git"
     },
     "serokell-nix": {
         "branch": "master",

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -5,5 +5,8 @@
 { pkgs ? import (import ../nix/nix/sources.nix {}).nixpkgs { } }:
 with pkgs;
 mkShell {
-  buildInputs = [ coreutils gnused gh git rename gnupg dput rpm debian-devscripts which util-linux perl ];
+  buildInputs = [
+    coreutils gnused gh git rename gnupg dput rpm debian-devscripts which util-linux perl
+    jq niv
+  ];
 }

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -3,7 +3,6 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-# TODO: #288 use this script to automate releases PRs
 # This script takes the new tag as its argument.
 # Run it from the base directory (tezos-packaging).
 

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -1,0 +1,48 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script fetches the latest tag from the https://gitlab.com/tezos/tezos/ repository,
+# compares it with the version presented in the nix/nix/sources.json, and performs an
+# update if the versions are different
+
+set -e
+
+git config user.name "Serokell CI bot" # necessary for pushing
+git config user.email "hi@serokell.io"
+git fetch --all
+
+# Get latest tag from tezos/tezos
+git clone https://gitlab.com/tezos/tezos.git upstream-repo
+cd upstream-repo
+latest_upstream_tag_hash="$(git rev-list --tags --max-count=1)"
+latest_upstream_tag="$(git describe --tags "$latest_upstream_tag_hash")"
+source scripts/version.sh
+cd ..
+rm -rf upstream-repo
+
+branch_name="auto/$latest_upstream_tag-release"
+
+our_tezos_tag="$(jq -r '.tezos.ref' nix/nix/sources.json | cut -d'/' -f3)"
+
+if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
+  # If corresponding branch doesn't exist yet, then the release PR
+  # wasn't created
+  if ! git rev-parse --verify branch_name; then
+    git switch -c "$branch_name"
+    echo "Updating Tezos to $latest_upstream_tag"
+    cd nix
+    niv update tezos -a ref="refs/tags/$latest_upstream_tag" -a rev="$latest_upstream_tag_hash"
+    niv update opam-repository -a rev="$opam_repository_tag"
+    git commit -a -m "[Chore] Bump Tezos sources to $latest_upstream_tag"
+    cd ..
+    ./scripts/update-brew-formulae.sh "$latest_upstream_tag-1"
+    git commit -a -m "[Chore] Update brew formulae for $latest_upstream_tag"
+    git push --set-upstream origin "$branch_name"
+
+    gh pr create -B master -t "[Chore] $latest_upstream_tag release" -F .github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+  fi
+else
+  echo "Our version is the same as the latest tag in the upstream repository"
+fi


### PR DESCRIPTION
## Description

This PR adds a script that checks if Tezos upstream had a new release and creates
a new PR with basic changes required for the new release.

This script is supposed to be run on schedule with some interval which is TBD.

A test PR created by the CI: https://github.com/serokell/tezos-packaging/pull/311
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #288

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
