### PR TITLE
[Chore] Fix URL for Ubuntu's RCs PPA in docs

### DIFF
--- a/docs/baking.md
+++ b/docs/baking.md
@@ -57,7 +57,7 @@ sudo add-apt-repository ppa:serokell/tezos
 Alternatively, use packages with release-candidate Tezos binaries:
 ```
 # Or use PPA with release-candidate Tezos binaries
-sudo add-apt-repository ppa:serokell/tezos
+sudo add-apt-repository ppa:serokell/tezos-rc
 ```
 
 On Raspberry Pi OS:


### PR DESCRIPTION
## Description

The URL in the baking doc instruction's command to use the PPA for release candidates, is incorrect.

This small fixup corrects it.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
