### PR TITLE
add missing line continuation

### DIFF
--- a/docker/package/scripts/tezos-node-start
+++ b/docker/package/scripts/tezos-node-start
@@ -25,7 +25,7 @@ if [[ -z "${CUSTOM_NODE_CONFIG:-}" ]]; then
         "$node" config update \
                 --data-dir "$DATA_DIR" \
                 --rpc-addr "$NODE_RPC_ADDR" \
-                ${NETWORK:+"--network=$NETWORK"}
+                ${NETWORK:+"--network=$NETWORK"} \
                 "$@"
     fi
 else


### PR DESCRIPTION
`tezos-node-start` script is missing line continuation, as a result arguments are interpreted as a separate command and service fails to start. For example, if we want to modify how rpc is exposed following examples from https://tezos.gitlab.io/user/node-configuration.html?highlight=acl#examples , we may create systemd override:

```sudo systemctl edit tezos-node-hangzhounet.service```

and  provide additional command line parameters like so: 

```
Service]
ExecStart=
ExecStart=/usr/bin/tezos-node-start --rpc-addr 10.0.2.15 --allow-all-rpc 10.0.2.15
```

(Note `ExecStart=` is necessary to clear ExecStart first since it is additive).

Currently service fails to start:

```
Oct 22 10:07:53 tez-h1 systemd[1]: Started Tezos node hangzhounet.
Oct 22 10:07:53 tez-h1 tezos-node-start[42140]: Updating the node configuration...
Oct 22 10:07:59 tez-h1 tezos-node-start[42142]: Oct 22 10:07:59.186 - node.config.validation: the node configuration has been successfully validated.
Oct 22 10:07:59 tez-h1 tezos-node-start[42152]: /usr/bin/tezos-node-start: line 29: --rpc-addr: command not found
Oct 22 10:07:59 tez-h1 systemd[1]: tezos-node-hangzhounet.service: Main process exited, code=exited, status=127/n/a
Oct 22 10:07:59 tez-h1 systemd[1]: tezos-node-hangzhounet.service: Failed with result 'exit-code'.
```

Adding line contunation fixes the issue.
