### PR TITLE
[Chore] Add missing mojave bottle for 010 baker

### DIFF
--- a/Formula/tezos-baker-010-PtGRANAD.rb
+++ b/Formula/tezos-baker-010-PtGRANAD.rb
@@ -28,6 +28,7 @@ class TezosBaker010Ptgranad < Formula
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker010Ptgranad.version}/"
     sha256 cellar: :any, catalina: "57879e69e556439e498baf2172474b04ab1963b8115508f565f2cde2596dff74"
+    sha256 cellar: :any, mojave: "5c17d92a7ccd1f005c241957aa9175b7a61b96ff1e726685b04f58956580dd24"
   end
 
   def make_deps


### PR DESCRIPTION
## Description
Problem: A mojave bottle is missing for the 010 baker formula.

Solution: Add missing bottle hash.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](../../tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
