### PR TITLE
[Chore] fix hangzhou-specific class names in brew formulae

### DIFF
--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-class TezosAccuser011Pthangzh < Formula
+class TezosAccuser011Pthangz2 < Formula
   @all_bins = []
 
   class << self
@@ -26,7 +26,7 @@ class TezosAccuser011Pthangzh < Formula
   desc "Daemon for accusing"
 
   bottle do
-    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangzh.version}/"
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangz2.version}/"
   end
 
   def make_deps

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-class TezosBaker011Pthangzh < Formula
+class TezosBaker011Pthangz2 < Formula
   @all_bins = []
 
   class << self
@@ -26,7 +26,7 @@ class TezosBaker011Pthangzh < Formula
   desc "Daemon for baking"
 
   bottle do
-    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangzh.version}/"
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangz2.version}/"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-class TezosEndorser011Pthangzh < Formula
+class TezosEndorser011Pthangz2 < Formula
   @all_bins = []
 
   class << self
@@ -27,7 +27,7 @@ class TezosEndorser011Pthangzh < Formula
   desc "Daemon for endorsing"
 
   bottle do
-    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangzh.version}/"
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangz2.version}/"
   end
 
   def make_deps


### PR DESCRIPTION
## Description

Problem: class names in brew formulae for hangzhou don't match
their respective filenames.

Solution: fix up the class names.

## Related issue(s)

Related to #324

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
