### PR TITLE
[Chore] Don't sign commits in bottles sync script 

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -176,5 +176,14 @@ steps:
    if: |
      build.branch == "master" &&
        (build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-rc.*-release/ ||
-          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]-rc.*/)
+          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-rc.*/)
    command: git push git@github.com:serokell/tezos-packaging-rc.git
+
+ # To avoid race-conditions for the gpg key between jobs which sometimes leads to a weird errors
+ - wait
+ # We need to sign commits that update brew formulae separately
+ - label: Sign formulae update commits
+   if: build.branch =~ /^auto\/update-brew-formulae-.*/
+   commands:
+   - nix-shell ./scripts/shell.nix
+       --run './scripts/sign-commits.sh'

--- a/scripts/sign-commits.sh
+++ b/scripts/sign-commits.sh
@@ -1,0 +1,36 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+# This script signs all commits in the current 'BUILDKITE_BRANCH'
+
+set -e
+
+git config user.name "serokell-bot" # necessary for pushing
+git config user.email "tezos-packaging@serokell.io"
+
+# Try to sign and push signed commits, retry in case of collision
+while : ; do
+  git fetch --all
+  # We call this script only after a commit was pushed to the given branch, so it's safe to switch to it
+  git switch "$BUILDKITE_BRANCH"
+  git reset --hard origin/"$BUILDKITE_BRANCH"
+  # Find if there are unsigned commits in the current branch
+  # If there are grep matches then there are unsigned commits
+  if git log --pretty="format:%G?" "origin/$BUILDKITE_PIPELINE_DEFAULT_BRANCH..$BUILDKITE_BRANCH" | grep "N$"; then
+    echo "Found unsigned commits"
+    # Rebase through all commits in the current branch and sign them, if some of the commits are already
+    # signed, a signature will be overridden
+    if ! git rebase --exec 'git commit --amend -n --gpg-sign="tezos-packaging@serokell.io" --no-edit' \
+      "origin/$BUILDKITE_PIPELINE_DEFAULT_BRANCH"; then
+      git rebase --abort
+      exit 1
+    fi
+    # This should fail in case we're trying to overwrite some new commits
+    ! git push --force-with-lease || break
+  else
+    echo "No unsigned commits found"
+    exit 0
+  fi
+done

--- a/scripts/sync-bottle-hashes.sh
+++ b/scripts/sync-bottle-hashes.sh
@@ -1,5 +1,4 @@
-#! /usr/bin/env nix-shell
-#! nix-shell shell.nix -i bash
+#! /usr/bin/env bash
 # SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
@@ -32,7 +31,7 @@ while : ; do
     git fetch --all
     git reset --hard origin/"$branch_name"
     ./scripts/bottle-hashes.sh .
-    git commit -a -m "[Chore] Add $1 hashes to brew formulae" --gpg-sign="tezos-packaging@serokell.io"
+    git commit -a -m "[Chore] Add $1 hashes to brew formulae"
     ! git push || break
 done
 

--- a/scripts/sync-bottle-hashes.sh
+++ b/scripts/sync-bottle-hashes.sh
@@ -13,8 +13,8 @@ if [ -z "$1" ] || [ -z "$2" ]; then
     exit 1
 fi
 
-git config user.name "Serokell CI bot" # necessary for pushing
-git config user.email "tezos-packaging@serokell.io" # this address matches the one that is used for signing packages
+git config user.name "serokell-bot" # necessary for pushing
+git config user.email "tezos-packaging@serokell.io"
 git fetch --all
 
 branch_name="auto/update-brew-formulae-$1"
@@ -45,6 +45,6 @@ set +e
 
 # We create the PR with the first push, when the other pipeline hasn't finished yet.
 # That's why we 'set +e': one of the two times the command will fail.
-gh pr create -B master -t "[Chore] Add bottle hashes for $1" -b "$pr_body"
+gh pr create -B master -t "[Chore] Add bottle hashes for $1 <unsigned>" -b "$pr_body"
 
 exit 0

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -10,8 +10,8 @@
 
 set -e
 
-git config user.name "Serokell CI bot" # necessary for pushing
-git config user.email "tezos-packaging@serokell.io" # this address matches the one that is used for signing packages
+git config user.name "serokell-bot" # necessary for pushing
+git config user.email "tezos-packaging@serokell.io"
 git fetch --all
 
 # Get latest tag from tezos/tezos


### PR DESCRIPTION
## Description
Problem: Public github actions runners don't have access to our signing
key, thus it's impossible to sign commits before pushing.

Solution: Sign commits in a separate CI step that will be triggered when
the branch with formulae update is updated. The script in this step will
sign all commits from current branch and 'git push
--force-with-lease' signatures.

Fix to a bug that was introduced in a4241488bfd54bdf7021cae4ef1de91f56474650.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../../tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
