### PR TITLE
[#332] Handle non-dict steps in pipeline filtering

### DIFF
--- a/.buildkite/filter-pipeline.py
+++ b/.buildkite/filter-pipeline.py
@@ -120,9 +120,10 @@ visited = set()
 visited_rev = set()
 
 steps = pipeline["steps"]
-key_to_label = build_key_to_label(steps)
-depends_on_dict, depends_on_dict_rev = build_tree(steps, key_to_label)
-for step in steps:
+dict_steps = list(filter(lambda x: isinstance(x, dict), steps))
+key_to_label = build_key_to_label(dict_steps)
+depends_on_dict, depends_on_dict_rev = build_tree(dict_steps, key_to_label)
+for step in dict_steps:
     if check_step(step, splitted_diff):
         label = step["label"]
         dfs(label, depends_on_dict, visited)
@@ -131,7 +132,7 @@ for step in steps:
 for name in visited:
     dfs(name, depends_on_dict_rev, visited_rev)
 
-for step in steps:
+for step in dict_steps:
     label = step["label"]
     if (label not in visited) and (label not in visited_rev):
         step["skip"] = "skipped due to lack of changes"

--- a/tests/buildkite/golden/pipeline-A.yml
+++ b/tests/buildkite/golden/pipeline-A.yml
@@ -30,6 +30,7 @@ steps:
   - E
   key: H
   label: H
+- wait
 - depends_on:
   - A
   key: X

--- a/tests/buildkite/golden/pipeline-C.yml
+++ b/tests/buildkite/golden/pipeline-C.yml
@@ -31,6 +31,7 @@ steps:
   - E
   key: H
   label: H
+- wait
 - depends_on:
   - A
   key: X

--- a/tests/buildkite/golden/pipeline-G.yml
+++ b/tests/buildkite/golden/pipeline-G.yml
@@ -32,6 +32,7 @@ steps:
   key: H
   label: H
   skip: skipped due to lack of changes
+- wait
 - depends_on:
   - A
   key: X

--- a/tests/buildkite/golden/pipeline-X.yml
+++ b/tests/buildkite/golden/pipeline-X.yml
@@ -37,6 +37,7 @@ steps:
   key: H
   label: H
   skip: skipped due to lack of changes
+- wait
 - depends_on:
   - A
   key: X

--- a/tests/buildkite/pipeline-raw.yml
+++ b/tests/buildkite/pipeline-raw.yml
@@ -50,6 +50,7 @@ steps:
     - E
     only_changes:
     - H
+  - wait
   - label: X
     key: X
     depends_on:


### PR DESCRIPTION
## Description
Problem: Currently filter-pipeline.py will fail in case a pipeline
the configuration has non-dict steps, e.g. 'wait'.

Solution: Ignore non-dict steps in pipeline-filtering and don't skip
them in the resulting pipeline.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #332

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
