### PR TITLE
[#334] Auto create release upon release PR merge

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -144,14 +144,14 @@ steps:
      queue: "docker"
    only_changes: *native_packaging_changes_regexes
 
- - label: create auto pre-release
+ - label: create auto release/pre-release
    commands:
    - mkdir binaries
    - mkdir arm-binaries
    - buildkite-agent artifact download "docker/*" binaries --step "build-via-docker"
    - buildkite-agent artifact download "docker/*" arm-binaries --step "build-arm-via-docker"
    - ls binaries
-   - ./scripts/autorelease.sh
+   - ./scripts/autorelease.sh "$BUILDKITE_MESSAGE"
    branches: master
    depends_on:
     - "build-via-docker"


### PR DESCRIPTION
Problem: we have automated almost the whole release making process except for actually publishing the release from autoreleases. Currently, after the release PR is merged and a auto pre-release made, we have to manually push a tag and publish a release with a correct name.

This has already lead to maintainers forgetting to publish a release, which led to some CI issues. We would like to mitigate this by automating this process as well.

Solution: reworked the auto-release making process to actually make full releases/pre-releases if we merged a release PR, or still make an `auto-release` if not.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #334 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
