### PR TITLE
[#328] Re-update the release PR template

### DIFF
--- a/.github/release_pull_request_template.md
+++ b/.github/release_pull_request_template.md
@@ -36,10 +36,6 @@ Some of the changes are done after the new release is created, consider followin
 and checking unfinished points in the merged release PR using this template.
 -->
 
-#### Create a new release in this repository
-
-- [ ] I created a new release that is based on the latest autorelease created by the CI.
-
 #### Update brew bottles and repository mirrors
 - [ ] I merged PR that updates bottles hashes (this PR is supposed to be created by the CI).
 

--- a/.github/release_pull_request_template.md
+++ b/.github/release_pull_request_template.md
@@ -42,9 +42,6 @@ and checking unfinished points in the merged release PR using this template.
 
 #### Update brew bottles and repository mirrors
 - [ ] I merged PR that updates bottles hashes (this PR is supposed to be created by the CI).
-<!--TODO: remove once https://github.com/serokell/tezos-packaging/issues/314 is resolved -->
-- [ ] I pushed changes to either [tezos-packaging-rc](https://github.com/serokell/tezos-packaging-rc) or
-      [tezos-packaging-stable](https://github.com/serokell/tezos-packaging-stable) mirror repositories.
 
 #### Update documentation
 


### PR DESCRIPTION
## Description

We have already mostly refactored the release PR template, but the two remaining automation issues (#314 and #334) were since then closed, so we need to remove those steps from the template as well.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates to #328 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
