### PR TITLE
[#314] Fix 'not on branch' error on updating mirrors

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -145,6 +145,7 @@ steps:
    only_changes: *native_packaging_changes_regexes
 
  - label: create auto release/pre-release
+   key: auto-release
    commands:
    - mkdir binaries
    - mkdir arm-binaries
@@ -170,6 +171,8 @@ steps:
      build.branch == "master" &&
        ( build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-release/ ||
          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-[0-9]+/ )
+   depends_on:
+   - "auto-release"
    command: git push --mirror git@github.com:serokell/tezos-packaging-stable.git
 
  - label: update RC mirror repository
@@ -177,6 +180,8 @@ steps:
      build.branch == "master" &&
        (build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-rc.*-release/ ||
           build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-rc.*/)
+   depends_on:
+   - "auto-release"
    command: git push --mirror git@github.com:serokell/tezos-packaging-rc.git
 
  # To avoid race-conditions for the gpg key between jobs which sometimes leads to a weird errors

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -170,14 +170,14 @@ steps:
      build.branch == "master" &&
        ( build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-release/ ||
          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-[0-9]+/ )
-   command: git push git@github.com:serokell/tezos-packaging-stable.git
+   command: git push --mirror git@github.com:serokell/tezos-packaging-stable.git
 
  - label: update RC mirror repository
    if: |
      build.branch == "master" &&
        (build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-rc.*-release/ ||
           build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-rc.*/)
-   command: git push git@github.com:serokell/tezos-packaging-rc.git
+   command: git push --mirror git@github.com:serokell/tezos-packaging-rc.git
 
  # To avoid race-conditions for the gpg key between jobs which sometimes leads to a weird errors
  - wait


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: in a CI run after merging a release PR, updating the relevant mirror repo fails because we don't use the proper `--mirror` option.

Solution: added the flag to the commands.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #314

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
