### PR TITLE
[#323] Add dependencies to tezos-sandbox formula

### DIFF
--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -19,7 +19,7 @@ class TezosSandbox < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev libffi coreutils util-linux]
   dependencies.each do |dependency|
     depends_on dependency
   end
@@ -54,5 +54,14 @@ class TezosSandbox < Formula
     install_template "src/bin_sandbox/main.exe",
                      "_build/default/src/bin_sandbox/main.exe",
                      "tezos-sandbox"
+  end
+
+  # homebrew does not allow for post-setup modification of user files,
+  # so we have to provide a caveat to be displayed for the user to adjust $PATH manually
+  def caveats
+    <<~EOS
+      tezos-sandbox depends on 'coreutils' and 'util-linux', which have been installed. Please run the following command to bring them in scope:
+        export PATH=#{HOMEBREW_PREFIX}/opt/coreutils/libexec/gnubin:#{HOMEBREW_PREFIX}/opt/util-linux/bin:$PATH
+    EOS
   end
 end


### PR DESCRIPTION
## Description

Problem: there is a known issue with using tezos-sandbox on MacOS, which is that it depends on `coreutils` and `util-linux`. These are not installed upon running `brew install tezos-sandbox`.
Additionally, homebrew installs all tools that conflict with MacOS ones in name with the `g` prefix, meaning the user needs to manipulate `$PATH` to use these dependencies.

Solution: added `coreutils` and `util-linux` as dependencies to the `tezos-sandbox` formula. As brew does not allow for post-setup user configuration manipulation, `$PATH` cannot be easily modified to include `gnubin`. We use the paradigmatic homebrew way and output the command in the caveats section for the user to run manually.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #323 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
