### PR TITLE
[#237] Create the first version of a voting wizard

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -563,6 +563,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     def fetch_sources(self, out_dir):
         os.makedirs(out_dir)
         shutil.copy(f"{os.path.dirname(__file__)}/tezos_setup_wizard.py", out_dir)
+        shutil.copy(f"{os.path.dirname(__file__)}/tezos_voting_wizard.py", out_dir)
 
     def gen_control_file(self, deps, ubuntu_version, out):
         run_deps_list = ["acl", "tezos-client", "tezos-node"]
@@ -648,9 +649,14 @@ tezos-setup-wizard:
 	mv $(CURDIR)/tezos_setup_wizard.py $(CURDIR)/tezos-setup-wizard
 	chmod +x $(CURDIR)/tezos-setup-wizard
 
-install: tezos-baking tezos-setup-wizard
+tezos-voting-wizard:
+	mv $(CURDIR)/tezos_voting_wizard.py $(CURDIR)/tezos-voting-wizard
+	chmod +x $(CURDIR)/tezos-voting-wizard
+
+install: tezos-baking tezos-setup-wizard tezos-voting-wizard
 	mkdir -p $(DESTDIR)$(BINDIR)
 	cp $(CURDIR)/tezos-setup-wizard $(DESTDIR)$(BINDIR)/tezos-setup-wizard
+	cp $(CURDIR)/tezos-voting-wizard $(DESTDIR)$(BINDIR)/tezos-voting-wizard
 """
         with open(out, "w") as f:
             f.write(file_contents)

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -562,6 +562,7 @@ class TezosBakingServicesPackage(AbstractPackage):
 
     def fetch_sources(self, out_dir):
         os.makedirs(out_dir)
+        shutil.copy(f"{os.path.dirname(__file__)}/wizard_structure.py", out_dir)
         shutil.copy(f"{os.path.dirname(__file__)}/tezos_setup_wizard.py", out_dir)
         shutil.copy(f"{os.path.dirname(__file__)}/tezos_voting_wizard.py", out_dir)
 
@@ -655,6 +656,7 @@ tezos-voting-wizard:
 
 install: tezos-baking tezos-setup-wizard tezos-voting-wizard
 	mkdir -p $(DESTDIR)$(BINDIR)
+	cp $(CURDIR)/wizard_structure.py $(DESTDIR)$(BINDIR)/wizard_structure.py
 	cp $(CURDIR)/tezos-setup-wizard $(DESTDIR)$(BINDIR)/tezos-setup-wizard
 	cp $(CURDIR)/tezos-voting-wizard $(DESTDIR)$(BINDIR)/tezos-voting-wizard
 """

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -9,13 +9,14 @@ A wizard utility to help set up tezos-baker.
 Asks questions, validates answers, and executes the appropriate steps using the final configuration.
 """
 
-import os, sys, subprocess, shlex, shutil
+import os, sys, shutil
 import readline
-import re, textwrap
+import re
 import urllib.request
 import json
 from typing import List
 
+from wizard_structure import *
 
 # Global options
 
@@ -59,6 +60,7 @@ history_modes = {
 
 TMP_SNAPSHOT_LOCATION = "/tmp/tezos_node.snapshot"
 
+
 # Regexes
 
 ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
@@ -66,122 +68,24 @@ secret_key_regex = b"(encrypted|unencrypted):(?:\w{54}|\w{88})"
 address_regex = b"tz[123]\w{33}"
 derivation_path_regex = b"(?:bip25519|ed25519|secp256k1|P-256)\/[0-9]+h\/[0-9]+h"
 
-# Input validators
-
-
-def enum_range_validator(options):
-    def _validator(input):
-        intrange = list(map(str, range(1, len(options) + 1)))
-        if input not in intrange and input not in options:
-            raise ValueError(
-                "Please choose one of the provided values or use their respective numbers: "
-                + ", ".join(options)
-            )
-        try:
-            opt = int(input) - 1
-        except:
-            return input
-        else:
-            opts = options
-            if isinstance(options, dict):
-                opts = list(options.keys())
-            return opts[opt]
-
-    return _validator
-
-
-def filepath_validator(input):
-    if input and not os.path.isfile(input):
-        raise ValueError("Please input a valid file path.")
-    return input
-
-
-def required_field_validator(input):
-    if not input.strip():
-        raise ValueError("Please provide this required option.")
-    return input
-
-
-# The input has to be valid to at least one of the two passed validators.
-def or_validator(validator1, validator2):
-    def _validator(input):
-        try:
-            return validator1(input)
-        except:
-            return validator2(input)
-
-    return _validator
-
-
-# Runs the input through the passed validator, allowing for possible alteration,
-# but doesn't raise an exception if it doesn't validate to allow for custom options, too.
-def or_custom_validator(validator):
-    def _validator(input):
-        result = input
-        try:
-            result = validator(input)
-        except:
-            pass
-        return result
-
-    return _validator
-
-
-# To be validated, the input should adhere to the Tezos secret key format:
-# {encrypted, unencrypted}:<base58 encoded string with length 54 or 88>
-def secret_key_validator(input):
-    match = re.match(secret_key_regex.decode("utf-8"), input.strip())
-    if not bool(match):
-        raise ValueError(
-            "The input doesn't match the format for the Tezos secret key: "
-            "{{encrypted, unencrypted}:<base58 encoded string with length 54 or 88>}"
-            "\nPlease check the input and try again."
-        )
-    return input
-
-
-# To be validated, the input should adhere to the derivation path format:
-# [0-9]+h/[0-9]+h
-def derivation_path_validator(input):
-    match = re.match(b"[0-9]+h\/[0-9]+h".decode("utf-8"), input.strip())
-    if not bool(match):
-        raise ValueError(
-            "The input doesn't match the format for the derivation path: "
-            "'[0-9]+h/[0-9]+h'"
-            "\nPlease check the input and try again."
-        )
-    return input
-
-
-class Validator:
-    def __init__(self, validator):
-        self.validator = validator
-
-    def validate(self, input):
-        if self.validator is not None:
-            if isinstance(self.validator, list):
-                for v in self.validator:
-                    input = v(input)
-                return input
-            else:
-                return self.validator(input)
-
 
 # Wizard CLI utility
 
 
-suppress_warning_text = "TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=YES"
+welcome_text = """Tezos Setup Wizard
 
+Welcome, this wizard will help you to set up the infrastructure to interact with the
+Tezos blockchain.
 
-def proc_call(cmd):
-    return subprocess.check_call(shlex.split(cmd))
+In order to run a baking instance, you'll need the following Tezos binaries:
+ tezos-client, tezos-node, tezos-baker-<proto>, tezos-endorser-<proto>.
+If you have installed tezos-baking, these binaries are already installed.
 
+All commands within the service are run under the 'tezos' user.
 
-def get_proc_output(cmd):
-    if sys.version_info.major == 3 and sys.version_info.minor < 7:
-        return subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
-    else:
-        return subprocess.run(shlex.split(cmd), capture_output=True)
+To access help and possible options for each question, type in 'help' or '?'.
+Type in 'exit' to quit.
+"""
 
 
 def fetch_snapshot(url):
@@ -190,32 +94,6 @@ def fetch_snapshot(url):
     urllib.request.urlretrieve(url, filename, progressbar_hook)
     print()
     return filename
-
-
-def progressbar_hook(chunk_number, chunk_size, total_size):
-    done = chunk_number * chunk_size
-    percent = min(int(done * 100 / total_size), 100)
-    print("Progress:", percent, "%,", int(done / (1024 * 1024)), "MB", end="\r")
-
-
-def color(input, colorcode):
-    return colorcode + input + "\x1b[0m"
-
-
-def yes_or_no(prompt, default=None):
-    valid = False
-    while not valid:
-        answer = input(prompt).strip().lower()
-        if not answer and default is not None:
-            answer = default
-        if answer in ["y", "yes"]:
-            print()
-            return True
-        elif answer in ["n", "no"]:
-            print()
-            return False
-        else:
-            print(color("Please provide a 'yes' or 'no' answer.", "\x1b[1;31m"))
 
 
 def wait_for_ledger_baking_app():
@@ -235,24 +113,6 @@ def wait_for_ledger_baking_app():
         )
         ledgers_derivations.setdefault(ledger_url, []).append(derivation_path)
     return ledgers_derivations
-
-
-def get_data_dir(network):
-    output = get_proc_output("systemctl show tezos-node-" + network + ".service").stdout
-    config = re.search(b"Environment=(.*)(?:$|\n)", output)
-    if config is None:
-        print(
-            "tezos-node-" + network + ".service configuration not found, "
-            "defaulting to /var/lib/tezos/node-" + network
-        )
-        return "/var/lib/tezos/node-" + network
-    config = config.group(1)
-    data_dir = re.search(b"DATA_DIR=(.*?)(?: |$|\n)", config)
-    if data_dir is not None:
-        return data_dir.group(1).decode("utf-8")
-    else:
-        print("DATA_DIR is undefined, defaulting to /var/lib/tezos/node-" + network)
-        return "/var/lib/tezos/node-" + network
 
 
 def ledger_urls_info(ledgers_derivations, node_endpoint):
@@ -283,14 +143,6 @@ def ledger_urls_info(ledgers_derivations, node_endpoint):
     return ledgers_info
 
 
-def search_baking_service_config(config_contents, regex, default):
-    res = re.search(regex, config_contents)
-    if res is None:
-        return default
-    else:
-        return res.group(1)
-
-
 def is_full_snapshot(import_mode):
     if import_mode == "download full":
         return True
@@ -300,79 +152,6 @@ def is_full_snapshot(import_mode):
         ).stdout
         return re.search(b"at level [0-9]+ in full", output) is not None
     return False
-
-
-class Step:
-    def __init__(
-        self,
-        id: str,
-        prompt: str,
-        help: str,
-        default: str = "1",
-        options=None,
-        validator=None,
-    ):
-        self.id = id
-        self.prompt = prompt
-        self.help = help
-        self.default = default
-        self.options = options
-        self.validator = validator
-
-    def pprint_options(self):
-        i = 1
-        def_i = None
-        try:
-            def_i = int(self.default)
-        except:
-            pass
-
-        if self.options and isinstance(self.options, list):
-            options_count = 0
-            for o in self.options:
-                if isinstance(o, dict):
-                    for values in o.values():
-                        if not isinstance(values, list):
-                            options_count += 1
-                        else:
-                            options_count += len(values)
-                else:
-                    options_count += 1
-            index_len = len(str(options_count))
-            str_format = f"{{:{index_len}}}. {{}}"
-            for o in self.options:
-                if isinstance(o, dict):
-                    for k, values in o.items():
-                        print()
-                        print(f"'{k}':")
-                        print()
-                        if not isinstance(values, list):
-                            values = [values]
-                        for v in values:
-                            if def_i is not None and i == def_i:
-                                print(str_format.format(i, "(default) " + v))
-                            else:
-                                print(str_format.format(i, v))
-                            i += 1
-                    print()
-                else:
-                    if def_i is not None and i == def_i:
-                        print(str_format.format(i, "(default) " + o))
-                    else:
-                        print(str_format.format(i, o))
-                    i += 1
-        elif self.options and isinstance(self.options, dict):
-            index_len = len(str(len(self.options)))
-            str_format = f"{{:{index_len}}}. {{:<26}}  {{}}"
-            for o in self.options:
-                description = textwrap.indent(
-                    textwrap.fill(self.options[o], 60), " " * 31
-                ).lstrip()
-                if def_i is not None and i == def_i:
-                    print(str_format.format(i, o + " (default)", description))
-                else:
-                    print(str_format.format(i, o, description))
-                i += 1
 
 
 # Steps
@@ -533,73 +312,7 @@ def get_ledger_derivation(ledgers_derivations, node_endpoint):
     )
 
 
-class Setup:
-    def __init__(self, config={}):
-        self.config = config
-
-    def query_step(self, step: Step):
-
-        validated = False
-        while not validated:
-            print(step.prompt)
-            step.pprint_options()
-            answer = input("> ").strip()
-
-            if answer.lower() in ["quit", "exit"]:
-                raise KeyboardInterrupt
-            elif answer.lower() in ["help", "?"]:
-                print(step.help)
-                print()
-            else:
-                if not answer and step.default is not None:
-                    answer = step.default
-
-                try:
-                    if step.validator is not None:
-                        answer = step.validator.validate(answer)
-                except ValueError as e:
-                    print(color("Validation error: " + str(e), "\x1b[1;31m"))
-                else:
-                    validated = True
-                    self.config[step.id] = answer
-
-    def fill_baking_config(self):
-        network = self.config["network"]
-        output = get_proc_output(
-            "systemctl show tezos-baking-" + network + ".service"
-        ).stdout
-        config_filepath = re.search(b"EnvironmentFiles=(.*) ", output)
-        if config_filepath is None:
-            print(
-                "EnvironmentFiles not found in tezos-baking-"
-                + network
-                + ".service configuration,",
-                "defaulting to /etc/default/tezos-baking-" + network,
-            )
-            config_filepath = "/etc/default/tezos-baking-" + network
-        else:
-            config_filepath = config_filepath.group(1).decode().strip()
-
-        with open(config_filepath, "r") as f:
-            config_contents = f.read()
-            self.config["client_data_dir"] = search_baking_service_config(
-                config_contents, 'DATA_DIR="(.*)"', "/var/lib/.tezos-client"
-            )
-            self.config["node_rpc_addr"] = search_baking_service_config(
-                config_contents, 'NODE_RPC_ENDPOINT="(.*)"', "http://localhost:8732"
-            )
-            self.config["baker_alias"] = search_baking_service_config(
-                config_contents, 'BAKER_ADDRESS_ALIAS="(.*)"', "baker"
-            )
-
-    def get_tezos_client_options(self):
-        return (
-            "--base-dir "
-            + self.config["client_data_dir"]
-            + " --endpoint "
-            + self.config["node_rpc_addr"]
-        )
-
+class Setup(Setup):
     def get_current_head_level(self):
         response = urllib.request.urlopen(
             self.config["node_rpc_addr"] + "/chains/main/blocks/head/header"
@@ -619,7 +332,9 @@ class Setup:
             print()
             if yes_or_no("Delete this data and bootstrap the node again? <y/N> ", "no"):
                 for path in diff:
-                    if proc_call("sudo rm -r " + os.path.join(node_dir, path)):
+                    try:
+                        proc_call("sudo rm -r " + os.path.join(node_dir, path))
+                    except:
                         print(
                             "Could not clean the Tezos node data directory. "
                             "Please do so manually."
@@ -930,52 +645,9 @@ class Setup:
     def start_baking(self):
         self.systemctl_start_action("baking")
 
-    def systemctl_start_action(self, service):
-        proc_call(
-            "sudo systemctl start tezos-"
-            + service
-            + "-"
-            + self.config["network"]
-            + ".service"
-        )
-
-    def systemctl_enable(self):
-        if self.config["systemd_mode"] == "yes":
-            print(
-                "Enabling the tezos-{}-{}.service".format(
-                    self.config["mode"], self.config["network"]
-                )
-            )
-            proc_call(
-                "sudo systemctl enable tezos-"
-                + self.config["mode"]
-                + "-"
-                + self.config["network"]
-                + ".service"
-            )
-        else:
-            print("The services won't restart on boot.")
-
     def run_setup(self):
 
-        print("Tezos Setup Wizard")
-        print()
-        print(
-            "Welcome, this wizard will help you to set up the infrastructure",
-            "to interact with the Tezos blockchain.",
-        )
-        print(
-            "In order to run a baking instance, you'll need the following Tezos binaries:\n",
-            "tezos-client, tezos-node, tezos-baker-<proto>, tezos-endorser-<proto>.\n",
-            "If you have installed tezos-baking, these binaries are already installed.",
-        )
-        print("All commands within the service are run under the 'tezos' user.")
-        print()
-        print(
-            "To access help and possible options for each question, type in 'help' or '?'."
-        )
-        print("Type in 'exit' to quit.")
-        print()
+        print(welcome_text)
 
         self.query_step(network_query)
         self.fill_baking_config()

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -381,9 +381,10 @@ network_query = Step(
     id="network",
     prompt="Which Tezos network would you like to use?\nCurrently supported:",
     help="The selected network will be used to set up all required services.\n"
-    "The currently supported protocol is 011-PtHangz2 (used on hangzhounet and mainnet).\n"
-    "\nKeep in mind that you must select the test network "
-    "(hangzhounet) if you plan on baking with a faucet JSON file.",
+    "The currently supported protocol is 011-PtHangz2 (used on hangzhounet and mainnet)\n"
+    "and 012-Psithaca (used on ithacanet).\n"
+    "Keep in mind that you must select the test network (hangzhounet ot ithacanet)\n"
+    "if you plan on baking with a faucet JSON file.\n",
     options=networks,
     validator=Validator(enum_range_validator(networks)),
 )

--- a/docker/package/tezos_voting_wizard.py
+++ b/docker/package/tezos_voting_wizard.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+"""
+A wizard utility to help with voting on the Tezos protocol.
+
+Asks questions, validates answers, and executes the appropriate steps using the final configuration.
+"""
+
+import os, sys, subprocess, shlex
+import readline
+import re, textwrap
+
+
+# Global options
+
+ballot_outcomes = {
+    "yay": "Vote for accepting the proposal",
+    "nay": "Vote for rejecting the proposal",
+    "pass": "Submit a vote not influencing the result but contributing to quorum",
+}
+
+# Regexes
+
+ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
+protocol_hash_regex = (
+    b"P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}"
+)
+
+# Input validators
+
+
+def enum_range_validator(options):
+    def _validator(input):
+        intrange = list(map(str, range(1, len(options) + 1)))
+        if input not in intrange and input not in options:
+            raise ValueError(
+                "Please choose one of the provided values or use their respective numbers: "
+                + ", ".join(options)
+            )
+        try:
+            opt = int(input) - 1
+        except:
+            return input
+        else:
+            opts = options
+            if isinstance(options, dict):
+                opts = list(options.keys())
+            return opts[opt]
+
+    return _validator
+
+
+def required_field_validator(input):
+    if not input.strip():
+        raise ValueError("Please provide this required option.")
+    return input
+
+
+# To be validated, the input should adhere to the protocol hash format:
+# <base58 encoded string with length 51 starting with P>
+def protocol_hash_validator(input):
+    proto_hash_regex_str = protocol_hash_regex.decode("utf-8")
+    match = re.match(proto_hash_regex_str, input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the protocol hash: "
+            + proto_hash_regex_str
+            + "\nPlease check the input and try again."
+        )
+    return input
+
+
+class Validator:
+    def __init__(self, validator):
+        self.validator = validator
+
+    def validate(self, input):
+        if self.validator is not None:
+            if isinstance(self.validator, list):
+                for v in self.validator:
+                    input = v(input)
+                return input
+            else:
+                return self.validator(input)
+
+
+# Wizard CLI utility
+
+welcome_text = """Tezos Voting Wizard
+
+Welcome, this wizard will help you to vote in the Tezos protocol amendment process.
+Please note that for this you need to already have set up the baking infrastructure
+on mainnet, as only bakers can submit ballots or proposals.
+
+If you have installed tezos-baking, you can run Tezos Setup Wizard to set it up:
+tezos-setup-wizard
+
+All commands within the service are run under the 'tezos' user.
+
+To access help and possible options for each question, type in 'help' or '?'.
+Type in 'exit' to quit.
+"""
+
+suppress_warning_text = "TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=YES"
+
+
+def proc_call(cmd):
+    return subprocess.check_call(shlex.split(cmd))
+
+
+def get_proc_output(cmd):
+    if sys.version_info.major == 3 and sys.version_info.minor < 7:
+        return subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
+    else:
+        return subprocess.run(shlex.split(cmd), capture_output=True)
+
+
+def color(input, colorcode):
+    return colorcode + input + "\x1b[0m"
+
+
+color_red = "\x1b[1;31m"
+
+
+def yes_or_no(prompt, default=None):
+    valid = False
+    while not valid:
+        answer = input(prompt).strip().lower()
+        if not answer and default is not None:
+            answer = default
+        if answer in ["y", "yes"]:
+            print()
+            return True
+        elif answer in ["n", "no"]:
+            print()
+            return False
+        else:
+            print(color("Please provide a 'yes' or 'no' answer.", color_red))
+
+
+# we don't need any data here, just a confirmation Tezos Wallet app is open
+def wait_for_ledger_wallet_app():
+    output = b""
+    while re.search(b"Found a Tezos Wallet", output) is None:
+        output = get_proc_output(
+            f"sudo -u tezos {suppress_warning_text} tezos-client list connected ledgers"
+        ).stdout
+        proc_call("sleep 1")
+
+
+def search_baking_service_config(config_contents, regex, default):
+    res = re.search(regex, config_contents)
+    if res is None:
+        return default
+    else:
+        return res.group(1)
+
+
+class Step:
+    def __init__(
+        self,
+        id: str,
+        prompt: str,
+        help: str,
+        default: str = "1",
+        options=None,
+        validator=None,
+    ):
+        self.id = id
+        self.prompt = prompt
+        self.help = help
+        self.default = default
+        self.options = options
+        self.validator = validator
+
+    def pprint_options(self):
+        i = 1
+        def_i = None
+        try:
+            def_i = int(self.default)
+        except:
+            pass
+
+        if self.options and isinstance(self.options, list):
+            str_format = "{:1}. {}"
+            for o in self.options:
+                if def_i is not None and i == def_i:
+                    print(str_format.format(i, "(default) " + o))
+                else:
+                    print(str_format.format(i, o))
+                i += 1
+        elif self.options and isinstance(self.options, dict):
+            str_format = "{:1}. {:<26}  {}"
+            for o in self.options:
+                description = textwrap.indent(
+                    textwrap.fill(self.options[o], 60), " " * 31
+                ).lstrip()
+                if def_i is not None and i == def_i:
+                    print(str_format.format(i, o + " (default)", description))
+                else:
+                    print(str_format.format(i, o, description))
+                i += 1
+
+
+# Steps
+
+network_query = Step(
+    id="network_mode",
+    prompt="Which Tezos network would you like to use?\n",
+    help="The selected network will be used for voting.\n"
+    "Usually you would vote on the mainnet, but you can also select\n"
+    "a custom network (needs to already be set up).",
+    options=networks,
+    validator=Validator(enum_range_validator(networks)),
+)
+
+custom_network_query = Step(
+    id="custom_network_name",
+    prompt="What's the name of the custom network you'd like to use?",
+    help="The selected network will be used to vote.\n"
+    "For example, to use the tezos-baking-custom@voting service, input 'voting'."
+    "You need to already have set up the custom network using systemd services.",
+    # TODO: "\nFor that, you can follow a tutorial here:",
+    validator=Validator(required_field_validator),
+)
+
+new_proposal_query = Step(
+    id="new_proposal_hash",
+    prompt="Provide the hash for your newly submitted proposal.",
+    default=None,
+    help="The format is 'P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}'",
+    validator=Validator([required_field_validator, protocol_hash_validator]),
+)
+
+# We define this step as a function since the corresponding step requires that we get the
+# proposal hashes off the chain.
+# tezos-client supports submitting up to 20 proposal hashes at a time, but it seems like this
+# isn't recommended for use with Ledger, so we leave it at one hash pro query for now.
+def get_proposal_period_hash(hashes):
+
+    # if the chain is in the proposal period, it's possible to submit a new proposal hash
+    extra_options = ["Specify new proposal hash"]
+
+    return Step(
+        id="chosen_hash",
+        prompt="Select a proposal hash.\n"
+        "You can choose one of the suggested hashes or provide your own:",
+        help="You can submit one proposal at a time.\n"
+        "'Specify new proposal hash' will ask a protocol hash from you. ",
+        default=None,
+        options=hashes + extra_options,
+        validator=Validator(
+            [
+                required_field_validator,
+                enum_range_validator(hashes + extra_options),
+            ]
+        ),
+    )
+
+
+ballot_outcome_query = Step(
+    id="ballot_outcome",
+    prompt="Choose the outcome for your ballot.",
+    help="'yay' is for supporting the proposal, 'nay' is for rejecting the proposal,\n"
+    "'pass' is used to not influence a vote but still contribute to reaching a quorum.",
+    default=None,
+    options=ballot_outcomes,
+    validator=Validator(
+        [required_field_validator, enum_range_validator(ballot_outcomes)]
+    ),
+)
+
+
+class Setup:
+    def __init__(self, config={}):
+        self.config = config
+
+    def query_step(self, step: Step):
+        validated = False
+        while not validated:
+            print(step.prompt)
+            step.pprint_options()
+            answer = input("> ").strip()
+
+            if answer.lower() in ["quit", "exit"]:
+                raise KeyboardInterrupt
+            elif answer.lower() in ["help", "?"]:
+                print(step.help)
+                print()
+            else:
+                if not answer and step.default is not None:
+                    answer = step.default
+
+                try:
+                    if step.validator is not None:
+                        answer = step.validator.validate(answer)
+                except ValueError as e:
+                    print(color("Validation error: " + str(e), color_red))
+                else:
+                    validated = True
+                    self.config[step.id] = answer
+
+    # Check whether the baker_alias account is set up to use ledger
+    def check_ledger_use(self):
+        baker_alias = self.config["baker_alias"]
+        address = get_proc_output(
+            f"sudo -u tezos {suppress_warning_text} tezos-client "
+            f"{self.config['tezos_client_options']} show address {baker_alias} --show-secret"
+        )
+        if address.returncode == 0:
+            value_regex = b"(?:" + ledger_regex + b")"
+            return bool(re.match(value_regex, address.stdout))
+
+    def check_baking_service(self):
+        try:
+            proc_call("systemctl is-active --quiet tezos-baking-mainnet.service")
+        except:
+            print("Looks like the tezos-baking-mainnet service isn't running.")
+            print("Please start the service or set up baking by running:")
+            print("tezos-setup-wizard")
+            sys.exit(1)
+
+    def check_data_correctness(self):
+        print("Baker data detected is as follows:")
+        print(f"Data directory: {self.config['client_data_dir']}")
+        print(f"Node RPC address: {self.config['node_rpc_addr']}")
+        print(f"Baker alias: {self.config['baker_alias']}")
+        if not yes_or_no("Does this look correct? (Y/n)", "yes"):
+            print("Try setting up baking again by running:")
+            print("tezos-setup-wizard")
+            sys.exit(1)
+
+    def fill_baking_config(self):
+        output = get_proc_output("systemctl show tezos-baking-mainnet.service").stdout
+        config_filepath = re.search(b"EnvironmentFiles=(.*) ", output)
+        if config_filepath is None:
+            print(
+                "EnvironmentFiles not found in tezos-baking-mainnet.service configuration,",
+                "defaulting to /etc/default/tezos-baking-mainnet",
+            )
+            config_filepath = "/etc/default/tezos-baking-mainnet"
+        else:
+            config_filepath = config_filepath.group(1).decode().strip()
+
+        with open(config_filepath, "r") as f:
+            config_contents = f.read()
+            self.config["client_data_dir"] = search_baking_service_config(
+                config_contents, 'DATA_DIR="(.*)"', "/var/lib/tezos/.tezos-client"
+            )
+            self.config["node_rpc_addr"] = search_baking_service_config(
+                config_contents, 'NODE_RPC_ENDPOINT="(.*)"', "http://localhost:8732"
+            )
+            self.config["baker_alias"] = search_baking_service_config(
+                config_contents, 'BAKER_ADDRESS_ALIAS="(.*)"', "baker"
+            )
+
+    def get_tezos_client_options(self):
+        return (
+            "--base-dir "
+            + self.config["client_data_dir"]
+            + " --endpoint "
+            + self.config["node_rpc_addr"]
+        )
+
+    def fill_voting_period_info(self):
+        voting_proc = get_proc_output(
+            f"sudo -u tezos {suppress_warning_text} tezos-client "
+            f"{self.config['tezos_client_options']} show voting period"
+        )
+        if voting_proc.returncode == 0:
+            info = voting_proc.stdout
+        else:
+            print(
+                "Couldn't get the voting period info. Please check that the network",
+                "for voting has been set up correctly.",
+            )
+
+        self.config["amendment_phase"] = (
+            re.search(b'Current period: "(\w+)"', info).group(1).decode("utf-8")
+        )
+        self.config["proposal_hashes"] = [
+            phash.decode() for phash in re.findall(protocol_hash_regex, info)
+        ]
+
+    def process_proposal_period(self):
+        self.query_step(get_proposal_period_hash(self.config["proposal_hashes"]))
+
+        hash_to_submit = self.config["chosen_hash"]
+        if hash_to_submit == "Specify new proposal hash":
+            self.query_step(new_proposal_query)
+            hash_to_submit = self.config["new_proposal_hash"]
+
+        result = get_proc_output(
+            f"sudo -u tezos {suppress_warning_text} tezos-client {self.config['tezos_client_options']} "
+            f"submit proposals for {self.config['baker_alias']} {hash_to_submit}"
+        )
+
+        if result.returncode == 0:
+            if yes_or_no("Submission successful! Choose again? <Y/n> ", "yes"):
+                self.process_proposal_period()
+                return
+        else:
+            print()
+
+            if re.search(b"[Ii]nvalid proposal", result.stderr) is not None:
+                print(color("The submitted proposal hash is invalid.", color_red))
+                print("Check your custom submitted proposal hash and try again.")
+                self.process_proposal_period()
+                return
+            elif re.search(b"Unauthorized proposal", result.stderr) is not None:
+                print(
+                    color(
+                        "Cannot submit because of an unauthorized proposal.", color_red
+                    )
+                )
+                print("This means you are not present in the voting listings.")
+            elif re.search(b"Not in a proposal period", result.stderr) is not None:
+                print(
+                    color(
+                        "Cannot submit because the voting period is no longer 'proposal'.",
+                        color_red,
+                    )
+                )
+                print("This means the voting period has already advanced.")
+            elif re.search(b"Too many proposals", result.stderr) is not None:
+                print(
+                    color(
+                        "Cannot submit because of too many proposals submitted.",
+                        color_red,
+                    )
+                )
+                print("This means you have already submitted more than 20 proposals.")
+            # No other "legitimate" proposal error ('empty_proposal', 'unexpected_proposal')
+            # should be possible with the wizard, so we just raise an error with the whole output.
+            else:
+                print(
+                    "Something went wrong when calling tezos-client. Please consult the logs."
+                )
+                raise OSError(result.stderr.decode())
+
+            print("Please check your baker data and possibly try again.")
+
+    def process_voting_period(self):
+        print("The current proposal is:")
+        # there's only one in any voting (exploration/promotion) period
+        print(self.config["proposal_hashes"][0])
+        print()
+
+        self.query_step(ballot_outcome_query)
+
+        result = get_proc_output(
+            f"sudo -u tezos {suppress_warning_text} tezos-client {self.config['tezos_client_options']} "
+            f"submit ballot for {self.config['baker_alias']} {self.config['proposal_hashes'][0]} "
+            f"{self.config['ballot_outcome']}"
+        )
+
+        if result.returncode != 0:
+            # handle the 'unauthorized ballot' error
+            # Unfortunately, despite the error's description text, tezos-client seems to use this error
+            # both when the baker has already voted and when the baker was not in the voting listings
+            # in the first place, so it's difficult to distinguish between the two cases.
+            if re.search(b"Unauthorized ballot", result.stderr) is not None:
+                print()
+                print(
+                    color("Cannot vote because of an unauthorized ballot.", color_red)
+                )
+                print(
+                    "This either means you have already voted or that you are not in the",
+                    "voting listings in the first place.",
+                )
+                print("Please check your baker data and possibly try again.")
+            if (
+                re.search(b"Not in Exploration or Promotion period", result.stderr)
+                is not None
+            ):
+                print()
+                print(
+                    color("Cannot vote because the voting period is", color_red),
+                    color(f"no longer '{self.config['amendment_phase']}'.", color_red),
+                )
+                print(
+                    "This most likely means the voting period has already advanced to the next one.",
+                )
+            # No other "legitimate" voting error ('invalid_proposal', 'unexpected_ballot')
+            # should be possible with the wizard, so we just raise an error with the whole output.
+            else:
+                print(
+                    "Something went wrong when calling tezos-client. Please consult the logs."
+                )
+                raise OSError(result.stderr.decode())
+
+    def run_voting(self):
+
+        print(welcome_text)
+
+        self.fill_baking_config()
+
+        self.check_baking_service()
+
+        # check with the user that the baker data sounds correct
+        self.check_data_correctness()
+
+        self.config["tezos_client_options"] = self.get_tezos_client_options()
+
+        # if a ledger is used for baking, ask to open Tezos Wallet app on it before proceeding
+        if self.check_ledger_use():
+            print()
+            print("Please open the Tezos Wallet app on your ledger.")
+            wait_for_ledger_wallet_app()
+
+        # process 'tezos-client show voting period'
+        self.fill_voting_period_info()
+
+        print(
+            f"The amendment is currently in the {self.config['amendment_phase']} period."
+        )
+        if self.config["amendment_phase"] == "proposal":
+            print(
+                "Bakers can submit up to 20 protocol amendment proposals,",
+                "including supporting existing ones.",
+            )
+            print()
+            self.process_proposal_period()
+        elif self.config["amendment_phase"] in ["exploration", "promotion"]:
+            print(
+                "Bakers can submit one ballot regarding the current proposal,",
+                "voting either 'yay', 'nay', or 'pass'.",
+            )
+            print()
+            self.process_voting_period()
+        else:
+            print("Voting isn't possible at the moment.")
+            print("Exiting the Tezos Voting Wizard.")
+
+        print()
+        print("Thank you for voting!")
+
+
+if __name__ == "__main__":
+    readline.parse_and_bind("tab: complete")
+    readline.set_completer_delims(" ")
+
+    try:
+        setup = Setup()
+        setup.run_voting()
+    except KeyboardInterrupt:
+        print("Exiting the Tezos Voting Wizard.")
+        sys.exit(1)
+    except EOFError:
+        print("Exiting the Tezos Voting Wizard.")
+        sys.exit(1)
+    except Exception as e:
+        print("Error in Tezos Voting Wizard, exiting.")
+        logfile = "tezos_voting_wizard.log"
+        with open(logfile, "a") as f:
+            f.write(str(e) + "\n")
+        print("The error has been logged to", os.path.abspath(logfile))
+        sys.exit(1)

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: LicenseRef-MIT-TQ
+
+"""
+Contains shared code from all Tezos wizards for a command line wizard skeleton.
+
+Helps with writing a tool that asks questions, validates answers, and executes
+the appropriate steps using the final configuration.
+"""
+
+import os, sys, subprocess, shlex
+import re, textwrap
+
+# Regexes
+
+secret_key_regex = b"(encrypted|unencrypted):(?:\w{54}|\w{88})"
+protocol_hash_regex = (
+    b"P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}"
+)
+
+
+# Input validators
+
+
+def enum_range_validator(options):
+    def _validator(input):
+        intrange = list(map(str, range(1, len(options) + 1)))
+        if input not in intrange and input not in options:
+            raise ValueError(
+                "Please choose one of the provided values or use their respective numbers: "
+                + ", ".join(options)
+            )
+        try:
+            opt = int(input) - 1
+        except:
+            return input
+        else:
+            opts = options
+            if isinstance(options, dict):
+                opts = list(options.keys())
+            return opts[opt]
+
+    return _validator
+
+
+def filepath_validator(input):
+    if input and not os.path.isfile(input):
+        raise ValueError("Please input a valid file path.")
+    return input
+
+
+def required_field_validator(input):
+    if not input.strip():
+        raise ValueError("Please provide this required option.")
+    return input
+
+
+# The input has to be valid to at least one of the two passed validators.
+def or_validator(validator1, validator2):
+    def _validator(input):
+        try:
+            return validator1(input)
+        except:
+            return validator2(input)
+
+    return _validator
+
+
+# Runs the input through the passed validator, allowing for possible alteration,
+# but doesn't raise an exception if it doesn't validate to allow for custom options, too.
+def or_custom_validator(validator):
+    def _validator(input):
+        result = input
+        try:
+            result = validator(input)
+        except:
+            pass
+        return result
+
+    return _validator
+
+
+# To be validated, the input should adhere to the Tezos secret key format:
+# {encrypted, unencrypted}:<base58 encoded string with length 54 or 88>
+def secret_key_validator(input):
+    match = re.match(secret_key_regex.decode("utf-8"), input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the Tezos secret key: "
+            "{{encrypted, unencrypted}:<base58 encoded string with length 54 or 88>}"
+            "\nPlease check the input and try again."
+        )
+    return input
+
+
+# To be validated, the input should adhere to the derivation path format:
+# [0-9]+h/[0-9]+h
+def derivation_path_validator(input):
+    match = re.match(b"[0-9]+h\/[0-9]+h".decode("utf-8"), input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the derivation path: "
+            "'[0-9]+h/[0-9]+h'"
+            "\nPlease check the input and try again."
+        )
+    return input
+
+
+# To be validated, the input should adhere to the protocol hash format:
+# <base58 encoded string with length 51 starting with P>
+def protocol_hash_validator(input):
+    proto_hash_regex_str = protocol_hash_regex.decode("utf-8")
+    match = re.match(proto_hash_regex_str, input.strip())
+    if not bool(match):
+        raise ValueError(
+            "The input doesn't match the format for the protocol hash: "
+            + proto_hash_regex_str
+            + "\nPlease check the input and try again."
+        )
+    return input
+
+
+class Validator:
+    def __init__(self, validator):
+        self.validator = validator
+
+    def validate(self, input):
+        if self.validator is not None:
+            if isinstance(self.validator, list):
+                for v in self.validator:
+                    input = v(input)
+                return input
+            else:
+                return self.validator(input)
+
+
+# Utilities
+
+
+def proc_call(cmd):
+    return subprocess.check_call(shlex.split(cmd))
+
+
+def get_proc_output(cmd):
+    if sys.version_info.major == 3 and sys.version_info.minor < 7:
+        return subprocess.run(shlex.split(cmd), stdout=subprocess.PIPE)
+    else:
+        return subprocess.run(shlex.split(cmd), capture_output=True)
+
+
+def progressbar_hook(chunk_number, chunk_size, total_size):
+    done = chunk_number * chunk_size
+    percent = min(int(done * 100 / total_size), 100)
+    print("Progress:", percent, "%,", int(done / (1024 * 1024)), "MB", end="\r")
+
+
+def color(input, colorcode):
+    return colorcode + input + "\x1b[0m"
+
+
+color_red = "\x1b[1;31m"
+
+
+def yes_or_no(prompt, default=None):
+    valid = False
+    while not valid:
+        answer = input(prompt).strip().lower()
+        if not answer and default is not None:
+            answer = default
+        if answer in ["y", "yes"]:
+            print()
+            return True
+        elif answer in ["n", "no"]:
+            print()
+            return False
+        else:
+            print(color("Please provide a 'yes' or 'no' answer.", color_red))
+
+
+# Wizard CLI skeleton
+
+
+suppress_warning_text = "TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=YES"
+
+
+def get_data_dir(network):
+    output = get_proc_output("systemctl show tezos-node-" + network + ".service").stdout
+    config = re.search(b"Environment=(.*)(?:$|\n)", output)
+    if config is None:
+        print(
+            "tezos-node-" + network + ".service configuration not found, "
+            "defaulting to /var/lib/tezos/node-" + network
+        )
+        return "/var/lib/tezos/node-" + network
+    config = config.group(1)
+    data_dir = re.search(b"DATA_DIR=(.*?)(?: |$|\n)", config)
+    if data_dir is not None:
+        return data_dir.group(1).decode("utf-8")
+    else:
+        print("DATA_DIR is undefined, defaulting to /var/lib/tezos/node-" + network)
+        return "/var/lib/tezos/node-" + network
+
+
+def search_baking_service_config(config_contents, regex, default):
+    res = re.search(regex, config_contents)
+    if res is None:
+        return default
+    else:
+        return res.group(1)
+
+
+class Step:
+    def __init__(
+        self,
+        id: str,
+        prompt: str,
+        help: str,
+        default: str = "1",
+        options=None,
+        validator=None,
+    ):
+        self.id = id
+        self.prompt = prompt
+        self.help = help
+        self.default = default
+        self.options = options
+        self.validator = validator
+
+    def pprint_options(self):
+        i = 1
+        def_i = None
+        try:
+            def_i = int(self.default)
+        except:
+            pass
+
+        if self.options and isinstance(self.options, list):
+            options_count = 0
+            for o in self.options:
+                if isinstance(o, dict):
+                    for values in o.values():
+                        if not isinstance(values, list):
+                            options_count += 1
+                        else:
+                            options_count += len(values)
+                else:
+                    options_count += 1
+            index_len = len(str(options_count))
+            str_format = f"{{:{index_len}}}. {{}}"
+            for o in self.options:
+                if isinstance(o, dict):
+                    for k, values in o.items():
+                        print()
+                        print(f"'{k}':")
+                        print()
+                        if not isinstance(values, list):
+                            values = [values]
+                        for v in values:
+                            if def_i is not None and i == def_i:
+                                print(str_format.format(i, "(default) " + v))
+                            else:
+                                print(str_format.format(i, v))
+                            i += 1
+                    print()
+                else:
+                    if def_i is not None and i == def_i:
+                        print(str_format.format(i, "(default) " + o))
+                    else:
+                        print(str_format.format(i, o))
+                    i += 1
+        elif self.options and isinstance(self.options, dict):
+            index_len = len(str(len(self.options)))
+            str_format = f"{{:{index_len}}}. {{:<26}}  {{}}"
+            for o in self.options:
+                description = textwrap.indent(
+                    textwrap.fill(self.options[o], 60), " " * 31
+                ).lstrip()
+                if def_i is not None and i == def_i:
+                    print(str_format.format(i, o + " (default)", description))
+                else:
+                    print(str_format.format(i, o, description))
+                i += 1
+
+
+class Setup:
+    def __init__(self, config={}):
+        self.config = config
+
+    def query_step(self, step: Step):
+        validated = False
+        while not validated:
+            print(step.prompt)
+            step.pprint_options()
+            answer = input("> ").strip()
+
+            if answer.lower() in ["quit", "exit"]:
+                raise KeyboardInterrupt
+            elif answer.lower() in ["help", "?"]:
+                print(step.help)
+                print()
+            else:
+                if not answer and step.default is not None:
+                    answer = step.default
+
+                try:
+                    if step.validator is not None:
+                        answer = step.validator.validate(answer)
+                except ValueError as e:
+                    print(color("Validation error: " + str(e), color_red))
+                else:
+                    validated = True
+                    self.config[step.id] = answer
+
+    def systemctl_start_action(self, service):
+        proc_call(
+            f"sudo systemctl start tezos-{service}-{self.config['network']}.service"
+        )
+
+    def systemctl_enable(self):
+        if self.config["systemd_mode"] == "yes":
+            print(
+                "Enabling the tezos-{}-{}.service".format(
+                    self.config["mode"], self.config["network"]
+                )
+            )
+            proc_call(
+                f"sudo systemctl enable tezos-{self.config['mode']}-"
+                f"{self.config['network']}.service"
+            )
+        else:
+            print("The services won't restart on boot.")
+
+    def get_tezos_client_options(self):
+        return (
+            "--base-dir "
+            + self.config["client_data_dir"]
+            + " --endpoint "
+            + self.config["node_rpc_addr"]
+        )
+
+    def fill_baking_config(self):
+        net = self.config["network"]
+        output = get_proc_output(f"systemctl show tezos-baking-{net}.service").stdout
+        config_filepath = re.search(b"EnvironmentFiles=(.*) ", output)
+        if config_filepath is None:
+            print(
+                f"EnvironmentFiles not found in tezos-baking-{net}.service configuration,",
+                f"defaulting to /etc/default/tezos-baking-{net}",
+            )
+            config_filepath = f"/etc/default/tezos-baking-{net}"
+        else:
+            config_filepath = config_filepath.group(1).decode().strip()
+
+        with open(config_filepath, "r") as f:
+            config_contents = f.read()
+            self.config["client_data_dir"] = search_baking_service_config(
+                config_contents, 'DATA_DIR="(.*)"', "/var/lib/tezos/.tezos-client"
+            )
+            self.config["node_rpc_addr"] = search_baking_service_config(
+                config_contents, 'NODE_RPC_ENDPOINT="(.*)"', "http://localhost:8732"
+            )
+            self.config["baker_alias"] = search_baking_service_config(
+                config_contents, 'BAKER_ADDRESS_ALIAS="(.*)"', "baker"
+            )

--- a/docs/tests/voting.md
+++ b/docs/tests/voting.md
@@ -1,0 +1,78 @@
+<!--
+   - SPDX-FileCopyrightText: 2022 TQ Tezos <https://tqtezos.com/>
+   -
+   - SPDX-License-Identifier: LicenseRef-MIT-TQ
+   -->
+
+# Voting with voting wizard
+
+This document explains how one can test voting via voting wizard on during all possible
+amendment periods.
+
+## Prerequisites
+
+1) Install `tezos-baking` package should on your system.
+2) Clone [local-chain repository](https://gitlab.com/morley-framework/local-chain).
+
+## Test scenario workflow
+
+1) Generate a pair of keys associated with `baker` alias:
+
+```
+sudo -u tezos tezos-client gen keys baker
+```
+
+2) In a separate terminal start a [voting scenario script](https://gitlab.com/morley-framework/local-chain#voting-scenario) from the local-chain repo.
+
+This script will provide you a path to the node config that will be used by the custom baking service.
+
+3) Provide address generated on the first step to the `voting.py` script. This address will receive some amount of XTZ.
+
+4) Create a config for the custom baking service that will be used by the voting wizard:
+
+```
+sudo cp /etc/default/tezos-baking-custom@ /etc/default/tezos-baking-custom@voting
+```
+Edit with the config provided by the voting script on the second step:
+```
+DATA_DIR="/var/lib/tezos/.tezos-client"
+NODE_RPC_ENDPOINT="http://localhost:8732"
+BAKER_ADDRESS_ALIAS="baker"
+CUSTOM_NODE_CONFIG="<paste your path to the node config here>"
+RESET_ON_STOP=""
+```
+
+Additionally, you can set `RESET_ON_STOP="true"` to enable automatic node directory removal which will
+be triggered once custom baking service will be stopped.
+
+5) Start custom baking service:
+
+```
+sudo systemctl start tezos-baking-custom@voting
+```
+
+Note that `tezos-node` service may take some time to generate a fresh identity and start.
+
+To check the status of the node service run:
+```
+systemctl status tezos-node-custom@voting
+```
+
+6) Register `baker` key as delegate once `tezos-node` is up and running:
+```
+sudo -u tezos tezos-client register key baker as delegate
+```
+
+7) After that `voting.py` will start going through the voting cycle.
+
+The script will stop at the beginning of each voting period that requires voting and ask you to vote.
+
+Launch `tezos-voting-wizard`, select `custom` network with `voting` name and submit your vote.
+Under normal conditions, you won't have to adjust any information about your baking service.
+
+Once you'll vote, you should prompt the `voting.py` script to continue going through the voting cycle.
+
+8) Stop custom baking service once voting cycle is over:
+```
+sudo systemctl stop tezos-baking-custom@voting
+```


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: bakers who want to vote on the Tezos protocol amendment currently have to do it through base `tezos-client` or other unintuitive avenues. As we already have an interactive baking setup wizard, we would like to extend interactive capabilities of our packages and provide a similar wizard for voting.

Solution: added the first version of Tezos Voting Wizard.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #237 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
