### PR TITLE
[#346] Document versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ This repo provides various forms of distribution for [Tezos](http://tezos.gitlab
 See the [official documentation](http://tezos.gitlab.io/introduction/howtouse.html)
 for information about the binaries, their usage, and concepts about the Tezos networks.
 
+See the [versioning doc](./docs/versioning.md) for information about the versioning
+policy for the provided forms of distribution.
+
 ## Set up a node and/or baking on Ubuntu
 
 The simplest procedure to set up a node and/or baking instance is provided for Ubuntu.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,52 @@
+<!--
+   - SPDX-FileCopyrightText: 2021 TQ Tezos <https://tqtezos.com/>
+   -
+   - SPDX-License-Identifier: LicenseRef-MIT-TQ
+   -->
+
+# Versioning
+
+`tezos-packaging` follows all Octez releases, both stable and candidates.
+
+Packages from our releases provide addinional functionality (e.g. systemd services
+in Ubuntu and Fedora package or brew formulae with launchd services).
+This additional functionality may change within the same upstream version.
+
+In order to track this, our GitHub releases and packages use
+the following RPM-like versioning scheme: `<name>-<version>-<release>`:
+* `<name>` is used to mention which Octez binary is packaged.
+* `<version>` is used to reference the packaged upstream version.
+* `<release>` is used to reflect changes in additional packages functionality.
+
+## GitHub releases
+
+We provide GitHub releases for stable upstream releases and pre-releases for release candidates.
+
+In our GitHub repository we use tags in which `<name>-` part is ommited.
+
+E.g. `v11.0-1` is the first `tezos-packaging` release within the `v11.0` upstream stable release,
+or `v11.0-rc2-2` for the second `tezos-packaging` release within the `v11.0-rc2` upstream release candidate.
+
+GitHub {pre-}releases contain static binaries and brew bottles compiled from the given
+upstream source version.
+
+## Ubuntu packages
+
+Ubuntu packages use a slightly different versioning scheme, which follows
+the [Debian versioning policy](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version):
+`<name>-<version>-0ubuntu<release>~<ubuntu-version>`.
+
+E.g. `tezos-client-11.0+no-adx-0ubuntu1~focal`, where `focal` is `20.04 LTS`.
+
+We use different PPA repositories for stable and release candidate Ubuntu packages.
+You can read more about this in the [doc about Ubuntu packages](./distros/ubuntu.md).
+
+## Fedora packages
+
+We use different Copr projects for stable and release candidate Fedora packages.
+You can read more about this in the [doc about Fedora packages](./distros/fedora.md).
+
+## Brew formulae
+
+We use two distinct repository mirrors to provide stable and release candidate brew formulae.
+You can read more about this in the [doc about macOS packaging](./distros/macos.md).


### PR DESCRIPTION
## Description
Problem: Our versioning policy isn't documented anywhere, as a result
users may get confused when they see a package with a version that is
different from the upstream release version.

Solution: Write a doc that explains our versioning policy and the way in
which packages for upstream releases and pre-releases are distributed.
Also, refer to this doc in the main README.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #346

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
