### PR TITLE
[#205] Provide M1 support

### DIFF
--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -12,7 +12,7 @@ class TezosAccuser011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosAccuser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangz2.version}/"
-    sha256 cellar: :any, catalina: "85131133994b5e081e1d798bbdc19bea15be1d31244425356bf6a380647947b5"
-    sha256 cellar: :any, mojave: "34122f13a471f526c8fd080852d408ea2f283ed74739cfa05c1d235bcb0b1f0f"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -35,7 +35,8 @@ class TezosAccuser011Pthangz2 < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -12,7 +12,7 @@ class TezosAdminClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
-    sha256 cellar: :any, catalina: "e52d8309f4949de2ac58dfab3b55bac0affa07454cf925201052c04cf49e8f74"
-    sha256 cellar: :any, mojave: "3ad9ce649528ed84775acdf3a6dad5cc15e0b2f56d0791d116678a37b5118011"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -35,7 +35,8 @@ class TezosAdminClient < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -12,7 +12,7 @@ class TezosBaker011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosBaker011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangz2.version}/"
-    sha256 cellar: :any, catalina: "1e4b26e392d46d8d98fbc8f4eb33839f4e0533a4618192c1d3fa5e4934ce3f58"
-    sha256 cellar: :any, mojave: "ea09f0531dbcfa0741b2475fd529c083878c7e5de8a4383f9535fa0f6698581e"
   end
 
   def make_deps

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -35,7 +35,8 @@ class TezosBaker011Pthangz2 < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -27,8 +27,6 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
-    sha256 cellar: :any, catalina: "78f048172a602f00cc863fdd7e92f51ac838f197962f49ea29bcde8c4ca0cb70"
-    sha256 cellar: :any, mojave: "2ded50c5b7d488d26acb98e02ece948ed1cdba3f1181fbb9613ea74d1c79b6b8"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -12,7 +12,7 @@ class TezosClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -35,7 +35,8 @@ class TezosClient < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -12,7 +12,7 @@ class TezosCodec < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
-    sha256 cellar: :any, catalina: "f5806d598791141eb6e84f97291fc662660444c670f5b195a7870831360ccab7"
-    sha256 cellar: :any, mojave: "b896b3ae6492b632cabf757e08e53934cdebbbae58139ef0272aad8313308d6b"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -35,7 +35,8 @@ class TezosCodec < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -12,7 +12,7 @@ class TezosEndorser011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -28,8 +28,6 @@ class TezosEndorser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangz2.version}/"
-    sha256 cellar: :any, catalina: "08e27735c7b211d01c6d2811d5277f27632d6266ce37f25e4ed8eed195f2c96f"
-    sha256 cellar: :any, mojave: "775f3c3681ce511effd62146208bb4458f2f2454e9ceb21efb9a4afaad41eb65"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -36,7 +36,8 @@ class TezosEndorser011Pthangz2 < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-node-hangzhounet.rb
+++ b/Formula/tezos-node-hangzhounet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeHangzhounet < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -4,7 +4,7 @@
 
 class TezosNodeMainnet < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-node"

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -12,7 +12,7 @@ class TezosNode < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
-    sha256 cellar: :any, catalina: "758915ccf47f0393042c2663f170a400597a424bdf00e687613260922724d50b"
-    sha256 cellar: :any, mojave: "f483696e497991b16a9bc34b417c4b613efeb003dd0753a68ed9c6aa455e1694"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -35,7 +35,8 @@ class TezosNode < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -34,7 +34,8 @@ class TezosSandbox < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -12,7 +12,7 @@ class TezosSandbox < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,7 +27,6 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
-    sha256 cellar: :any, catalina: "fa023385d72c253f5d7cb42376b10416f1cef463d47afbf651138d3bb264709e"
   end
 
   def make_deps

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttp < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerHttps < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerTcp < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -4,7 +4,7 @@
 
 class TezosSignerUnix < Formula
   url "file:///dev/null"
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   bottle :unneeded
   depends_on "tezos-signer"

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -35,7 +35,8 @@ class TezosSigner < Formula
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
-    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-x86_64-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
     system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
     ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
     system "rustup-init", "--default-toolchain", "1.52.1", "-y"

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -12,7 +12,7 @@ class TezosSigner < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v11.0+no_adx", :shallow => false
 
-  version "v11.0+no_adx-1"
+  version "v11.0+no_adx-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,8 +27,6 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
-    sha256 cellar: :any, catalina: "3759467a866693df55f9b8d056f9d20b919ec1db15ca5501e81963eaf42f0ff1"
-    sha256 cellar: :any, mojave: "a116fe6a65c0798746b3599be921f16bdf045902cbac1fbe2a0de7ec30beb8c0"
   end
 
   def make_deps

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: Currently formulae download opam x86_64 binary from the
GitHub release, which causes a build failure on machines with M1 CPU.

Solution: Determine CPU architecture in runtime and download appropriate
opam binary.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #205 (will be resolved once mirror repository is updated)
Resolves #354 (documentation update won't be needed since we're going to support M1 natively)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
