### PR TITLE
[#353] Big Sur GitHub actions

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -8,7 +8,7 @@ permissions:
   # Restrict GITHUB_TOKEN permissions
   contents: write
 jobs:
-  build-bottles:
+  build-bottles-catalina:
     runs-on: macos-10.15
     steps:
       - name: Install coreutils for macOS # for sha256sum
@@ -33,6 +33,40 @@ jobs:
 
       - name: Add Catalina bottle hashes to formulae
         run: ./scripts/sync-bottle-hashes.sh "${GITHUB_REF#refs/tags/}" "Catalina"
+
+      - name: Attach bottles to the release
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh release upload "${GITHUB_REF#refs/tags/}" *.bottle.*
+
+  build-bottles-big-sur:
+    runs-on: macos-11
+    # Unfortunately there is no convenient way to concatenate lists in YAML :(
+    # So the entire steps sequence is copy-pasted to use different macOS version as an
+    # argument in one step
+    steps:
+      - name: Install coreutils for macOS # for sha256sum
+        run: brew install coreutils
+
+      - name: Install GNU sed # for the other pipeline compatibility
+        run: |
+          brew install gnu-sed
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build bottles
+        run: ./scripts/build-bottles.sh
+
+      - name: Upload bottles to Github Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: homebrew-bottles
+          path: '*.bottle.*'
+
+      - name: Add Big Sur bottle hashes to formulae
+        run: ./scripts/sync-bottle-hashes.sh "${GITHUB_REF#refs/tags/}" "Big Sur"
 
       - name: Attach bottles to the release
         env:

--- a/Formula/tezos-sapling-params.rb
+++ b/Formula/tezos-sapling-params.rb
@@ -15,6 +15,7 @@ class TezosSaplingParams < Formula
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSaplingParams.version}/"
     sha256 cellar: :any, mojave: "4e89932b0626cffe80214ba45342280c340b34c58ebbf7c3e0185a6d4662732d"
     sha256 cellar: :any, catalina: "5f7a5687d67051eafcfb7cb5ac542143a325a135403daeca6595602bfd400441"
+    sha256 cellar: :any, big_sur: "c910acffd3369bf5c4e0cff112efe6d56035394639b9571d845ad5ecb4dbd01f"
   end
 
   def install

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -12,7 +12,7 @@ if [[ -d ./Formula ]]
 then
     if [[ -d "$1" ]]
     then
-        regex="(tezos-.*)-v.*\.(catalina|mojave)\.bottle\.tar\.gz"
+        regex="(tezos-.*)-v.*\.(catalina|mojave|big_sur)\.bottle\.tar\.gz"
         for bottle in "$1"/tezos-*.bottle.tar.gz; do
             if [[ $bottle =~ $regex ]]; then
                 bottle_hash=`sha256sum "$bottle" | cut -d " " -f 1`

--- a/scripts/sync-bottle-hashes.sh
+++ b/scripts/sync-bottle-hashes.sh
@@ -31,7 +31,7 @@ while : ; do
     git fetch --all
     git reset --hard origin/"$branch_name"
     ./scripts/bottle-hashes.sh .
-    git commit -a -m "[Chore] Add $1 hashes to brew formulae"
+    git commit -a -m "[Chore] Add $1 hashes to brew formulae for $2"
     ! git push || break
 done
 

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -16,7 +16,8 @@ then
             -exec sed -i "s/version \"v.*\"/version \"$tag\"/g" {} \; \
             -exec sed -i "s/:tag => \"v.*\"/:tag => \"$version\"/g" {} \; \
             -exec sed -i "/catalina/d" {} \; \
-            -exec sed -i "/mojave/d" {} \;
+            -exec sed -i "/mojave/d" {} \; \
+            -exec sed -i "/big_sur/d" {} \;
     else
         echo "The argument does not look like a tag, which should have a form of 'v*-[0-9]*'"
     fi


### PR DESCRIPTION
## Description
Problem: At the moment we provide bottles only for Mojave and Catalina,
and both of these versions are quite old at the moment. Service support
for Mojave stopped some time ago.

Solution: Build bottles for x86_64 Big Sur using GitHub actions since
they recently started providing runners with this macOS version.

You can check [this pipeline](https://github.com/serokell/tezos-packaging/runs/4561166171) to ensure that it actually works.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves first part of #353. `arm64` support will be provided in another PR.

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
