### PR TITLE
[#353] arm64 Big Sur bottles building in CI

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -3,16 +3,6 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 steps:
- - label: Build bottles
-   key: build-bottles
-   agents:
-     queue: "x86_64-darwin"
-   if: build.tag =~ /^v.*/
-   commands:
-   - ./scripts/build-bottles.sh
-   artifact_paths:
-     - '*.bottle.*'
-
  - label: Build source packages
    key: build-source-packages
    if: build.tag =~ /^v.*-1/
@@ -33,24 +23,6 @@ steps:
    - export TEZOS_VERSION="$(cat nix/nix/sources.json | jq -r '.tezos.ref' | cut -d'/' -f3)"
    - buildkite-agent artifact download "out/*" . --step build-source-packages
    - ./scripts/publish-native-packages.sh out
-
- - label: Add Mojave bottle hashes to formulae
-   depends_on:
-   - "build-bottles"
-   if: build.tag =~ /^v.*/
-   commands:
-   - buildkite-agent artifact download --step build-bottles "*" .
-   - nix-shell ./scripts/shell.nix
-       --run './scripts/sync-bottle-hashes.sh "$BUILDKITE_TAG" "Mojave"'
-
- - label: Attach bottles to the release
-   depends_on:
-   - "build-bottles"
-   if: build.tag =~ /^v.*/
-   commands:
-   - buildkite-agent artifact download --step build-bottles "*" .
-   - nix-shell ./scripts/shell.nix
-       --run 'gh release upload "$BUILDKITE_TAG" *.bottle.*'
 
  - label: Check for new Tezos release
    if: build.source == "schedule" && build.branch == "master"

--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -3,6 +3,16 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 steps:
+ - label: Build Big Sur arm64 bottles
+   key: build-bottles
+   agents:
+     queue: "arm64-darwin"
+   if: build.tag =~ /^v.*/
+   commands:
+   - ./scripts/build-bottles.sh
+   artifact_paths:
+     - '*.bottle.*'
+
  - label: Build source packages
    key: build-source-packages
    if: build.tag =~ /^v.*-1/
@@ -23,6 +33,24 @@ steps:
    - export TEZOS_VERSION="$(cat nix/nix/sources.json | jq -r '.tezos.ref' | cut -d'/' -f3)"
    - buildkite-agent artifact download "out/*" . --step build-source-packages
    - ./scripts/publish-native-packages.sh out
+
+ - label: Add Big Sur arm64 bottle hashes to formulae
+   depends_on:
+   - "build-bottles"
+   if: build.tag =~ /^v.*/
+   commands:
+   - buildkite-agent artifact download --step build-bottles "*" .
+   - nix-shell ./scripts/shell.nix
+       --run './scripts/sync-bottle-hashes.sh "$BUILDKITE_TAG" "Big Sur arm64"'
+
+ - label: Attach bottles to the release
+   depends_on:
+   - "build-bottles"
+   if: build.tag =~ /^v.*/
+   commands:
+   - buildkite-agent artifact download --step build-bottles "*" .
+   - nix-shell ./scripts/shell.nix
+       --run 'gh release upload "$BUILDKITE_TAG" *.bottle.*'
 
  - label: Check for new Tezos release
    if: build.source == "schedule" && build.branch == "master"

--- a/Formula/tezos-sapling-params.rb
+++ b/Formula/tezos-sapling-params.rb
@@ -16,6 +16,7 @@ class TezosSaplingParams < Formula
     sha256 cellar: :any, mojave: "4e89932b0626cffe80214ba45342280c340b34c58ebbf7c3e0185a6d4662732d"
     sha256 cellar: :any, catalina: "5f7a5687d67051eafcfb7cb5ac542143a325a135403daeca6595602bfd400441"
     sha256 cellar: :any, big_sur: "c910acffd3369bf5c4e0cff112efe6d56035394639b9571d845ad5ecb4dbd01f"
+    sha256 cellar: :any, arm64_big_sur: "d7c04f2f95e459cb8639e99fb998311adc1d0babfd026987a1dcecf1e77e1f96"
   end
 
   def install

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -12,7 +12,7 @@ if [[ -d ./Formula ]]
 then
     if [[ -d "$1" ]]
     then
-        regex="(tezos-.*)-v.*\.(catalina|mojave|big_sur)\.bottle\.tar\.gz"
+        regex="(tezos-.*)-v.*\.(catalina|mojave|big_sur|arm64_big_sur)\.bottle\.tar\.gz"
         for bottle in "$1"/tezos-*.bottle.tar.gz; do
             if [[ $bottle =~ $regex ]]; then
                 bottle_hash=`sha256sum "$bottle" | cut -d " " -f 1`

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -17,7 +17,8 @@ then
             -exec sed -i "s/:tag => \"v.*\"/:tag => \"$version\"/g" {} \; \
             -exec sed -i "/catalina/d" {} \; \
             -exec sed -i "/mojave/d" {} \; \
-            -exec sed -i "/big_sur/d" {} \;
+            -exec sed -i "/big_sur/d" {} \; \
+            -exec sed -i "/arm64_big_sur/d" {} \;
     else
         echo "The argument does not look like a tag, which should have a form of 'v*-[0-9]*'"
     fi


### PR DESCRIPTION
## Description
Problem: Since Big Sur, macOS targets two different architectures:
x86_64 and arm64. Each architecture requires its own bottle with
a prebuilt binary.
Currently, our CI setup lacks arm64 Big Sur bottles building.

Solution: Use buildkite-agent that is running on M1 mac for building
arm64 bottles. Also, attach these bottles to the releases and provide
their hashes to the formulae automatically.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #353

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
