### PR TITLE
[Chore] Fix tezos-baking package dependencies 

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: There is no endorser daemon in 012 protocol. However,
'tezos-baking' package ended up depending on 'tezos-endorser-012-psithaca'.
As a result, it's impossible to install/upgrade tezos-baking-12.0-rc1-0ubuntu1 :(

Solution: Remove dependency on 'tezos-endorser-012-psithaca' package.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves a bug introduced in #360.

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
