### PR TITLE
[#339] Wait for node to shutdown before cleaning

### DIFF
--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -20,7 +20,6 @@ def pkill_background(binary):
 
 
 def run_node(network, use_tls):
-    machine.succeed("rm -rf node-dir")
     machine.succeed("mkdir node-dir")
     tls_args = " --rpc-tls=" + host_cert + "," + host_key + " " if use_tls else " "
     machine.succeed(f"{tezos_node} config init --data-dir node-dir --network {network}")
@@ -61,6 +60,9 @@ def kill_node_with_daemons():
     pkill_background("tezos-accuser")
     pkill_background("tezos-baker")
     pkill_background("tezos-node")
+    # Waiting node process to be killed before cleaning up to avoid race-conditions
+    machine.wait_until_fails("pgrep tezos-node")
+    machine.succeed("rm -rf node-dir")
 
 
 def test_node_with_daemons_scenario(network, use_tls=False):


### PR DESCRIPTION
## Description
Problem: Sometimes binaries tests are failing due to the inability to clean
up node data directory.

Solution: Clean up may fail in case node didn't shut down completely
before removing the data directory.
Wait for the node process to die before the data directory removal.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #339

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
