### PR TITLE
Use self hosted x86 Big Sur builder

### DIFF
--- a/.buildkite/generate-tags-pipeline.sh
+++ b/.buildkite/generate-tags-pipeline.sh
@@ -15,76 +15,89 @@ ymlappend () {
 
 # we don't bottle meta-formulas that contain only services
 formulae=("tezos-accuser-011-PtHangz2" "tezos-accuser-012-Psithaca" "tezos-admin-client" "tezos-baker-011-PtHangz2" "tezos-baker-012-Psithaca" "tezos-client" "tezos-codec" "tezos-endorser-011-PtHangz2" "tezos-node" "tezos-sandbox" "tezos-signer")
+architecture=("arm64" "x86_64")
+declare -A queues=(["arm64"]="arm64-darwin" ["x86_64"]="x86_64-rosetta-darwin")
+declare -A brew_bottle_oses=(["arm64"]="arm64_big_sur" ["x86_64"]="big_sur")
 
-# tezos-sapling-params is used as a dependency for some of the formulas
-# so we handle it separately.
-# We don't build the bottle for it because it is never updated over time.
-ymlappend "
- - label: Install tezos-sapling-params
-   key: install-tsp
+for arch in "${architecture[@]}"; do
+  # tezos-sapling-params is used as a dependency for some of the formulas
+  # so we handle it separately.
+  # We don't build the bottle for it because it is never updated over time.
+  queue="${queues[$arch]}"
+  brew_bottle_os=${brew_bottle_oses[$arch]}
+  ymlappend "
+ - label: Install tezos-sapling-params-$arch
+   key: install-tsp-$arch
    agents:
-     queue: \"arm64-darwin\"
+     queue: \"$queue\"
    if: build.tag =~ /^v.*/
    commands:
    - brew install --formula ./Formula/tezos-sapling-params.rb"
 
-n=0
-for f in "${formulae[@]}"; do
-  n=$((n+1))
-  ymlappend "
-
- - label: Check if $f bottle for Big Sur arm64 is already built
-   key: check-built-$n
+  n=0
+  for f in "${formulae[@]}"; do
+    n=$((n+1))
+    ymlappend "
+ - label: Check if $f bottle for Big Sur $arch is already built
+   key: check-built-$arch-$n
    if: build.tag =~ /^v.*/
    soft_fail:
    - exit_status: 3 # We don't want the pipeline to fail if the bottle's already built
    commands:
    - nix-shell ./scripts/shell.nix
-       --run './scripts/check-bottle-built.sh \"$f\" \"arm64_big_sur\"'
+       --run './scripts/check-bottle-built.sh \"$f\" \"$brew_bottle_os\"'
 
- - label: Build $f bottle for Big Sur arm64
-   key: build-bottle-$n
+ - label: Build $f bottle for Big Sur $arch
+   key: build-bottle-$arch-$n
    agents:
-     queue: \"arm64-darwin\"
+     queue: \"$queue\"
    if: build.tag =~ /^v.*/
-   depends_on: \"check-built-$n\"
+   depends_on: \"check-built-$arch-$n\"
    command: |
-     if [ \$\$(buildkite-agent step get \"outcome\" --step \"check-built-$n\") == "passed" ]; then
+     if [ \$\$(buildkite-agent step get \"outcome\" --step \"check-built-$arch-$n\") == "passed" ]; then
        ./scripts/build-one-bottle.sh \"$f\"
      fi
    artifact_paths:
      - '*.bottle.*'"
-done
+  done
 
-ymlappend "
- - label: Uninstall tezos-sapling-params
-   key: uninstall-tsp
+  ymlappend "
+ - label: Uninstall tezos-sapling-params $arch
+   key: uninstall-tsp-$arch
    depends_on:"
 
-for ((i=1; i<=n; i++)); do
-  ymlappend "   - build-bottle-$i"
-done
+  for ((i=1; i<=n; i++)); do
+    ymlappend "   - build-bottle-$arch-$i"
+  done
 
-ymlappend "   agents:
-     queue: \"arm64-darwin\"
+  ymlappend "   agents:
+     queue: \"$queue\"
    if: build.tag =~ /^v.*/
    commands:
    - brew uninstall ./Formula/tezos-sapling-params.rb
+   # opam doesn't always handle the situation when the same library is present for
+   # multiple architectures, see https://github.com/ocaml/opam-repository/issues/20941
+   # so all dependencies are cleared after bottles builds to avoid errors
+   - brew autoremove
 
-   # Since using the tag that triggered the pipeline isn't very resilient, we use the version
-   # from the tezos-client formula, which hopefully will stay the most up-to-date.
- - label: Add Big Sur arm64 bottle hashes to formulae
+ # To avoid running two brew processes together
+ - wait"
+
+done
+
+ymlappend "
+ - label: Add Big Sur bottle hashes to formulae
    depends_on:
-   - \"uninstall-tsp\"
+   - \"uninstall-tsp-arm64\"
+   - \"uninstall-tsp-x86_64\"
    if: build.tag =~ /^v.*/
    soft_fail: true # No artifacts to download if all the bottles are already built
    commands:
-   - mkdir -p \"Big Sur arm64\"
-   - buildkite-agent artifact download \"*bottle.tar.gz\" \"Big Sur arm64/\"
+   - mkdir -p \"Big Sur\"
+   - buildkite-agent artifact download \"*bottle.tar.gz\" \"Big Sur/\"
    - export FORMULA_TAG=\"\$(sed -n 's/^\s\+version \"\(.*\)\"/\1/p' ./Formula/tezos-client.rb)\"
    - nix-shell ./scripts/shell.nix
-       --run './scripts/sync-bottle-hashes.sh \"\$FORMULA_TAG\" \"Big Sur arm64\"'
-
+       --run './scripts/sync-bottle-hashes.sh \"\$FORMULA_TAG\" \"Big Sur\"'
  - label: Attach bottles to the release
    depends_on:
    - \"uninstall-tsp\"

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ { id: macos-10.15, name: "catalina" }, { id: macos-11, name: "big_sur" } ]
+        os: [ { id: macos-10.15, name: "catalina" } ]
         # we don't bottle meta-formulas that contain only services
         formula: [tezos-accuser-011-PtHangz2, tezos-accuser-012-Psithaca, tezos-admin-client, tezos-baker-011-PtHangz2, tezos-baker-012-Psithaca, tezos-client, tezos-codec, tezos-endorser-011-PtHangz2, tezos-node, tezos-sandbox, tezos-signer]
 
@@ -92,11 +92,3 @@ jobs:
 
       - name: Add bottle hashes to formulae
         run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Catalina"
-
-      - name: Download Big Sur bottles from the release
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${{ env.tag }}" -p "*.big_sur.bottle.tar.gz" -D "./Big Sur"
-
-      - name: Add bottle hashes to formulae
-        run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Big Sur"


### PR DESCRIPTION
## Description
Problem: At the moment, we use GitHub actions in order to build x86_64
Big Sur bottles. However, now we have our own infrastructure based on
Big Sur can be used to build x86_64 bottles using Rosetta.

Solution: Now we have an additional buildkite agent that runs all command
under Rosetta and have access to x86_64 brew binary.

Update 'generate-tags-pipeline.sh' script to generate steps
for building x86_64 Big Sur bottles using this new buildkite agent.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
https://issues.serokell.io/issue/TM-609

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
