### PR TITLE
[#375] Document 'tezos-packaging' usage on WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ the binaries, and the services used.
 - [**Raspberry Pi OS**](./docs/distros/ubuntu.md#raspberry)
 - [**Fedora**](./docs/distros/fedora.md)
 - [**macOS**](./docs/distros/macos.md)
+- [**Windows using WSL**](./docs/distros/ubuntu.md#wsl)
 
 The information about supported versions of the aforementioned OSes is available in the [support policy doc](./docs/support-policy.md).
 

--- a/docker/package/scripts/udev-rules
+++ b/docker/package/scripts/udev-rules
@@ -6,11 +6,10 @@
 # that are fixing https://github.com/LedgerHQ/udev-rules/issues/5, so that provided rules work on the Raspberry Pi OS
 # Ubuntu 18.04
 
-# Don't add udev rules in case the package is installed inside either docker or podman container
-# or WSL (since it doesn't fully support udev and libusb at the moment).
+# Don't add udev rules in case the package is installed inside either docker or podman container.
 # Otherwise, post-installation script will fail due to inability to non-zero exit code of the
 # 'udevadm control --reload-rules' call
-if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ] && ! grep -qEi "(Microsoft|WSL)" /proc/sys/kernel/osrelease ; then
+if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ] ; then
     cat <<EOF > /etc/udev/rules.d/20-hw1.rules
 # HW.1 / Nano
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"
@@ -27,6 +26,13 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004|4000|4001|40
 EOF
 
     udevadm trigger
+    # In WSL reloading the udev rules may fail unless the service is restarted
+    # first, see: https://github.com/dorssel/usbipd-win/wiki/WSL-support/e4a2d98725c3fea0cb139b71d290e887950c8371#udev
+    if grep -qEi "(Microsoft|WSL)" /proc/sys/kernel/osrelease ; then
+        # Here we try to restart using both the default 'service' command as well
+        # as 'systemctl', since many people switch to 'systemd'.
+        service udev restart || systemctl restart udev.service
+    fi
     udevadm control --reload-rules
     usermod -a -G plugdev tezos || true
 fi

--- a/docs/distros/ubuntu.md
+++ b/docs/distros/ubuntu.md
@@ -3,6 +3,7 @@
    -
    - SPDX-License-Identifier: LicenseRef-MIT-TQ
    -->
+<a name="ubuntu"></a>
 # Ubuntu Launchpad PPA with `tezos-*` binaries
 
 If you are using Ubuntu you can use PPA in order to install `tezos-*` executables.
@@ -34,7 +35,7 @@ Configuration files for these services are located in `/etc/default/tezos-baking
 ## Ubuntu packages on Raspberry Pi OS
 
 If you have a Raspberry Pi running the 64bit version of the official OS, you can
-use the Lauchpad PPA to install `tezos-*` executables on it as well.
+use the Launchpad PPA to install `tezos-*` executables on it as well.
 
 You can add the PPA using:
 ```
@@ -50,6 +51,16 @@ And install packages with `apt-get`, e.g. for `tezos-client`:
 ```
 sudo apt-get install tezos-client
 ```
+
+<a name="wsl"></a>
+## Ubuntu packages on WSL
+
+If you use [Ubuntu on WSL](https://ubuntu.com/wsl), you can use the Launchpad PPA
+to install `tezos-*` executables on it as well.
+
+You can add the PPA and install packages in the same way as described in [Ubuntu section](#ubuntu)
+
+In order to use ledger on WSL some additional preparation steps are needed. We recommed to use `usbipd-win` tool and follow [this guide](https://docs.microsoft.com/en-us/windows/wsl/connect-usb) about connecting usb devices to WSL.
 
 ## Systemd services from Ubuntu packages
 

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -55,6 +55,13 @@ Apart from the `.service` file you'll need the service startup script and defaul
 configuration file, they can be found in the [`scripts`](../docker/package/scripts) and
 [`defaults`](../docker/package/defaults) folders respectively.
 
+## Systemd units on WSL
+
+Unfortunately, `systemd` is not officially supported on WSL.
+
+However, there are several unofficial workarounds for it and some have been known to work with `tezos-packaging`'s units.
+
+If you are successfully running a distro on WSL with `systemd`, the documentation above should apply to you too.
 
 ## Multiple similar systemd services
 


### PR DESCRIPTION
## Description

Problem: During testing it was found that `tezos-packaging`
can be used on WSL, but its usage has some limitations.

Solution: Information about WSL support was added to support
policy doc. Limitations are also mentioned in the corresponding
sections.

## Related issue(s)

Resolves #375

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
