### PR TITLE
[Chore] Fix faucet link

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -42,7 +42,7 @@ snapshot_import_modes = {
 key_import_modes = {
     "ledger": "From a ledger",
     "secret-key": "Either the unencrypted or password-encrypted secret key for your address",
-    "json": "Faucet JSON file from https://faucet.tzalpha.net/",
+    "json": "Faucet JSON file from https://teztnets.xyz/",
 }
 
 systemd_enable = {
@@ -450,7 +450,7 @@ secret_key_query = Step(
 json_filepath_query = Step(
     id="json_filepath",
     prompt="Provide the path to your downloaded faucet JSON file.",
-    help="Download the faucet JSON file from https://faucet.tzalpha.net/.\n"
+    help="Download the faucet JSON file from https://teztnets.xyz/.\n"
     "The file will contain the 'mnemonic' and 'secret' fields.",
     validator=Validator([required_field_validator, filepath_validator]),
 )

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -173,7 +173,7 @@ In order to import such a key, run:
 sudo -u tezos tezos-client import secret key baker <secret-key>
 ```
 
-3) You have a faucet JSON file from https://faucet.tzalpha.net/.
+1) You have a faucet JSON file from https://teztnets.xyz/.
 
 In order to activate the account run:
 ```


### PR DESCRIPTION
Problem: There are several occurencies of https://faucet.tzalpha.net/,
which is deprecated since hangzhounet and doesn't work now.

Solution: Replace them with https://teztnets.xyz/.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
