### PR TITLE
[Chore] Fix tezos-node-ithacanet formula class name

### DIFF
--- a/Formula/tezos-node-ithacanet.rb
+++ b/Formula/tezos-node-ithacanet.rb
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-class TezosNodeHangzhounet < Formula
+class TezosNodeIthacanet < Formula
   url "file:///dev/null"
   version "v12.0-rc2-1"
 


### PR DESCRIPTION
## Description
Problem: tezos-node-ithacanet.rb main class has invalid name. As a
result, an attempt to tap serokell/tezos-packaging-rc results in an
error.

Solution: Fix the class name to match the formula name.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
