### PR TITLE
[#390] Update support policy doc

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -239,7 +239,7 @@ Source: {self.name.lower()}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev, {str_build_deps}
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, {str_build_deps}
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
@@ -389,7 +389,7 @@ Source: {self.name}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev, wget
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev, wget
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 
@@ -578,7 +578,7 @@ Source: {self.name}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=9), {"dh-systemd (>= 1.5), " if ubuntu_version != "hirsute" else ""} autotools-dev
+Build-Depends: debhelper (>=9), dh-systemd (>= 1.5), autotools-dev
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -80,7 +80,6 @@ common_deps = run_deps + build_deps
 ubuntu_versions = [
     "bionic",  # 18.04
     "focal",  # 20.04
-    "hirsute",  # 21.04
 ]
 
 pwd = os.getcwd()

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -20,10 +20,6 @@ Currently, these are versions:
 * 18.04 LTS (Bionic Beaver)
 * 20.04 LTS (Focal Fossa)
 
-When feasible, we also provide support for non-LTS versions on request from the users.
-Currently:
-* 21.04 (Hirsute Hippo) - requested in [#212](https://github.com/serokell/tezos-packaging/issues/212)
-
 There are packages for `arm64` and `amd64` architectures.
 
 ## Fedora packages

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -27,8 +27,8 @@ There are packages for `arm64` and `amd64` architectures.
 We aim to provide packages for all [currently supported Fedora releases](https://docs.fedoraproject.org/en-US/releases/).
 
 Currently, these are versions:
-* Fedora 34, both `x86_64` and `aarch64`
-* Fedora 35, only `aarch64`. `x86_64` is currently unsupported due to [tezos/#1449](https://gitlab.com/tezos/tezos/-/issues/1449)
+* Fedora 34
+* Fedora 35
 
 There are packages for `x86_64` and `aarch64` architectures.
 


### PR DESCRIPTION
## Description

Update list of supported OSes versions:

1) Remove Ubuntu 21.04 since it's obsolete now.
2) Mention that there are both `x86_64` and `aarch64` packages for Fedora 35 now.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #390

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
