### PR TITLE
[Chore] Fetch BUILDKITE_BRANCH before updating mirror

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -182,7 +182,11 @@ steps:
          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-[0-9]+/ )
    depends_on:
    - "auto-release"
-   command: git push --mirror git@github.com:serokell/tezos-packaging-stable.git
+   env:
+    MIRROR_REPO: "git@github.com:serokell/tezos-packaging-stable.git"
+   commands: &update_mirror
+   - git pull origin "$BUILDKITE_BRANCH:$BUILDKITE_BRANCH"
+   - git push --mirror "$MIRROR_REPO"
 
  - label: update RC mirror repository
    if: |
@@ -191,4 +195,6 @@ steps:
           build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-rc.*/)
    depends_on:
    - "auto-release"
-   command: git push --mirror git@github.com:serokell/tezos-packaging-rc.git
+   env:
+    MIRROR_REPO: "git@github.com:serokell/tezos-packaging-rc.git"
+   commands: *update_mirror


### PR DESCRIPTION
## Description
Problem: 'git push --mirror' pushes changes from the local ref which is
nearly empty due to the way buildkite fetches repository before doing
CI step.

Solution: Explicitly fetch, checkout, and pull current branch before
pushing to the mirror repository.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
