### PR TITLE
[#398] Remove unneeded bottle field for meta brew formulae

### DIFF
--- a/Formula/tezos-node-hangzhounet.rb
+++ b/Formula/tezos-node-hangzhounet.rb
@@ -6,7 +6,6 @@ class TezosNodeHangzhounet < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-node"
 
   desc "Meta formula that provides background tezos-node service that runs on hangzhounet"

--- a/Formula/tezos-node-ithacanet.rb
+++ b/Formula/tezos-node-ithacanet.rb
@@ -6,7 +6,6 @@ class TezosNodeIthacanet < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-node"
 
   desc "Meta formula that provides background tezos-node service that runs on ithacanet"

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -6,7 +6,6 @@ class TezosNodeMainnet < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-node"
 
   desc "Meta formula that provides background tezos-node service that runs on mainnet"

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -6,7 +6,6 @@ class TezosSignerHttp < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-signer"
 
   desc "Meta formula that provides backround tezos-signer service that runs over http"

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -6,7 +6,6 @@ class TezosSignerHttps < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-signer"
 
   desc "Meta formula that provides backround tezos-signer service that runs over https"

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -6,7 +6,6 @@ class TezosSignerTcp < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-signer"
 
   desc "Meta formula that provides backround tezos-signer service that runs over tcp socket"

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -6,7 +6,6 @@ class TezosSignerUnix < Formula
   url "file:///dev/null"
   version "v12.0-1"
 
-  bottle :unneeded
   depends_on "tezos-signer"
 
   desc "Meta formula that provides backround tezos-signer service that runs over unix socket"

--- a/docs/distros/macos.md
+++ b/docs/distros/macos.md
@@ -58,12 +58,20 @@ Once the configuration is updated, you should restart the service:
 
 ## Building brew bottles
 
-In order to build bottles with Tezos binaries run
-`build-bottles.sh` script:
+In order to build bottles with Tezos binaries run the [`build-one-bottle.sh`](../../scripts/build-one-bottle.sh)
+script with the formula that you want to build. For example:
 ```
-./scripts/build-bottles.sh
+./scripts/scripts/build-one-bottle.sh tezos-client
 ```
 
-Note that this might take a while, because builds don't share common parts and for each binary
-dependencies are compiled from scratch. Once the bottles are built, the corresponding sections in the
-formulas should be updated. Also, bottles should be uploaded to the release artifacts.
+Note that several formulae have `tezos-sapling-params` has a dependency, so you
+might need to run:
+```
+brew install --formula ./Formula/tezos-sapling-params.rb
+```
+first.
+
+Building many of these might take a while, because builds don't share common parts and for each
+binary dependencies are compiled from scratch.
+Once the bottles are built, the corresponding sections in the formulae should be updated.
+Also, bottles should be uploaded to the release artifacts.

--- a/scripts/build-one-bottle.sh
+++ b/scripts/build-one-bottle.sh
@@ -15,6 +15,6 @@ fi
 
 brew install --formula --build-bottle "./Formula/$1.rb"
 brew bottle --force-core-tap --no-rebuild "./Formula/$1.rb"
-brew uninstall "./Formula/$1.rb"
+brew uninstall --formula "./Formula/$1.rb"
 # https://github.com/Homebrew/brew/pull/4612#commitcomment-29995084
 mv "$1"*.bottle.* "$(echo $1*.bottle.* | sed s/--/-/)"


### PR DESCRIPTION
## Description

In several brew meta formulae we use the `bottle :unneeded` option, that has been deprecated and recently removed entirely.

This PR removes this option from the affected formulae.

## Related issue(s)

Resolves #398

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
