### PR TITLE
[Chore] Fix: tezos-baking fails to build on Fedora

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -203,7 +203,7 @@ cd .. && ./docker/docker-tezos-packages.sh --os fedora --type source --package t
 
 Sign source packages:
 ```
-rpm --add-sign out/*.src.rpm
+rpm --addsign out/*.src.rpm
 ```
 Note, that in order to sign them, you'll need gpg key to be set up in `~/.rpmmacros`.
 

--- a/docker/package/fedora.py
+++ b/docker/package/fedora.py
@@ -29,7 +29,7 @@ def build_fedora_package(
                 systemd_unit.service_file.service.environment_file.lower()
             )
         if systemd_unit.suffix is None:
-            unit_name = f"{pkg.name}"
+            unit_name = pkg.name
         else:
             unit_name = f"{pkg.name}-{systemd_unit.suffix}"
         out_path = (
@@ -39,9 +39,12 @@ def build_fedora_package(
         )
         print_service_file(systemd_unit.service_file, out_path)
         if systemd_unit.config_file is not None:
+            default_name = (
+                unit_name if systemd_unit.instances is None else f"{unit_name}@"
+            )
             shutil.copy(
                 f"{cwd}/defaults/{systemd_unit.config_file}",
-                f"{dir}/{unit_name}.default",
+                f"{dir}/{default_name}.default",
             )
         for script, script_source in [
             (systemd_unit.startup_script, systemd_unit.startup_script_source),


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: COPR reports tezos-baking-v12.0-1 failing to build on any
version/architecture because 'tezos-baking-custom@.default' isn't found.

Solution: fixed the bug in how the default name is chosen.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates to #369 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
