### PR TITLE
[Chore] Update installation instruction for new Raspberry Pi OS

### DIFF
--- a/docs/baking.md
+++ b/docs/baking.md
@@ -23,9 +23,8 @@ It is the recommended way at the moment to set up a baking instance.
 To bake on a Raspberry Pi you will need a device that has at least 4 GB of RAM
 and an arm64 processor; for example a Raspberry Pi 4B.
 
-You will also need to run the 64bit version of the [Raspberry Pi OS](https://www.raspberrypi.org/software/),
-that you can use by following the [installation instructions](https://www.raspberrypi.org/documentation/installation/installing-images/)
-with an image downloaded from the [official 64bit repository](https://downloads.raspberrypi.org/raspios_arm64/images/).
+You will also need to run the [64bit version of the Raspberry Pi OS](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit),
+that you can use by following the [installation instructions](https://www.raspberrypi.com/documentation/computers/getting-started.html#installing-the-operating-system).
 
 ### Installation
 
@@ -66,7 +65,7 @@ On Raspberry Pi OS:
 # Install software properties commons
 sudo apt-get install software-properties-common
 # Add PPA with Tezos binaries
-sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu bionic main'
+sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu focal main'
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 37B8819B7D0D183812DCA9A8CE5A4D8933AE7CBB
 ```
 

--- a/docs/distros/ubuntu.md
+++ b/docs/distros/ubuntu.md
@@ -34,15 +34,15 @@ Configuration files for these services are located in `/etc/default/tezos-baking
 <a name="raspberry"></a>
 ## Ubuntu packages on Raspberry Pi OS
 
-If you have a Raspberry Pi running the 64bit version of the official OS, you can
-use the Launchpad PPA to install `tezos-*` executables on it as well.
+If you have a Raspberry Pi running the [64bit version of the official OS](https://www.raspberrypi.com/software/operating-systems/#raspberry-pi-os-64-bit),
+you can use the Launchpad PPA to install `tezos-*` executables on it as well.
 
 You can add the PPA using:
 ```
 # Intall software properties commons
 sudo apt-get install software-properties-common
 # Add PPA with Tezos binaries
-sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu bionic main'
+sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu focal main'
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 37B8819B7D0D183812DCA9A8CE5A4D8933AE7CBB
 sudo apt-get update
 ```


### PR DESCRIPTION
## Description

Recently the 64bit version of the Raspberry Pi OS [has been made more visible and easily available](https://www.raspberrypi.com/news/raspberry-pi-os-64-bit/) and the current version is also based on a newer release of Debian.

This PR updates the documentation to reflect these news.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
