### PR TITLE
[Chore] Ithaca mainnet activation

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -14,7 +14,7 @@ from .systemd import Service, ServiceFile, SystemdUnit, Unit, Install
 
 networks = ["mainnet", "hangzhounet", "ithacanet"]
 networks_protos = {
-    "mainnet": ["011-PtHangz2"],
+    "mainnet": ["011-PtHangz2", "012-Psithaca"],
     "hangzhounet": ["011-PtHangz2"],
     "ithacanet": ["012-Psithaca"],
 }

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: Ithaca will soon be activated on mainnet. We need to support
an automatic switchover.

Solution: added 012-Psithaca to the list of mainnet protocols.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
