### PR TITLE
[#409] Use formulae tags for attaching bottles to releases

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -22,22 +22,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install GNU sed
+        run: |
+          brew install gnu-sed
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+
+      - id: extract-tag
+        name: Extract the right version from the formula
+        run: echo "tag=$(sed -n 's/^\s\+version \"\(.*\)\"/\1/p' ./Formula/${{ matrix.formula }}.rb)" >> $GITHUB_ENV
+
       - id: check-built
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         name: Check if the bottle has already been built
         continue-on-error: true
-        run: gh release view "${GITHUB_REF#refs/tags/}" | grep "${{ matrix.formula }}.*\.${{ matrix.os.name }}.bottle.tar.gz"
-
-      - name: Install coreutils for macOS # for sha256sum
-        if: steps.check-built.outcome == 'failure'
-        run: brew install coreutils
-
-      - name: Install GNU sed # for the other pipeline compatibility
-        if: steps.check-built.outcome == 'failure'
-        run: |
-          brew install gnu-sed
-          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+        run: gh release view "${{ env.tag }}" | grep "${{ matrix.formula }}.*\.${{ matrix.os.name }}.bottle.tar.gz"
 
         # tezos-sapling-params is used as a dependency for some of the formulas
         # so we handle it separately.
@@ -61,7 +60,7 @@ jobs:
         if: steps.check-built.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release upload "${GITHUB_REF#refs/tags/}" *.bottle.*
+        run: gh release upload "${{ env.tag }}" *.bottle.*
 
   sync-hashes:
     runs-on: macos-10.15
@@ -70,20 +69,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install GNU sed
+        run: |
+          brew install gnu-sed
+          echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
+
+      - name: Install coreutils for macOS # for sha256sum
+        run: brew install coreutils
+
+       # Since using the tag that triggered the pipeline isn't very resilient, we use the version
+       # from the tezos-client formula, which hopefully will stay the most up-to-date.
+      - id: extract-tag
+        name: Extract the right version from the formula
+        run: echo "tag=$(sed -n 's/^\s\+version \"\(.*\)\"/\1/p' ./Formula/tezos-client.rb)" >> $GITHUB_ENV
+
        # It's possible we have had to rerun the building workflow, skipping some jobs and
        # erasing the previously built bottles, so we use the release to download them all
       - name: Download Catalina bottles from the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${GITHUB_REF#refs/tags/}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
+        run: gh release download "${{ env.tag }}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
 
       - name: Add bottle hashes to formulae
-        run: ./scripts/sync-bottle-hashes.sh "${GITHUB_REF#refs/tags/}" "Catalina"
+        run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Catalina"
 
       - name: Download Big Sur bottles from the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${GITHUB_REF#refs/tags/}" -p "*.big_sur.bottle.tar.gz" -D "./Big Sur"
+        run: gh release download "${{ env.tag }}" -p "*.big_sur.bottle.tar.gz" -D "./Big Sur"
 
       - name: Add bottle hashes to formulae
-        run: ./scripts/sync-bottle-hashes.sh "${GITHUB_REF#refs/tags/}" "Big Sur"
+        run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Big Sur"

--- a/scripts/check-bottle-built.sh
+++ b/scripts/check-bottle-built.sh
@@ -1,0 +1,29 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2022 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+# This script takes the name of the binary for which to check if the bottle
+# has already been built and the OS name as its arguments.
+
+set -eo pipefail
+
+if [ -z "$1" ] || [ -z "$2" ] ; then
+    echo "Please call this script with the name of the formula and the OS name."
+    exit 1
+fi
+
+if [ ! -f "./Formula/$1.rb" ] ; then
+    echo "This formula doesn't exist."
+    exit 2
+fi
+
+tag=$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "./Formula/$1.rb")
+
+gh release view "$tag" | grep "$1.*\.$2.bottle.tar.gz"
+
+if [ $? -eq 0 ]; then
+    echo "Bottle is already attached to the $tag release."
+    exit 3
+else
+    exit 0
+fi


### PR DESCRIPTION
Problem: currently, both on GitHub Actions and with Buildkite, we build brew bottles on a new tag being pushed. In these runs, the bottle-building CI steps that have to do with:

1. checking that the bottle has already been built;
2. attaching built bottles to releases;
3. making commits that add new hashes to the formulae;

use the tag that triggered the pipeline. Turns out this behaviour doesn't work for any subsequent releases we make in the same upstream release, because the bottle versions usually stay the same, leading e.g. to the `v.*-2` release having `v.*-1` bottles attached.

Solution: changed the scripts to use the version of a specific formula where appropriate, or the one in `tezos-client.rb` where there is no specific bottle to be handled, as `tezos-client` is probably going to use the latest version.
In addition, changed BK steps to also check if a bottle has already been built.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #409

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
