### PR TITLE
[#402] Get network for voting from CL arguments

### DIFF
--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -10,6 +10,7 @@ the appropriate steps using the final configuration.
 
 import os, sys, subprocess, shlex
 import re, textwrap
+import argparse
 
 # Regexes
 
@@ -132,6 +133,12 @@ class Validator:
                 return input
             else:
                 return self.validator(input)
+
+
+# Command line argument parsing
+
+
+parser = argparse.ArgumentParser()
 
 
 # Utilities

--- a/docs/voting.md
+++ b/docs/voting.md
@@ -35,5 +35,11 @@ documented [here](./baking.md#using-a-custom-chain).
 After the custom baking instance is fully set up, you can vote or propose amendments on it by running:
 
 ```bash
-tezos-voting-wizard
+tezos-voting-wizard --network <custom-network-name>
+```
+
+E.g. if you have a custom baking instance `tezos-baking-custom@voting`, you can run:
+
+```bash
+tezos-voting-wizard --network voting
 ```


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: currently, Tezos Voting Wizard will ask to choose the network
to vote on first thing upon startup. This introduces an extra step
unnecessary for the vast majority of users, who will only ever want
to vote on mainnet.

Solution: removed the two steps meant to find out the network, replaced
them with a command line argument that defaults to 'mainnet'.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #402 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
