### PR TITLE
[#414] Compile ocaml-bls12-381 without ADX extension

### DIFF
--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -11,7 +11,7 @@ class TezosAccuser011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosAccuser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangz2.version}/"
-    sha256 cellar: :any, big_sur: "b7648005a94bbfc04cc1750f4fb6e7387c433d5b20a9f9cb311cc1fb51e3abc8"
-    sha256 cellar: :any, catalina: "c5ef686b2f4fa7f0f2d985f539d665e4318cec41ca3f8f4c6ef113874c487563"
-    sha256 cellar: :any, arm64_big_sur: "bc15bdf710fbfebe901907c9976fd4b1f0c3760bf698a5afb2b2c555a5f9167c"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -34,6 +34,9 @@ class TezosAccuser011Pthangz2 < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -34,6 +34,9 @@ class TezosAccuser012Psithaca < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -11,7 +11,7 @@ class TezosAccuser012Psithaca < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosAccuser012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser012Psithaca.version}/"
-    sha256 cellar: :any, big_sur: "f2b8e2c04bc6e906bfa8a5757f7fcf0d4713e74f76736b34c86f1eb572eb3043"
-    sha256 cellar: :any, catalina: "7dd91b0a533906be9f52683e28067296b7063fbd5551d6fc2c525d6ffe253e96"
-    sha256 cellar: :any, arm64_big_sur: "84d83f553e8f87c3037eb70a11f7e60517fbd06ff2a82c762cfb654b63617c69"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -11,7 +11,7 @@ class TezosAdminClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
-    sha256 cellar: :any, big_sur: "c959899261892fce36353d1590a1da590ee6d38d499f70c92978764e49eaebcc"
-    sha256 cellar: :any, catalina: "c773a2f48e00daf3bfdfefe7f56289e04f2411201ef0ec4a542e6498af098cc3"
-    sha256 cellar: :any, arm64_big_sur: "05afde5a93677a173de4e9ab8e6f1b8ec437c81538ad1884f22ab433c5709351"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -34,6 +34,9 @@ class TezosAdminClient < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -11,7 +11,7 @@ class TezosBaker011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosBaker011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangz2.version}/"
-    sha256 cellar: :any, big_sur: "27a407e4af93b6068acfa80936753a637f3bf3931b01b80f6db6f183640a41d4"
-    sha256 cellar: :any, catalina: "408f1c5ea0819ea29322dc773863887d2949c6165428f2770969462d53d76804"
-    sha256 cellar: :any, arm64_big_sur: "c848d6dcec78685694d064a9e1510f0850106f4a08145ece76d9f8ed718dab79"
   end
 
   def make_deps

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -34,6 +34,9 @@ class TezosBaker011Pthangz2 < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -11,7 +11,7 @@ class TezosBaker012Psithaca < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosBaker012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker012Psithaca.version}/"
-    sha256 cellar: :any, big_sur: "677a250ff4f37942b0d6a58ea9fa47cd3556fdcb838218839599bd1280f7dbca"
-    sha256 cellar: :any, catalina: "d12dd5058d093e71449b2ffc11658b86429d844a732c8fec5a05b5172fd8dc6b"
-    sha256 cellar: :any, arm64_big_sur: "8a04acb74bb698d5632e9547a72cd10b372c24922c63b4614e4899fad9b3f5a2"
   end
 
   def make_deps

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -34,6 +34,9 @@ class TezosBaker012Psithaca < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -11,7 +11,7 @@ class TezosClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
-    sha256 cellar: :any, big_sur: "8e6cb02f236ad62f4640078d9034316c4439f8e1a3e6110affc4fb1c07313627"
-    sha256 cellar: :any, catalina: "612f90df53fab77953c5135fdcb6931aaa60deef1df4196d50e3d102428e128e"
-    sha256 cellar: :any, arm64_big_sur: "04e3ee1b86da77aabfee3cb1218bb02e27d7570799c4aa1df4b7f848850b083b"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -34,6 +34,9 @@ class TezosClient < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -11,7 +11,7 @@ class TezosCodec < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
-    sha256 cellar: :any, big_sur: "f994339572337c4f23dcd24ac263c2453491f311a1ae604b73ade3b15a7ae4b0"
-    sha256 cellar: :any, catalina: "250e6a5ebc8efb44d9b9c7048f00519b09c96f3b62863bb5c2e897de7250b0d6"
-    sha256 cellar: :any, arm64_big_sur: "8498b3ba192453f9bbf974fcf5915dd71eb96f95f62b18d454f40b192bdd7759"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -34,6 +34,9 @@ class TezosCodec < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -11,7 +11,7 @@ class TezosEndorser011Pthangz2 < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -27,9 +27,6 @@ class TezosEndorser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangz2.version}/"
-    sha256 cellar: :any, big_sur: "f3be51324f5d8438b07606f78ba78ba9235307efa670c49fe0814afe18956214"
-    sha256 cellar: :any, catalina: "b28fc4e07752c4b81d344591c428aa09728b98bbd406ecf6dee17d7bf7264789"
-    sha256 cellar: :any, arm64_big_sur: "46d65bc78ba02d3d75904843cfbae52048877a6c9ae5b2f9fef898063f29bd00"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -35,6 +35,9 @@ class TezosEndorser011Pthangz2 < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-node-hangzhounet.rb
+++ b/Formula/tezos-node-hangzhounet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeHangzhounet < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node-ithacanet.rb
+++ b/Formula/tezos-node-ithacanet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeIthacanet < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeMainnet < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -34,6 +34,9 @@ class TezosNode < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -11,7 +11,7 @@ class TezosNode < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
-    sha256 cellar: :any, big_sur: "0dc55d2c431830f12c8ef7360ea0862459a59206f4e04253bdfb668aef19b8af"
-    sha256 cellar: :any, catalina: "f5e6227bdc9563dee0dc0d94b37e72ebb2964bfe072fd36b5354350de5d709f7"
-    sha256 cellar: :any, arm64_big_sur: "b012d00635120b3a161682a307c7e36022cf05a7fa374f81feff16ee22e86a46"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -11,7 +11,7 @@ class TezosSandbox < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
-    sha256 cellar: :any, big_sur: "f44fed48a1395d9f68e0473dd2945e0bce9f49dc5575b517d2b15cf26e28c24e"
-    sha256 cellar: :any, catalina: "1a846d5f9516d85ac968857a0867690742c9c4bd9c8a8887f4e1c1960c29d6ea"
-    sha256 cellar: :any, arm64_big_sur: "80b602a5d12786bf81410053cc791ac12d72e05cc39282a363210b2d04c54584"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -34,6 +34,9 @@ class TezosSandbox < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerHttp < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerHttps < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerTcp < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerUnix < Formula
   url "file:///dev/null"
-  version "v12.0-1"
+  version "v12.0-3"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -11,7 +11,7 @@ class TezosSigner < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v12.0", :shallow => false
 
-  version "v12.0-1"
+  version "v12.0-3"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|
@@ -26,9 +26,6 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
-    sha256 cellar: :any, big_sur: "257bc9f6bb0b00ed50f0c7dee127ffc8d0aeb8ca8f41185cda5924944f744785"
-    sha256 cellar: :any, catalina: "f059a501e05447d53bd25c0a10b7984ac6085eadae9acc1efc90dc851390d621"
-    sha256 cellar: :any, arm64_big_sur: "25052b8c81d1eead304cb83f7bdf78e2f942f620a2b44cbfe710cd7dbc56096a"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -34,6 +34,9 @@ class TezosSigner < Formula
   def make_deps
     ENV.deparallelize
     ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
     # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
     arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
     system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"

--- a/docker/build/build-tezos.sh
+++ b/docker/build/build-tezos.sh
@@ -13,6 +13,9 @@ cd tezos
 
 git apply ../static.patch
 export OPAMYES="true"
+# Disable usage of instructions from the ADX extension to avoid incompatibility
+# with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+export BLST_PORTABLE="yes"
 wget https://sh.rustup.rs/rustup-init.sh
 chmod +x rustup-init.sh
 ./rustup-init.sh --profile minimal --default-toolchain 1.52.1 -y

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -167,6 +167,9 @@ def gen_systemd_rules_contents(package):
     rules_contents = f"""#!/usr/bin/make -f
 
 export DEB_CFLAGS_APPEND=-fPIC
+# Disable usage of instructions from the ADX extension to avoid incompatibility
+# with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+export BLST_PORTABLE=yes
 
 %:
 	dh $@ {"--with systemd" if len(package.systemd_units) > 0 else ""}

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "2",
+    "release": "3",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description
Problem: By default ocaml-bls12-381 library (which is used as a
dependency by Octez) is compiled using instructions from ADX extension.
As a result, if package was build on a CPU that has this extension, CPUs
that don't have it won't be able to use binary from this package.

Solution: Compile Octez with 'BLST_PORTABLE=y' to avoid using ADX
instruction in ocaml-bls12-381.

We still need to find a way to test built packages and binaries on old CPU.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #414 (will be resolved once updated packages are released).

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
