### PR TITLE
[Chore] Hotfix 'check-bottle-built.sh'

### DIFF
--- a/scripts/check-bottle-built.sh
+++ b/scripts/check-bottle-built.sh
@@ -19,6 +19,8 @@ fi
 
 tag=$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "./Formula/$1.rb")
 
+# Command below is allowed to fail
+set +e
 gh release view "$tag" | grep "$1.*\.$2.bottle.tar.gz"
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Description
Problem: This script returns 1 exit code in case grep fails due to
'set -e'.

Solution: Allow 'gh release view ... | grep ...' to fail by setting
'set +e' before it.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #409

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
