### PR TITLE
[Chore] More hotfixes to the bottles release proccess

### DIFF
--- a/.buildkite/generate-tags-pipeline.sh
+++ b/.buildkite/generate-tags-pipeline.sh
@@ -97,7 +97,7 @@ ymlappend "
    - buildkite-agent artifact download \"*bottle.tar.gz\" \"Big Sur/\"
    - export FORMULA_TAG=\"\$(sed -n 's/^\s\+version \"\(.*\)\"/\1/p' ./Formula/tezos-client.rb)\"
    - nix-shell ./scripts/shell.nix
-       --run './scripts/sync-bottle-hashes.sh \"\$FORMULA_TAG\" \"Big Sur\"'
+       --run './scripts/sync-bottle-hashes.sh \"\$\$FORMULA_TAG\" \"Big Sur\"'
  - label: Attach bottles to the release
    depends_on:
    - \"uninstall-tsp\"
@@ -107,4 +107,4 @@ ymlappend "
    - buildkite-agent artifact download \"*bottle.tar.gz\" .
    - export FORMULA_TAG=\"\$(sed -n 's/^\s\+version \"\(.*\)\"/\1/p' ./Formula/tezos-client.rb)\"
    - nix-shell ./scripts/shell.nix
-       --run 'gh release upload \"\$FORMULA_TAG\" *.bottle.*'"
+       --run 'gh release upload \"\$\$FORMULA_TAG\" *.bottle.*'"

--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -91,4 +91,6 @@ jobs:
         run: gh release download "${{ env.tag }}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
 
       - name: Add bottle hashes to formulae
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Catalina"


### PR DESCRIPTION
## Description

1) Fix `FORMULA_TAG` variable handling in BK tags pipeline.
2) Add `GITHUB_TOKEN` variable to `Add bottle hashes to formulae` step on GA to allow
   it to open PRs.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
