### PR TITLE
[Chore] Add bottle hashes for v12.0-3

### DIFF
--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -26,6 +26,7 @@ class TezosAccuser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangz2.version}/"
+    sha256 cellar: :any, catalina: "c173b4b5e30a53f0e58905a626aea06f5b014ed52970384dc7434b586ee73111"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-011-PtHangz2.rb
+++ b/Formula/tezos-accuser-011-PtHangz2.rb
@@ -26,6 +26,8 @@ class TezosAccuser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser011Pthangz2.version}/"
+    sha256 cellar: :any, big_sur: "89e911a20b202ef7ac5c2e68a5f8294130ba3473662d8328a8d0400d4d2751df"
+    sha256 cellar: :any, arm64_big_sur: "2f1bda7596b64267d2b2c0d2ed0d88186cccd355f6d367625d927db38ec33a53"
     sha256 cellar: :any, catalina: "c173b4b5e30a53f0e58905a626aea06f5b014ed52970384dc7434b586ee73111"
   end
 

--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -26,6 +26,8 @@ class TezosAccuser012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser012Psithaca.version}/"
+    sha256 cellar: :any, big_sur: "05f9fc4e2725fd9c4947dd9bd53b8eb23c6295a6e1c31e98b5c4706e61f6d7da"
+    sha256 cellar: :any, arm64_big_sur: "0ec97b2c37cdd28bff5b1274aad2a4c02fcb46b0adf5f6a490326750f8613a95"
     sha256 cellar: :any, catalina: "721695c9dde4cdf73513f991b71a072efe204c116632cf4e3dcbef31deb2a5ce"
   end
 

--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -26,6 +26,7 @@ class TezosAccuser012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser012Psithaca.version}/"
+    sha256 cellar: :any, catalina: "721695c9dde4cdf73513f991b71a072efe204c116632cf4e3dcbef31deb2a5ce"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -26,6 +26,7 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, catalina: "c7e90977bd66a3c4f2c042dacdffc9f2a5129b8ffa5c2fe159e176f871d839da"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -26,6 +26,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, big_sur: "c79a4ad7ae8cd981c38bfcb4b5b4b808a202c497cf503c6d07b84a41e6b36866"
+    sha256 cellar: :any, arm64_big_sur: "f761621b82b5c2510e9add0336de68b75e71b5eb46ba8c74ae1286879a97225d"
     sha256 cellar: :any, catalina: "c7e90977bd66a3c4f2c042dacdffc9f2a5129b8ffa5c2fe159e176f871d839da"
   end
 

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -26,6 +26,7 @@ class TezosBaker011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangz2.version}/"
+    sha256 cellar: :any, catalina: "8aef5c13c11388035391fa94b5fbc0494248cd2cf3b3b7c5bade9e06318419ff"
   end
 
   def make_deps

--- a/Formula/tezos-baker-011-PtHangz2.rb
+++ b/Formula/tezos-baker-011-PtHangz2.rb
@@ -26,6 +26,8 @@ class TezosBaker011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker011Pthangz2.version}/"
+    sha256 cellar: :any, big_sur: "49209ff19504f92514977fa87d963aaddcc017ffa969aa5a13271f4a5d18637e"
+    sha256 cellar: :any, arm64_big_sur: "9d1ee6a5f204d9ce2da3991ad8675349ce869d7a23ed8fbc3072eea7590864cb"
     sha256 cellar: :any, catalina: "8aef5c13c11388035391fa94b5fbc0494248cd2cf3b3b7c5bade9e06318419ff"
   end
 

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -26,6 +26,8 @@ class TezosBaker012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker012Psithaca.version}/"
+    sha256 cellar: :any, big_sur: "852bf2e88297a15e2d9cceb84fefcd65cfbf4ebd70043d3b6c27f9a762bcf108"
+    sha256 cellar: :any, arm64_big_sur: "ac34902a7d501b99ca3718c32f677ffa18e41cb203e86eee2dc5645e075ed5a6"
     sha256 cellar: :any, catalina: "d7c5aa52818b215047a80107c4f161312639b0a42ed0e9cda4960fa4c8d6333d"
   end
 

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -26,6 +26,7 @@ class TezosBaker012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker012Psithaca.version}/"
+    sha256 cellar: :any, catalina: "d7c5aa52818b215047a80107c4f161312639b0a42ed0e9cda4960fa4c8d6333d"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -26,6 +26,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, big_sur: "bbda2f183fd531c3c952048abca287ec48cf26dccca15931b778b91ae13bfe7f"
+    sha256 cellar: :any, arm64_big_sur: "cba5b40b7e7206852f1d3ede4e6dd9a91e04de8d3da75fac76b7d63134987d75"
     sha256 cellar: :any, catalina: "ee35f6325130a559c5ddeca654e8cb90eecc21aa6146ffba4c7ffcbe92438281"
   end
 

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -26,6 +26,7 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, catalina: "ee35f6325130a559c5ddeca654e8cb90eecc21aa6146ffba4c7ffcbe92438281"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -26,6 +26,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, big_sur: "dfdaeb2df8d12c1ca3a213d0d9219a77bbc36e86f2584b5afe659dac9f54b654"
+    sha256 cellar: :any, arm64_big_sur: "1e72fa1c045be7730603c203790405a277bd14b1a651a63dfbd527014aa9a840"
     sha256 cellar: :any, catalina: "6bde95b316a911501504dc11d0f7b322883734226cc41c21df33421fa81eae3a"
   end
 

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -26,6 +26,7 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, catalina: "6bde95b316a911501504dc11d0f7b322883734226cc41c21df33421fa81eae3a"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -27,6 +27,7 @@ class TezosEndorser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangz2.version}/"
+    sha256 cellar: :any, catalina: "a060f557c9c42b3fb556886411be4af5050214353848612a06d884ce12ca2447"
   end
 
   def make_deps

--- a/Formula/tezos-endorser-011-PtHangz2.rb
+++ b/Formula/tezos-endorser-011-PtHangz2.rb
@@ -27,6 +27,8 @@ class TezosEndorser011Pthangz2 < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosEndorser011Pthangz2.version}/"
+    sha256 cellar: :any, big_sur: "639a3cd818b5562a5347adb2946dd639a810f37aa5548791b795f9f3f52d667d"
+    sha256 cellar: :any, arm64_big_sur: "fbcd5ec71c77cd2cd1d06a079707a17c65c84d62d3824d29ae47e5302d99b8f6"
     sha256 cellar: :any, catalina: "a060f557c9c42b3fb556886411be4af5050214353848612a06d884ce12ca2447"
   end
 

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -26,6 +26,7 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, catalina: "c1d5fe2b9af9c420c5983e3330043adecf82f880dd0ac9348cc0b9957c8c65bb"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -26,6 +26,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, big_sur: "8f69271ba2c77aae5eec6533556283a8b180094a67f43acb6c399a6feeb2b5c8"
+    sha256 cellar: :any, arm64_big_sur: "e95189cc34ca8ab783c638c1951b7a209c2a4c2122f96ee27b7aa88826fef1e4"
     sha256 cellar: :any, catalina: "c1d5fe2b9af9c420c5983e3330043adecf82f880dd0ac9348cc0b9957c8c65bb"
   end
 

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -26,6 +26,7 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, catalina: "1c991eee17f93853d52ffe9d8fc43561041e1c02e772eccb8a3847753327cf24"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -26,6 +26,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, big_sur: "4ce06800728f2ea8489971c3f9dcfce6e528df7b1b0f85e4cbec3f661091f233"
+    sha256 cellar: :any, arm64_big_sur: "6ed4886e8cf4d685bd5380fa1ef1b9b80cd30ea3367d95b91f92b5f32dad0f8b"
     sha256 cellar: :any, catalina: "1c991eee17f93853d52ffe9d8fc43561041e1c02e772eccb8a3847753327cf24"
   end
 

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -26,6 +26,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, big_sur: "3de2ea46991a3dfd070e0f00b2407329bc13e55ca9a67dc0851a3bb96421304b"
+    sha256 cellar: :any, arm64_big_sur: "20a02372268cd045a85cba2cbbf862966579b8ec698e4729040913654ac4074d"
     sha256 cellar: :any, catalina: "12e8c657f22d4f602e7f1c2f97811cc18832bb55f4e0802a2410d0bb13019147"
   end
 

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -26,6 +26,7 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, catalina: "12e8c657f22d4f602e7f1c2f97811cc18832bb55f4e0802a2410d0bb13019147"
   end
 
   def make_deps


### PR DESCRIPTION
Problem: we have built brew bottles for the new Octez release, but their hashes
aren't in the formulae yet.

Solution: added the hashes.