### PR TITLE
[#421] Protocol switch-over with 'tezos-baking'

### DIFF
--- a/docs/baking.md
+++ b/docs/baking.md
@@ -79,6 +79,15 @@ Packages for `tezos-node`, `tezos-baker-<proto>` and `tezos-endorser-<proto>` pr
 systemd units for running the corresponding binaries in the background, these units
 are orchestrated by the `tezos-baking-<network>` units.
 
+## Packages and protocols updates
+
+In order to have a safe transition during a new protocol activation on mainnet,
+it's required to run two sets of daemons: for the current and for the upcoming protocol.
+
+`tezos-baking` package aims to provide such a setup. This package is updated some time before
+the new protocol is activated (usually 1-2 weeks) to run daemons for two protocols. Once the new
+protocol is activated, the `tezos-baking` package is updated again to stop running daemons for the old protocol.
+
 ## Using the wizard
 
 If at this point you want to set up the baking instance, or just a node, using the wizard, run:

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -39,19 +39,18 @@ from scratch.
 
 For this you'll need a `.service` file to define each systemd service.
 The easiest way to get one is to run [`gen_systemd_service_file.py`](../gen_systemd_service_file.py).
-You should specify the service name as an argument. Note that there are two
-predefined services for `tezos-node`: `tezos-node-{mainnet, hangzhounet}`.
+You should specify the binary name as an argument.
 
 E.g.:
 ```
-./gen_systemd_service_file.py tezos-node-mainnet
+./gen_systemd_service_file.py tezos-node
 # or
 ./gen_systemd_service_file.py tezos-baker-011-PtHangz2
 ```
-After that you'll have a `.service` file in the current directory.
+After that you'll have `.service` files in the current directory.
 
-Apart from the `.service` file you'll need the service startup script and default
-configuration file, they can be found in the [`scripts`](../docker/package/scripts) and
+Apart from these `.service` files you'll need the services' startup scripts and default
+configuration files, they can be found in the [`scripts`](../docker/package/scripts) and
 [`defaults`](../docker/package/defaults) folders respectively.
 
 ## Systemd units on WSL


### PR DESCRIPTION
## Description

Problem: Protocol switch-over requires users to run two sets of daemons.
Our baking doc should mention how `tezos-baking` services handle it.

Solution: Add a section to the baking doc which mentions that
`tezos-baking` package handles this requirement.

Also, fix `gen_systemd_service_file.py` usage instructions

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #421

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
