### PR TITLE
[Chore] Fix 'MIRROR_REPO' variable interpolation

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -185,7 +185,7 @@ steps:
     MIRROR_REPO: "git@github.com:serokell/tezos-packaging-stable.git"
    commands: &update_mirror
    - git pull origin "$BUILDKITE_BRANCH:$BUILDKITE_BRANCH"
-   - git push --mirror "$MIRROR_REPO"
+   - git push --mirror "$$MIRROR_REPO"
 
  - label: update RC mirror repository
    if: |


### PR DESCRIPTION
## Description

Problem: 'MIRROR_REPO' is a runtime step variable. As a result
'$MIRROR_REPO' interpolation returns an empty string, see
https://buildkite.com/docs/pipelines/environment-variables#runtime-variable-interpolation.

Solution: Escape '$' character.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
