### PR TITLE
[Chore] Fix 'Attach bottles to the release' dependencies

### DIFF
--- a/.buildkite/generate-tags-pipeline.sh
+++ b/.buildkite/generate-tags-pipeline.sh
@@ -87,10 +87,11 @@ done
 
 ymlappend "
  - label: Add Big Sur bottle hashes to formulae
-   depends_on:
-   - \"uninstall-tsp-arm64\"
-   - \"uninstall-tsp-x86_64\"
-   if: build.tag =~ /^v.*/
+   depends_on:"
+for arch in "${architecture[@]}"; do
+   ymlappend "   - \"uninstall-tsp-$arch\""
+done
+   ymlappend "   if: build.tag =~ /^v.*/
    soft_fail: true # No artifacts to download if all the bottles are already built
    commands:
    - mkdir -p \"Big Sur\"
@@ -99,9 +100,11 @@ ymlappend "
    - nix-shell ./scripts/shell.nix
        --run './scripts/sync-bottle-hashes.sh \"\$\$FORMULA_TAG\" \"Big Sur\"'
  - label: Attach bottles to the release
-   depends_on:
-   - \"uninstall-tsp\"
-   if: build.tag =~ /^v.*/
+   depends_on:"
+for arch in "${architecture[@]}"; do
+   ymlappend "   - \"uninstall-tsp-$arch\""
+done
+   ymlappend "   if: build.tag =~ /^v.*/
    soft_fail: true # No artifacts to download if all the bottles are already built
    commands:
    - buildkite-agent artifact download \"*bottle.tar.gz\" .


### PR DESCRIPTION
## Description
Problem: Currently this step depends on non-architecture specific
step 'uninstall-tsp' which is no longer present.

Solution: Make it depend on arch-specific uninstall-tsp steps.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
