### PR TITLE
[#401] Don't require tezos-baking-mainnet.service to vote

### DIFF
--- a/docker/package/tezos_voting_wizard.py
+++ b/docker/package/tezos_voting_wizard.py
@@ -118,23 +118,22 @@ ballot_outcome_query = Step(
     ),
 )
 
-client_data_dir_query = Step(
-    id="client_data_dir",
-    prompt="Provide the path to the data directory of tezos-client.",
-    help="The data directory will be used by tezos-client to vote. If you have baking set up\n"
-    "through systemd services, the path is usually '/var/lib/tezos/.tezos-client' by default.",
-    default=None,
-    validator=Validator([required_field_validator, dirpath_validator]),
-)
 
-node_rpc_addr_query = Step(
-    id="node_rpc_addr",
-    prompt="Provide the node's RPC address.",
-    help="The node's RPC address will be used by tezos-client to vote. If you have baking set up\n"
-    "through systemd services, the address is usually 'http://localhost:8732' by default.",
-    default=None,
-    validator=Validator([required_field_validator]),
-)
+def get_node_rpc_addr_query(default=None):
+    return Step(
+        id="node_rpc_addr",
+        prompt="Provide the node's RPC address.",
+        help="The node's RPC address will be used by tezos-client to vote. If you have baking set up\n"
+        "through systemd services, the address is usually 'http://localhost:8732' by default.",
+        default=default,
+        validator=Validator(
+            [
+                required_field_validator,
+                reachable_url_validator("chains/main/blocks/head/"),
+            ]
+        ),
+    )
+
 
 baker_alias_query = Step(
     id="baker_alias",
@@ -144,6 +143,18 @@ baker_alias_query = Step(
     default=None,
     validator=Validator([required_field_validator]),
 )
+
+# We define the step as a function to disallow choosing json
+def get_key_mode_query(modes):
+    return Step(
+        id="key_import_mode",
+        prompt="How do you want to import the voter key?",
+        help="Tezos Voting Wizard will use the 'baker' alias for the key\n"
+        "that will be used for voting. You will only need to import the key\n"
+        "once unless you'll want to change the key.",
+        options=modes,
+        validator=Validator(enum_range_validator(modes)),
+    )
 
 
 class Setup(Setup):
@@ -178,13 +189,12 @@ class Setup(Setup):
         print("Baker data detected is as follows:")
         print(f"Data directory: {self.config['client_data_dir']}")
         print(f"Node RPC address: {self.config['node_rpc_addr']}")
-        print(f"Baker alias: {self.config['baker_alias']}")
+        print(f"Voter key: {self.config['baker_key_value']}")
         return yes_or_no("Does this look correct? (Y/n) ", "yes")
 
     def search_client_config(self, field, default):
         config_filepath = os.path.join(self.config["client_data_dir"], "config")
         if not os.path.isfile(config_filepath):
-            print("No config file in this directory. Falling back on the default.")
             return default
         else:
             return search_json_with_default(config_filepath, field, default)
@@ -192,30 +202,62 @@ class Setup(Setup):
     def collect_baking_info(self):
         if self.check_baking_service():
             self.fill_baking_config()
+
+            value, _ = get_key_address(
+                self.config["tezos_client_options"], self.config["baker_alias"]
+            )
+            self.config["baker_key_value"] = value
+
             collected = self.check_data_correctness()
         else:
-            # Here, we collect some semi-sensible defaults. Since the baking service isn't
-            # running here, these defaults have a low chance of being correct.
-            print("Default values will be used. Please check them carefully.\n")
 
-            self.config["client_data_dir"] = "/var/lib/tezos/.tezos-client"
-            self.config["node_rpc_addr"] = self.search_client_config(
-                "endpoint", "http://localhost:8732"
-            )
-            self.config["baker_alias"] = "baker"
+            network_dir = "/var/lib/tezos/client-" + self.config["network"]
 
+            proc_call(f"sudo -u tezos mkdir -p {network_dir}")
+
+            print("With no tezos-baking.service running, this wizard will use")
+            print(f"the default directory for this network: {network_dir}")
+
+            self.config["client_data_dir"] = network_dir
+
+            self.config["node_rpc_addr"] = self.search_client_config("endpoint", None)
+            if self.config["node_rpc_addr"] is None:
+                self.query_and_update_config(get_node_rpc_addr_query())
+
+            key_import_modes.pop("json", None)
+            self.get_baker_key()
+
+            # Check correctness in case user wants to change this data upon reruns
             collected = self.check_data_correctness()
 
         while not collected:
-            self.query_step(client_data_dir_query)
+            self.query_and_update_config(
+                get_node_rpc_addr_query(self.config["node_rpc_addr"])
+            )
 
-            self.config["node_rpc_addr"] = search_client_config("endpoint", None)
-            if self.config["node_rpc_addr"] is None:
-                self.query_step(node_rpc_addr_query)
-
-            self.query_step(baker_alias_query)
+            replace_baker_key = self.check_baker_account()
+            if replace_baker_key:
+                key_mode_query = get_key_mode_query(key_import_modes)
+                self.import_key(key_mode_query)
 
             collected = self.check_data_correctness()
+
+    def get_baker_key(self):
+        if "baker_alias" not in self.config:
+            self.config["baker_alias"] = "baker"
+
+        self.config["tezos_client_options"] = self.get_tezos_client_options()
+
+        baker_key_value = get_key_address(
+            self.config["tezos_client_options"], self.config["baker_alias"]
+        )
+
+        if baker_key_value is not None:
+            value, _ = baker_key_value
+            self.config["baker_key_value"] = value
+        else:  # if there is no key with this alias, query import
+            key_mode_query = get_key_mode_query(key_import_modes)
+            self.import_key(key_mode_query)
 
     def get_network(self):
         if parsed_args.network == "mainnet":

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -11,6 +11,7 @@ the appropriate steps using the final configuration.
 import os, sys, subprocess, shlex
 import re, textwrap
 import argparse
+import json
 
 # Regexes
 
@@ -43,6 +44,12 @@ def enum_range_validator(options):
             return opts[opt]
 
     return _validator
+
+
+def dirpath_validator(input):
+    if input and not os.path.isdir(input):
+        raise ValueError("Please input a valid path to a directory.")
+    return input
 
 
 def filepath_validator(input):
@@ -229,6 +236,15 @@ def search_baking_service_config(config_contents, regex, default):
         return default
     else:
         return res.group(1)
+
+
+def search_json_with_default(json_filepath, field, default):
+    with open(json_filepath, "r") as f:
+        try:
+            json_dict = json.load(f)
+        except:
+            return default
+        return json_dict.pop(field, default)
 
 
 class Step:


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: currently, the voting wizard only supports systems which
have baking through systemd services set up. This is not the actual
minimal requirement, which is access to a ledger via tezos-client.

Solution: only check the service for baking info if it's running,
otherwise collect the necessary information from the user.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #401

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
