### PR TITLE
[#431] Hotfix 'update-tezos.sh'

### DIFF
--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -48,7 +48,9 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
     git commit -a -m "[Chore] Update brew formulae for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io"
 
     sed -i 's/"release": "[0-9]\+"/"release": "1"/' ./meta.json
-    git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io"
+    # Commit may fail when release number wasn't updated since the last release
+    git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+      echo "release number wasn't updated"
 
     git push --set-upstream origin "$branch_name"
 


### PR DESCRIPTION
## Description
Problem: An attempt to commit empty changes for release number update
causes 'update-tezos.sh' script to fail. This may happen when we didn't
make any additional releases since the last Octez release.

Solution: Allow this step to fail and print a message that release
number wasn't updated.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
