### PR TITLE
[Chore] Remove hangzhou from mainnet baking service

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -14,7 +14,7 @@ from .systemd import Service, ServiceFile, SystemdUnit, Unit, Install
 
 networks = ["mainnet", "hangzhounet", "ithacanet"]
 networks_protos = {
-    "mainnet": ["011-PtHangz2", "012-Psithaca"],
+    "mainnet": ["012-Psithaca"],
     "hangzhounet": ["011-PtHangz2"],
     "ithacanet": ["012-Psithaca"],
 }


### PR DESCRIPTION
## Description

Problem: ithaca has been activated on mainnet, so there is no
longer need to run its daemons in the mainnet baking service.

Solution: Remove hangzhou from the mainnet baking service.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
