### PR TITLE
[#442] Support testnets in the voting wizards

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -19,12 +19,6 @@ from wizard_structure import *
 
 # Global options
 
-networks = {
-    "mainnet": "Main Tezos network",
-    "hangzhounet": "Test network using version 011 of Tezos protocol (Hangzhou)",
-    "ithacanet": "Test network using version 012 of Tezos protocol (Ithaca2)",
-}
-
 modes = {
     "baking": "Set up and start all services for baking: "
     "tezos-node, tezos-baker, and tezos-endorser.",

--- a/docker/package/tezos_voting_wizard.py
+++ b/docker/package/tezos_voting_wizard.py
@@ -22,7 +22,6 @@ ballot_outcomes = {
     "pass": "Submit a vote not influencing the result but contributing to quorum",
 }
 
-
 # Command line argument parsing
 
 parser.add_argument(
@@ -30,7 +29,7 @@ parser.add_argument(
     required=False,
     default="mainnet",
     help="Name of the network to vote on. Is 'mainnet' by default, "
-    "but can take the (part after @) name of any custom instance. "
+    "but can be a testnet or the (part after @) name of any custom instance. "
     "For example, to use the tezos-baking-custom@voting service, input 'voting'. "
     "You need to already have set up the custom network using systemd services.",
 )
@@ -260,8 +259,8 @@ class Setup(Setup):
             self.import_key(key_mode_query)
 
     def get_network(self):
-        if parsed_args.network == "mainnet":
-            self.config["network"] = "mainnet"
+        if parsed_args.network in networks.keys():
+            self.config["network"] = parsed_args.network
         else:
             # TODO: maybe check/validate this
             self.config["network"] = "custom@" + parsed_args.network

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -234,6 +234,12 @@ key_import_modes = {
     "json": "Faucet JSON file from https://teztnets.xyz/",
 }
 
+networks = {
+    "mainnet": "Main Tezos network",
+    "hangzhounet": "Test network using version 011 of Tezos protocol (Hangzhou)",
+    "ithacanet": "Test network using version 012 of Tezos protocol (Ithaca2)",
+}
+
 # Wizard CLI skeleton
 
 

--- a/docs/voting.md
+++ b/docs/voting.md
@@ -43,3 +43,11 @@ E.g. if you have a custom baking instance `tezos-baking-custom@voting`, you can 
 ```bash
 tezos-voting-wizard --network voting
 ```
+
+## Using testnets
+
+`tezos-voting-wizard` also supports voting on currently running testnets, for example:
+
+```bash
+tezos-voting-wizard --network ithacanet
+```


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: Currently the voting wizard supports mainnet and custom networks, but not testnets.

Solution: Add support for the testnets.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #442 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).