### PR TITLE
[#401] Fix URLs and waiting for ledger

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -382,7 +382,12 @@ class Setup(Setup):
 
             key_mode_query = get_key_mode_query(key_import_modes)
 
-            self.import_key(key_mode_query)
+            self.import_key(key_mode_query, "Baking")
+
+            proc_call(
+                f"sudo -u tezos {suppress_warning_text} tezos-client {tezos_client_options} "
+                f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
+            )
 
     def register_baker(self):
         print()

--- a/docs/tests/voting.md
+++ b/docs/tests/voting.md
@@ -17,7 +17,7 @@ amendment periods.
 
 1) Generate a pair of keys associated with `baker` alias:
 
-```
+```bash
 sudo -u tezos tezos-client gen keys baker
 ```
 
@@ -29,10 +29,12 @@ This script will provide you a path to the node config that will be used by the 
 
 4) Create a config for the custom baking service that will be used by the voting wizard:
 
-```
+```bash
 sudo cp /etc/default/tezos-baking-custom@ /etc/default/tezos-baking-custom@voting
 ```
+
 Edit with the config provided by the voting script on the second step:
+
 ```
 DATA_DIR="/var/lib/tezos/.tezos-client"
 NODE_RPC_ENDPOINT="http://localhost:8732"
@@ -46,19 +48,21 @@ be triggered once custom baking service will be stopped.
 
 5) Start custom baking service:
 
-```
+```bash
 sudo systemctl start tezos-baking-custom@voting
 ```
 
 Note that `tezos-node` service may take some time to generate a fresh identity and start.
 
 To check the status of the node service run:
-```
+
+```bash
 systemctl status tezos-node-custom@voting
 ```
 
 6) Register `baker` key as delegate once `tezos-node` is up and running:
-```
+
+```bash
 sudo -u tezos tezos-client register key baker as delegate
 ```
 
@@ -66,12 +70,19 @@ sudo -u tezos tezos-client register key baker as delegate
 
 The script will stop at the beginning of each voting period that requires voting and ask you to vote.
 
-Launch `tezos-voting-wizard`, select `custom` network with `voting` name and submit your vote.
+Launch the wizard by running:
+
+```bash
+tezos-voting-wizard --network voting
+```
+
 Under normal conditions, you won't have to adjust any information about your baking service.
+Confirm the information and submit your vote.
 
 Once you'll vote, you should prompt the `voting.py` script to continue going through the voting cycle.
 
 8) Stop custom baking service once voting cycle is over:
-```
+
+```bash
 sudo systemctl stop tezos-baking-custom@voting
 ```


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: there are several minor inconveniences affecting both Tezos
wizards: the URL validator sometimes fails to report an issue correctly,
and it's not possible to go back after choosing ledger as your key import
method to choose another one without closing the whole wizard.

Solution: changed the URL joining method, added an out to waiting for the
ledger app.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Follows #433

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
