### PR TITLE
[#403] Services fail to start

### DIFF
--- a/docker/package/scripts/tezos-baker-start
+++ b/docker/package/scripts/tezos-baker-start
@@ -56,6 +56,12 @@ launch_baker() {
     fi
 }
 
+# TODO we should use --keep-alive instead of this loop once
+# https://gitlab.com/tezos/tezos/-/issues/2873 is fixed
+# Waiting till node start to respond
+
+while ! "$tezos_client" --endpoint "$NODE_RPC_ENDPOINT" rpc list &> /dev/null; do sleep 1; done
+
 if [[ -z "$BAKER_ADDRESS_ALIAS" ]]; then
     launch_baker "$@"
 else


### PR DESCRIPTION
## Description

If node needs more time to start responding, than baker/endorser services can wait for it, systemd restarts all the tezos services indefinetily.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #403

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
