### PR TITLE
[Chore] Fixup tezos-baker-013-PtJakart.rb

### DIFF
--- a/Formula/tezos-baker-013-PtJakart.rb
+++ b/Formula/tezos-baker-013-PtJakart.rb
@@ -87,7 +87,7 @@ class TezosBaker013Ptjakart < Formula
           launch_baker "$BAKER_ACCOUNT"
       fi
     EOS
-    File.write("tezos-baker-013-PtJakart", startup_contents)
+    File.write("tezos-baker-013-PtJakart-start", startup_contents)
     bin.install "tezos-baker-013-PtJakart-start"
     make_deps
     install_template "src/proto_013_PtJakart/bin_baker/main_baker_013_PtJakart.exe",


### PR DESCRIPTION
## Description
Problem: The startup script for 'tezos-baker-013-PtJakart.rb' is written to
non-existing path. This causes build to fail.

Solution: Fix startup script path.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
