### PR TITLE
[#451] Add 'netbase' to 'tezos-node' package deps

### DIFF
--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -11,7 +11,7 @@ class TezosAccuser012Psithaca < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-accuser-013-PtJakart.rb
+++ b/Formula/tezos-accuser-013-PtJakart.rb
@@ -11,7 +11,7 @@ class TezosAccuser013Ptjakart < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -11,7 +11,7 @@ class TezosAdminClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -11,7 +11,7 @@ class TezosBaker012Psithaca < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-baker-013-PtJakart.rb
+++ b/Formula/tezos-baker-013-PtJakart.rb
@@ -11,7 +11,7 @@ class TezosBaker013Ptjakart < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -11,7 +11,7 @@ class TezosClient < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -11,7 +11,7 @@ class TezosCodec < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-node-ithacanet.rb
+++ b/Formula/tezos-node-ithacanet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeIthacanet < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node-jakartanet.rb
+++ b/Formula/tezos-node-jakartanet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeJakartanet < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -3,7 +3,7 @@
 
 class TezosNodeMainnet < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-node"
 

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -11,7 +11,7 @@ class TezosNode < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -11,7 +11,7 @@ class TezosSandbox < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerHttp < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerHttps < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerTcp < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -3,7 +3,7 @@
 
 class TezosSignerUnix < Formula
   url "file:///dev/null"
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   depends_on "tezos-signer"
 

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -11,7 +11,7 @@ class TezosSigner < Formula
 
   url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0-rc1", :shallow => false
 
-  version "v13.0-rc1-1"
+  version "v13.0-rc1-2"
 
   build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
   build_dependencies.each do |dependency|

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -202,6 +202,13 @@ class TezosBinaryPackage(AbstractPackage):
         self.meta = meta
         self.dune_filepath = dune_filepath
 
+    def __get_os_specific_native_deps(self, os_name):
+        return [
+            x[os_name] if (isinstance(x, dict)) else x
+            for x in self.additional_native_deps
+            if isinstance(x, str) or (isinstance(x, dict) and os_name in x.keys())
+        ]
+
     def fetch_sources(self, out_dir):
         os.makedirs(out_dir)
         os.chdir(out_dir)
@@ -233,7 +240,9 @@ class TezosBinaryPackage(AbstractPackage):
 
     def gen_control_file(self, deps, ubuntu_version, out):
         str_build_deps = ", ".join(deps)
-        str_additional_native_deps = ", ".join(self.additional_native_deps)
+        str_additional_native_deps = ", ".join(
+            self.__get_os_specific_native_deps("ubuntu")
+        )
         file_contents = f"""
 Source: {self.name.lower()}
 Section: utils
@@ -254,7 +263,9 @@ Description: {self.desc}
     def gen_spec_file(self, build_deps, run_deps, out):
         build_requires = " ".join(build_deps)
         requires = " ".join(run_deps)
-        str_additional_native_deps = ", ".join(self.additional_native_deps)
+        str_additional_native_deps = ", ".join(
+            self.__get_os_specific_native_deps("fedora")
+        )
         (
             systemd_deps,
             systemd_install,

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -252,7 +252,7 @@ packages.append(
         systemd_units=node_units,
         postinst_steps=node_postinst_steps,
         postrm_steps=node_postrm_steps,
-        additional_native_deps=["tezos-sapling-params"],
+        additional_native_deps=["tezos-sapling-params", {"ubuntu": "netbase"}],
         dune_filepath="src/bin_node/main.exe",
     )
 )

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>"
 }

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -24,7 +24,7 @@ cd ..
 rm -rf upstream-repo
 
 git clone --bare https://gitlab.com/tezos/opam-repository.git upstream-opam-repository
-opam_repository_branch="$(git --git-dir=upstream-opam-repository for-each-ref --contains "$opam_repository_tag" --count=1 --sort='-refname' --format="%(refname:lstrip=3)" refs/remotes/origin)""
+opam_repository_branch="$(git --git-dir=upstream-opam-repository for-each-ref --contains "$opam_repository_tag" --count=1 --sort='-refname' --format="%(refname:lstrip=3)" refs/remotes/origin)"
 rm -rf upstream-opam-repository
 
 branch_name="auto/$latest_upstream_tag-release"


### PR DESCRIPTION
## Description
Problem: 'tezos-node' fails with 'Failure "resolution failed: unknown scheme"'
inside fresh Ubuntu docker container when it attempts to resolve some URL.

Solution: Add 'netbase' dependency to Ubuntu 'tezos-node' package.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Relates #451

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
