### PR TITLE
[Chore] Add bottle hashes for v13.0-1

### DIFF
--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -26,6 +26,7 @@ class TezosAccuser012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser012Psithaca.version}/"
+    sha256 cellar: :any, catalina: "58c40f75b7f318975d17b1fa65797b9549ed5d407c8bdde2209d5a77f3a75123"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-012-Psithaca.rb
+++ b/Formula/tezos-accuser-012-Psithaca.rb
@@ -26,6 +26,8 @@ class TezosAccuser012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser012Psithaca.version}/"
+    sha256 cellar: :any, big_sur: "d16c630cee04d49f541a43f976b1a4dd28909da8c244b5a92dade19ee44d09c6"
+    sha256 cellar: :any, arm64_big_sur: "ae1fc570920ce4857355bee95d2f476cd3e11fbb647bd1b4312b74ccd5448a53"
     sha256 cellar: :any, catalina: "58c40f75b7f318975d17b1fa65797b9549ed5d407c8bdde2209d5a77f3a75123"
   end
 

--- a/Formula/tezos-accuser-013-PtJakart.rb
+++ b/Formula/tezos-accuser-013-PtJakart.rb
@@ -26,6 +26,8 @@ class TezosAccuser013Ptjakart < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser013Ptjakart.version}/"
+    sha256 cellar: :any, big_sur: "e6418258cfe5942abf18f1b139d28271e824a6aa49e3e889de98381512bee7df"
+    sha256 cellar: :any, arm64_big_sur: "08a3ac1dfa299aa34eedbf0deff66558e12fc850c51a1abf0e414d94f2423cd4"
     sha256 cellar: :any, catalina: "84c320c327b25f3d047df4971eaf78cd64bb7685cede0aab09a37e3ea9c4a7a4"
   end
 

--- a/Formula/tezos-accuser-013-PtJakart.rb
+++ b/Formula/tezos-accuser-013-PtJakart.rb
@@ -26,6 +26,7 @@ class TezosAccuser013Ptjakart < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuser013Ptjakart.version}/"
+    sha256 cellar: :any, catalina: "84c320c327b25f3d047df4971eaf78cd64bb7685cede0aab09a37e3ea9c4a7a4"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -26,6 +26,8 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, big_sur: "66440791b22d8b78bfde2d12b6f94406812422aa1da7a7eadaaffba857d6d731"
+    sha256 cellar: :any, arm64_big_sur: "1728ca20ae075237b091c41b31167b64a5d88e769e2bf5c14d3b6f569e79cb89"
     sha256 cellar: :any, catalina: "739c675926396d9a11fcf62e33ba07fc80774f6dc0a74e3ce08d99cc1f9dd9d7"
   end
 

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -26,6 +26,7 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, catalina: "739c675926396d9a11fcf62e33ba07fc80774f6dc0a74e3ce08d99cc1f9dd9d7"
   end
 
   def make_deps

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -26,6 +26,7 @@ class TezosBaker012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker012Psithaca.version}/"
+    sha256 cellar: :any, catalina: "690bdec90eb45090d4e1c0a13f3c289dca5a5445fd124fd7703b61976b05938c"
   end
 
   def make_deps

--- a/Formula/tezos-baker-012-Psithaca.rb
+++ b/Formula/tezos-baker-012-Psithaca.rb
@@ -26,6 +26,8 @@ class TezosBaker012Psithaca < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker012Psithaca.version}/"
+    sha256 cellar: :any, big_sur: "86d3a0576187994ff33869cd6406972d219b762cd07dd160928d42451d5ac918"
+    sha256 cellar: :any, arm64_big_sur: "2629578fe67caed75f93cb025f63a251de5c1fc3eae7240b030c97f52ed4ff13"
     sha256 cellar: :any, catalina: "690bdec90eb45090d4e1c0a13f3c289dca5a5445fd124fd7703b61976b05938c"
   end
 

--- a/Formula/tezos-baker-013-PtJakart.rb
+++ b/Formula/tezos-baker-013-PtJakart.rb
@@ -26,6 +26,7 @@ class TezosBaker013Ptjakart < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker013Ptjakart.version}/"
+    sha256 cellar: :any, catalina: "fbacb754a587d63a05db96be762ea1134871207e9039f684ef9c5c3e18d6ac28"
   end
 
   def make_deps

--- a/Formula/tezos-baker-013-PtJakart.rb
+++ b/Formula/tezos-baker-013-PtJakart.rb
@@ -26,6 +26,8 @@ class TezosBaker013Ptjakart < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBaker013Ptjakart.version}/"
+    sha256 cellar: :any, big_sur: "0e47c78a6cbec0a2ff755927998a0f5a77a1e56217d778c46e2a821df6e74322"
+    sha256 cellar: :any, arm64_big_sur: "db0f0d00f95a5d363db2dcb8e66ee7fee076ff5e86b8fe136d0cc6953a761da2"
     sha256 cellar: :any, catalina: "fbacb754a587d63a05db96be762ea1134871207e9039f684ef9c5c3e18d6ac28"
   end
 

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -26,6 +26,7 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, catalina: "4239b5655f5e828279e3a336645b635609553203dc4f4d0b4a1fb5cd3642699b"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -26,6 +26,8 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, big_sur: "40a2581ef0170009a9804fdfd2f1313ad98c4af484cb62ab28e3b7ad8a801315"
+    sha256 cellar: :any, arm64_big_sur: "8aa9e2f8855ac4a30584ab262053310618fc5bdd8872da57f682485ee1622a8f"
     sha256 cellar: :any, catalina: "4239b5655f5e828279e3a336645b635609553203dc4f4d0b4a1fb5cd3642699b"
   end
 

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -26,6 +26,8 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, big_sur: "c16489f8c6f3589fcec4a22cc851060f5bd333fdf09308ae3d6735403d94fa8d"
+    sha256 cellar: :any, arm64_big_sur: "d3a707b11596af4ffe8ed168b12d00c4b3a6591c203521dcaf19370e5b278ff6"
     sha256 cellar: :any, catalina: "3eba55dbc887bf66c6003e8d835e987d0def75ead10f147b3af7a65ae8af965f"
   end
 

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -26,6 +26,7 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, catalina: "3eba55dbc887bf66c6003e8d835e987d0def75ead10f147b3af7a65ae8af965f"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -26,6 +26,8 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, big_sur: "3def45b2641c54c6806780f1c3f12fc782ce57dfe6c6035149439b1f32f00c36"
+    sha256 cellar: :any, arm64_big_sur: "167077b54aba0b2ae383a4ab99a929a9d68a48c5080ac26f80e5e249cc94e9aa"
     sha256 cellar: :any, catalina: "abadb1cf4dce649e5ee1e5d364287a2ce91d8602eb40ec09a1426f6dc4084289"
   end
 

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -26,6 +26,7 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, catalina: "abadb1cf4dce649e5ee1e5d364287a2ce91d8602eb40ec09a1426f6dc4084289"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -26,6 +26,7 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, catalina: "558e7df1c0e8072a136518321dcd2f05fef33ee464903ff1f03fff9f7f3c5651"
   end
 
   def make_deps

--- a/Formula/tezos-sandbox.rb
+++ b/Formula/tezos-sandbox.rb
@@ -26,6 +26,8 @@ class TezosSandbox < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSandbox.version}/"
+    sha256 cellar: :any, big_sur: "1b60bc69094a2a2caeba7bd44ae48acf41830cda53c57ff3879c89907448943c"
+    sha256 cellar: :any, arm64_big_sur: "62b7ba85aea0bbe693d05910b22c662aa9afedfd82e69037284be3e413daa892"
     sha256 cellar: :any, catalina: "558e7df1c0e8072a136518321dcd2f05fef33ee464903ff1f03fff9f7f3c5651"
   end
 

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -26,6 +26,7 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, catalina: "f1b8306063139e689f0fbf5f1ef5cbc78764ff6f10b42ecc1fcb0d9664201d8e"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -26,6 +26,8 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, big_sur: "af9bf4218096f3c44c60b98ed20ab676a659895e6e525cd31ec479435b751e66"
+    sha256 cellar: :any, arm64_big_sur: "8d8957ab2cd2333dee713c2b815760a05450bc98d4c6e3f6ada4f0c32f0ced73"
     sha256 cellar: :any, catalina: "f1b8306063139e689f0fbf5f1ef5cbc78764ff6f10b42ecc1fcb0d9664201d8e"
   end
 


### PR DESCRIPTION
Problem: we have built brew bottles for the new Octez release, but their hashes
aren't in the formulae yet.

Solution: added the hashes.
