### PR TITLE
[#385] Remove 'zcash-params' workaround from macos doc

### DIFF
--- a/docs/distros/macos.md
+++ b/docs/distros/macos.md
@@ -25,27 +25,6 @@ brew install tezos-client
 
 For faster formulae installation we provide prebuilt bottles for some macOS versions in the releases.
 
-## Sapling params on Macs with Apple CPUs
-
-The `tezos-sapling-params` formula provides the `zcash-params` required by some Octez binaries.
-However, you may see the following error when trying to use Octez binary on Mac with Apple CPU:
-```
-Failed to initialize Zcash parameters: cannot find Zcash params in any of:
-...
-You may download them using https://raw.githubusercontent.com/zcash/zcash/master/zcutil/fetch-params.sh
-```
-
-This problem is caused by the fact that on Macs with Apple CPUs brew installs `zcash-params` to
-a directory that isn't checked by Octez binaries.
-
-[MR](https://gitlab.com/tezos/tezos/-/merge_requests/4609) that targets to fix this was merged but
-wasn't included into a release yet. So in the meantime, an additional workaround is required.
-
-In order to make `zcash-params` available for Octez binaries you can run the following command:
-```
-ln -s /opt/homebrew/Cellar/tezos-sapling-params/v8.2-3/share/zcash-params/ ~/.zcash-params
-```
-
 ## Launchd background services on macOS.
 
 IMPORTANT: All provided `launchd` services are run as a user agents, thus they're stopped after the logout.


### PR DESCRIPTION
## Description

Problem: 'tezos-node' is now capable of searching 'zcash-params' within
HOMEBREW_PREFIX. However, docs still mention that additional workaround
is needed on macs with Apple CPUs.

Solution: Remove this workaround from macos-related doc.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
