### PR TITLE
[#462] Add shellcheck linter to CI

### DIFF
--- a/.buildkite/check-trailing-whitespace.sh
+++ b/.buildkite/check-trailing-whitespace.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 files=$(git ls-files -- . ':!:*.patch' | xargs grep --files-with-matches --binary-files=without-match '[[:blank:]]$')
-if [[ ! -z $files ]];then
+if [[ -n $files ]];then
   echo '  Files with trailing whitespace found:'
   for f in "${files[@]}"; do
     echo "  * $f"

--- a/.buildkite/check-trailing-whitespace.sh
+++ b/.buildkite/check-trailing-whitespace.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
 files=$(git ls-files -- . ':!:*.patch' | xargs grep --files-with-matches --binary-files=without-match '[[:blank:]]$')
-if [[ -n $files ]];then
+if [[ -n "$files" ]];then
   echo '  Files with trailing whitespace found:'
   for f in "${files[@]}"; do
     echo "  * $f"

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -23,6 +23,8 @@ steps:
    soft_fail: true
  - label: lint python code
    command: nix run -f . pkgs.python39Packages.black -c black --check --diff --color .
+ - label: lint bash scripts
+   command: nix run -f . pkgs.shellcheck -c shellcheck --exclude=SC1008,SC2148,SC1091 -x $(find . -name '*.sh')
  - label: pipeline-filtering
    command: nix-shell .buildkite/shell.nix --run 'nix run -f . pkgs.bats -c ./tests/buildkite/filter-pipeline.bats'
    only_changes:

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -24,7 +24,7 @@ steps:
  - label: lint python code
    command: nix run -f . pkgs.python39Packages.black -c black --check --diff --color .
  - label: lint bash scripts
-   command: nix run -f . pkgs.shellcheck -c shellcheck --exclude=SC1008,SC2148,SC1091 -x $(find . -name '*.sh')
+   command: nix run -f . pkgs.shellcheck -c shellcheck --shell=bash --exclude=SC1091 -x $(find . -name '*.sh')
  - label: pipeline-filtering
    command: nix-shell .buildkite/shell.nix --run 'nix run -f . pkgs.bats -c ./tests/buildkite/filter-pipeline.bats'
    only_changes:

--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -16,7 +16,7 @@ opam init local ../opam-repository --bare --disable-sandboxing
 opam switch create . --repositories=local
 eval "$(opam env)"
 opams="$(find ./vendors ./src ./tezt -name \*.opam -print)"
-opam install $opams --deps-only --criteria="-notuptodate,-changed,-removed"
+opam install "$opams" --deps-only --criteria="-notuptodate,-changed,-removed"
 eval "$(opam env)"
 dune build "$dune_filepath"
 cp "./_build/default/$dune_filepath" "../$binary_name"

--- a/scripts/build-one-bottle.sh
+++ b/scripts/build-one-bottle.sh
@@ -16,4 +16,4 @@ brew install --formula --build-bottle "./Formula/$1.rb"
 brew bottle --force-core-tap --no-rebuild "./Formula/$1.rb"
 brew uninstall --formula "./Formula/$1.rb"
 # https://github.com/Homebrew/brew/pull/4612#commitcomment-29995084
-mv "$1"*.bottle.* "$(echo $1*.bottle.* | sed s/--/-/)"
+mv "$1"*.bottle.* "$(echo "$1"*.bottle.* | sed s/--/-/)"

--- a/scripts/check-bottle-built.sh
+++ b/scripts/check-bottle-built.sh
@@ -19,11 +19,10 @@ fi
 
 tag=$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "./Formula/$1.rb")
 
-# Command below is allowed to fail
 set +e
-gh release view "$tag" | grep "$1.*\.$2.bottle.tar.gz"
 
-if [ $? -eq 0 ]; then
+# Command below is allowed to fail
+if gh release view "$tag" | grep "$1.*\.$2.bottle.tar.gz"; then
     echo "Bottle is already attached to the $tag release."
     exit 3
 else

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -18,7 +18,8 @@ git clone https://gitlab.com/tezos/tezos.git upstream-repo
 cd upstream-repo
 latest_upstream_tag_hash="$(git rev-list --tags --max-count=1)"
 latest_upstream_tag="$(git describe --tags "$latest_upstream_tag_hash")"
-git checkout $latest_upstream_tag
+opam_repository_tag='' # will be set by version.sh
+git checkout "$latest_upstream_tag"
 source scripts/version.sh
 cd ..
 rm -rf upstream-repo


### PR DESCRIPTION
## Description

Problem: We have some linters running on our Buildkite pipeline.
However, we don't check shell scripts in any specialised way.
It would be nice to add shellcheck to run on every .sh file.

Solution: Add CI step for bash scripts linting and fix existing
style problems.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #462 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
