### PR TITLE
[#388] Properly package two wizards

### DIFF
--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -4,7 +4,7 @@
 FROM fedora:32
 RUN dnf update -y
 RUN dnf install -y libev-devel gmp-devel hidapi-devel libffi-devel zlib-devel libpq-devel m4 perl git pkg-config \
-  rpmdevtools python3 wget opam rsync which cargo autoconf
+  rpmdevtools python3-devel python3-setuptools wget opam rsync which cargo autoconf
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging
@@ -17,3 +17,4 @@ COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
 COPY LICENSE /tezos-packaging/LICENSE
 ENTRYPOINT ["python3", "-m", "package.package_generator"]
+

--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -4,7 +4,7 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y libev-dev libgmp-dev libhidapi-dev libffi-dev zlib1g-dev libpq-dev m4 perl pkg-config \
-  debhelper dh-make dh-systemd devscripts autotools-dev python3 python3-distutils wget rsync
+  debhelper dh-make dh-systemd dh-python devscripts autotools-dev python3-all python3-setuptools wget rsync
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-mozilla-security/rust-next -y && apt-get update && apt-get -y install cargo
 RUN add-apt-repository ppa:avsm/ppa -y && apt-get update && apt-get -y install opam

--- a/docker/package/fedora.py
+++ b/docker/package/fedora.py
@@ -20,7 +20,7 @@ def build_fedora_package(
     home = os.environ["HOME"]
 
     pkg.fetch_sources(dir)
-    pkg.gen_makefile(f"{dir}/Makefile")
+    pkg.gen_buildfile("/".join([dir, pkg.buildfile]))
     pkg.gen_license(f"{dir}/LICENSE")
     for systemd_unit in pkg.systemd_units:
         if systemd_unit.service_file.service.environment_file is not None:

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -15,7 +15,7 @@ import urllib.request
 import json
 from typing import List
 
-from wizard_structure import *
+from .wizard_structure import *
 
 # Global options
 
@@ -465,7 +465,7 @@ class Setup(Setup):
         print(f"sudo systemctl disable tezos-baking-{self.config['network']}.service")
 
 
-if __name__ == "__main__":
+def main():
     readline.parse_and_bind("tab: complete")
     readline.set_completer_delims(" ")
 
@@ -503,3 +503,7 @@ if __name__ == "__main__":
             f.write(str(e) + "\n")
         print("The error has been logged to", os.path.abspath(logfile))
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/package/tezos_voting_wizard.py
+++ b/docker/package/tezos_voting_wizard.py
@@ -12,7 +12,7 @@ import os, sys
 import readline
 import re
 
-from wizard_structure import *
+from .wizard_structure import *
 
 # Global options
 
@@ -451,7 +451,7 @@ class Setup(Setup):
         print("Thank you for voting!")
 
 
-if __name__ == "__main__":
+def main():
     readline.parse_and_bind("tab: complete")
     readline.set_completer_delims(" ")
 
@@ -471,3 +471,7 @@ if __name__ == "__main__":
             f.write(str(e) + "\n")
         print("The error has been logged to", os.path.abspath(logfile))
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -25,7 +25,7 @@ def build_ubuntu_package(
     date = subprocess.check_output(["date", "-R"]).decode().strip()
     if source_archive_path is None:
         pkg.fetch_sources(dir)
-        pkg.gen_makefile(f"{dir}/Makefile")
+        pkg.gen_buildfile("/".join([dir, pkg.buildfile]))
         subprocess.run(["tar", "-czf", f"{dir}.tar.gz", dir], check=True)
     else:
         shutil.copy(f"{cwd}/../{source_archive_path}", f"{dir}.tar.gz")


### PR DESCRIPTION
## Description

Problem: Right now, when installing the tezos-baking package, we just
copy this common file to /usr/bin/ together with the wizards'
executable scripts.

Solution: Change the buildsystem to pybuild.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #388

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
