### PR TITLE
[Chore] Hotfix 'build-binary.sh' script

### DIFF
--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -15,8 +15,11 @@ cd tezos
 opam init local ../opam-repository --bare --disable-sandboxing
 opam switch create . --repositories=local
 eval "$(opam env)"
-opams="$(find ./vendors ./src ./tezt -name \*.opam -print)"
-opam install "$opams" --deps-only --criteria="-notuptodate,-changed,-removed"
+opams=()
+while IFS=  read -r -d $'\0'; do
+    opams+=("$REPLY")
+done < <(find ./vendors ./src ./tezt -name \*.opam -print0)
+opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"
 eval "$(opam env)"
 dune build "$dune_filepath"
 cp "./_build/default/$dune_filepath" "../$binary_name"


### PR DESCRIPTION
## Description
Problem: After recently applied shellcheck suggestions,
'build-binary.sh' doesn't provide a list of opam files to install
correctly.

Solution: Store find result in the array instead of a single string
variable to provide proper quoted expansion.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
