### PR TITLE
[Chore] Update documentation on scripts

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -37,6 +37,7 @@ steps:
 
  - label: build via nix
    commands:
+   # NOTE: if this changes, remember to update the instructions in the nix/README.md too
    - nix-build ./nix -A binaries -o binaries
    branches: "!master"
  - label: test nix-built binaries
@@ -153,6 +154,17 @@ steps:
    agents:
      queue: "docker"
    only_changes: *native_packaging_changes_regexes
+
+ - label: test gen_systemd_service_file.py script
+   commands:
+   - eval "$SET_VERSION"
+   - ./gen_systemd_service_file.py tezos-node
+   branches: "!master"
+   agents:
+     queue: "docker"
+   only_changes:
+   - gen_systemd_service_file.py
+   - docker/package/.*
 
  - label: create auto release/pre-release
    key: auto-release

--- a/docs/distros/macos.md
+++ b/docs/distros/macos.md
@@ -60,7 +60,7 @@ Once the configuration is updated, you should restart the service:
 In order to build bottles with Tezos binaries run the [`build-one-bottle.sh`](../../scripts/build-one-bottle.sh)
 script with the formula that you want to build. For example:
 ```
-./scripts/scripts/build-one-bottle.sh tezos-client
+./scripts/build-one-bottle.sh tezos-client
 ```
 
 Note that several formulae have `tezos-sapling-params` has a dependency, so you

--- a/docs/systemd.md
+++ b/docs/systemd.md
@@ -38,10 +38,13 @@ If you're not using Ubuntu or Fedora you can still construct systemd units for b
 from scratch.
 
 For this you'll need a `.service` file to define each systemd service.
-The easiest way to get one is to run [`gen_systemd_service_file.py`](../gen_systemd_service_file.py).
-You should specify the binary name as an argument.
+The easiest way to get one is to generate one with `docker` by running [`gen_systemd_service_file.py`](../gen_systemd_service_file.py).
 
-E.g.:
+First you'll need to set the `TEZOS_VERSION` env variable, e.g.:
+```sh
+export TEZOS_VERSION="v7.3"
+```
+Then you can use the script, specifying the binary name as an argument, e.g.:
 ```
 ./gen_systemd_service_file.py tezos-node
 # or

--- a/gen_systemd_service_file.py
+++ b/gen_systemd_service_file.py
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+# Note: if you modify this file, check if its usage in docs/systemd.md
+# needs to be updated too.
+
 from docker.package import *
 import sys
 

--- a/scripts/build-one-bottle.sh
+++ b/scripts/build-one-bottle.sh
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2022 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-# Newer brew versions fail when checking for a rebuild version of non-core taps.
-# So for now we skip the check with '--no-rebuild'
+# Note: if you modify this file, check if its usage in docs/distros/macos.md
+# needs to be updated too.
 
 set -eo pipefail
 
@@ -13,6 +13,8 @@ if [ -z "$1" ] ; then
 fi
 
 brew install --formula --build-bottle "./Formula/$1.rb"
+# Newer brew versions fail when checking for a rebuild version of non-core taps.
+# So for now we skip the check with '--no-rebuild'
 brew bottle --force-core-tap --no-rebuild "./Formula/$1.rb"
 brew uninstall --formula "./Formula/$1.rb"
 # https://github.com/Homebrew/brew/pull/4612#commitcomment-29995084


### PR DESCRIPTION
## Description

Problem: there are some scripts whose usage is mentioned in the
documentation, but they are hardly ever used or tested.
As a consequence, some of these examples need to be rechecked.

Solution: update some of the documentation and leave comments to
hopefully avoid this in the future.
Additionally adds a quick CI step to check the script that's most
likely less used.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
