### PR TITLE
[#438] Document PPA installation steps on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ voting on custom networks.
 `tezos-packaging` supports several native distribution methods for convenience:
 
 - [**Ubuntu**](./docs/distros/ubuntu.md)
+- [**Debian**](./docs/distros/ubuntu.md#debian)
 - [**Raspberry Pi OS**](./docs/distros/ubuntu.md#raspberry)
 - [**Fedora**](./docs/distros/fedora.md)
 - [**macOS**](./docs/distros/macos.md)

--- a/docs/distros/ubuntu.md
+++ b/docs/distros/ubuntu.md
@@ -30,6 +30,26 @@ As an addition, `tezos-baking` package provides `tezos-baking-<network>` service
 systemd units for `tezos-node` and `tezos-baker-<proto>`.
 Configuration files for these services are located in `/etc/default/tezos-baking-<network>`.
 
+<a name="debian"></a>
+## Ubuntu packages on Debian
+
+You can add the PPA using:
+```
+# Install software properties commons
+sudo apt-get install software-properties-common gnupg
+# Add PPA with Tezos binaries
+sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu bionic main'
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 37B8819B7D0D183812DCA9A8CE5A4D8933AE7CBB
+sudo apt-get update
+```
+If packages for `bionic` are not suited for your Debian version, see the
+[related askubuntu thread](https://askubuntu.com/a/445496) to choose a valid one.
+
+Then install with `apt-get`, e.g. for `tezos-client`:
+```
+sudo apt-get install tezos-client
+```
+
 <a name="raspberry"></a>
 ## Ubuntu packages on Raspberry Pi OS
 
@@ -38,7 +58,7 @@ you can use the Launchpad PPA to install `tezos-*` executables on it as well.
 
 You can add the PPA using:
 ```
-# Intall software properties commons
+# Install software properties commons
 sudo apt-get install software-properties-common
 # Add PPA with Tezos binaries
 sudo add-apt-repository 'deb http://ppa.launchpad.net/serokell/tezos/ubuntu focal main'

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -22,6 +22,17 @@ Currently, these are versions:
 
 There are packages for `arm64` and `amd64` architectures.
 
+## Debian packages
+
+We aim to provide packages for all [debian releases](https://www.debian.org/releases/),
+which match the supported Ubuntu releases.
+
+Currently, these are versions:
+* Debian 11 (bullseye)
+* Debian 10 (buster)
+
+There are packages for `arm64` and `amd64` architectures.
+
 ## Fedora packages
 
 We aim to provide packages for all [currently supported Fedora releases](https://docs.fedoraproject.org/en-US/releases/).


### PR DESCRIPTION
## Description

Problem: We should be able to use serokell launchpad ppa
on some debian releases, but straightforward way won't work
because of different versioning policies.

Solution: Provide commands to install on debian and update docs.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #438 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
