### PR TITLE
[#472] Handle ledger setup interruption

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -382,12 +382,18 @@ class Setup(Setup):
 
             key_mode_query = get_key_mode_query(key_import_modes)
 
-            self.import_key(key_mode_query, "Baking")
+            ledger_set_up = False
+            while not ledger_set_up:
+                self.import_key(key_mode_query, "Baking")
 
-            proc_call(
-                f"sudo -u tezos {suppress_warning_text} tezos-client {tezos_client_options} "
-                f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
-            )
+                try:
+                    proc_call(
+                        f"sudo -u tezos {suppress_warning_text} tezos-client {tezos_client_options} "
+                        f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
+                    )
+                    ledger_set_up = True
+                except PermissionError:
+                    print("Going back to the import mode selection.")
 
     def register_baker(self):
         print()


### PR DESCRIPTION
## Description

Problem: When Ctrl+C is fired during the step that interacts with
the ledger during baker setup wizard fails with an error.

Solution: Handle the exception.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #472 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)
- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
