### PR TITLE
[Chore] Repin opam-repository branch

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -53,7 +53,7 @@ steps:
    - eval "$SET_VERSION"
    - cd docker
    - ./docker-static-build.sh
-   - nix shell -f.. pkgs.upx -c upx tezos-*
+   - nix run -f.. pkgs.upx -c upx tezos-*
    artifact_paths:
      - ./docker/tezos-*
    agents:

--- a/nix/nix/sources.json
+++ b/nix/nix/sources.json
@@ -36,8 +36,8 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "opam-repository": {
-        "branch": "static-layers-1",
-        "ref": "static-layers-1",
+        "branch": "master",
+        "ref": "master",
         "repo": "https://gitlab.com/tezos/opam-repository",
         "rev": "845375388d477153b36344f69a23a1b34b2bf82e",
         "type": "git"


### PR DESCRIPTION
## Description
Problem: opam-repository currently pinned to branch that no longer
exists.

Solution: Repin it to master.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
