### PR TITLE
[#464] Support liquidity baking toggle vote

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -577,7 +577,11 @@ class TezosBakingServicesPackage(AbstractPackage):
         custom_unit.poststop_script = "tezos-baking-custom-poststop"
         custom_unit.instances = []
         self.systemd_units.append(custom_unit)
-        self.postinst_steps = ""
+        # TODO: we will likely need to remove this once toggle vote isn't new anymore
+        self.postinst_steps = """echo "Please note that the liquidity baking toggle vote option"
+echo "is now mandatory when baking. You can read more about it here:"
+echo "https://tezos.gitlab.io/alpha/liquidity_baking.html#toggle-vote"
+"""
         self.postrm_steps = ""
 
     def fetch_sources(self, out_dir):

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -363,6 +363,18 @@ def search_json_with_default(json_filepath, field, default):
         return json_dict.pop(field, default)
 
 
+def replace_in_service_config(config_filepath, field, value):
+    with open(config_filepath, "r") as f:
+        config_contents = f.read()
+
+    old = re.search(f"{field}=.*", config_contents)
+    if old is None:
+        return None
+    else:
+        new = f"{field}={value}"
+        proc_call(f"sudo sed -i 's/{old.group(0)}/{new}' {config_filepath}")
+
+
 class Step:
     def __init__(
         self,
@@ -584,7 +596,7 @@ class Setup:
             f"{self.config['tezos_client_options']} config update"
         )
 
-    def fill_baking_config(self):
+    def get_baking_config_filepath(self):
         net = self.config["network"]
         output = get_proc_output(f"systemctl show tezos-baking-{net}.service").stdout
         config_filepath = re.search(b"EnvironmentFiles=(.*) ", output)
@@ -596,7 +608,10 @@ class Setup:
             config_filepath = f"/etc/default/tezos-baking-{net}"
         else:
             config_filepath = config_filepath.group(1).decode().strip()
+        return config_filepath
 
+    def fill_baking_config(self):
+        config_filepath = self.get_baking_config_filepath()
         with open(config_filepath, "r") as f:
             config_contents = f.read()
             self.config["client_data_dir"] = search_baking_service_config(


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: in anticipation of `jakarta` on `mainnet`, we need to properly support the liquidity baking toggle vote option that is now mandatory. The Setup Wizard needs to ask for the user's preference.

Solution: added a step that queries the user's preference. There seems to be no good way to provide this option for our systemd service, so we modify the service's config file on each wizard invocation. Also added a post-install notification to `tezos-baking` .deb.

NB: another part of the issue is to make sure running systemd services can handle package upgrade. I was unable to break them, but perhaps it requires more consideration 🤔 

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #464

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
