### PR TITLE
[#453] Package rollup Octez binaries

### DIFF
--- a/Formula/tezos-tx-rollup-node-alpha.rb
+++ b/Formula/tezos-tx-rollup-node-alpha.rb
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2021 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+class TezosTxRollupNodeAlpha < Formula
+  @all_bins = []
+
+  class << self
+    attr_accessor :all_bins
+  end
+  homepage "https://gitlab.com/tezos/tezos"
+
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v13.0", :shallow => false
+
+  version "v13.0-2"
+
+  build_dependencies = %w[pkg-config autoconf rsync wget rustup-init]
+  build_dependencies.each do |dependency|
+    depends_on dependency => :build
+  end
+
+  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies.each do |dependency|
+    depends_on dependency
+  end
+  desc "Entry point for initializing, configuring and running a Tezos tx rollup node"
+
+#  bottle do
+#    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+#    sha256 cellar: :any, big_sur: "40a2581ef0170009a9804fdfd2f1313ad98c4af484cb62ab28e3b7ad8a801315"
+#    sha256 cellar: :any, arm64_big_sur: "8aa9e2f8855ac4a30584ab262053310618fc5bdd8872da57f682485ee1622a8f"
+#    sha256 cellar: :any, catalina: "4239b5655f5e828279e3a336645b635609553203dc4f4d0b4a1fb5cd3642699b"
+#  end
+
+  def make_deps
+    ENV.deparallelize
+    ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
+    # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
+    ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
+    system "rustup-init", "--default-toolchain", "1.52.1", "-y"
+    system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
+  end
+
+  def install_template(dune_path, exec_path, name)
+    bin.mkpath
+    self.class.all_bins << name
+    system ["eval $(opam env)", "dune build #{dune_path}", "cp #{exec_path} #{name}"].join(" && ")
+    bin.install name
+  end
+
+  def install
+    make_deps
+    install_template "src/proto_alpha/bin_tx_rollup_node/main_tx_rollup_node_alpha.exe",
+                     "_build/default/proto_alpha/bin_tx_rollup_node/main_tx_rollup_node_alpha.exe",
+                     "tezos-tx-rollup-node-alpha"
+  end
+end

--- a/docker/build/build-tezos.sh
+++ b/docker/build/build-tezos.sh
@@ -23,5 +23,5 @@ source "$HOME/.cargo/env"
 
 opam init --bare --disable-sandboxing
 make build-deps
-eval "$(opam env)" && PROFILE="static" make build && make build-sandbox
+eval "$(opam env)" && PROFILE="static" make build && make build-unreleased && make build-sandbox
 chmod +w tezos-*

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -11,8 +11,17 @@ set -euo pipefail
 binaries=("tezos-admin-client" "tezos-client" "tezos-node" "tezos-signer" "tezos-codec" "tezos-sandbox")
 
 for proto in $(jq -r ".active | .[]" ../protocols.json); do
-    binaries+=("tezos-accuser-$proto" "tezos-baker-$proto" )
+    binaries+=("tezos-accuser-$proto" "tezos-baker-$proto")
 done
+
+add_rollup_binaries () {
+    for proto in $(jq -r ".$1_rollup | .[]" ../protocols.json); do
+        binaries+=("tezos-$1-rollup-node-$proto" "tezos-$1-rollup-client-$proto")
+    done
+}
+
+add_rollup_binaries "tx"
+add_rollup_binaries "sc"
 
 if [[ "${USE_PODMAN-}" == "True" ]]; then
     virtualisation_engine="podman"

--- a/protocols.json
+++ b/protocols.json
@@ -24,5 +24,11 @@
   "active": [
     "012-Psithaca",
     "013-PtJakart"
+  ],
+  "sc_rollup": [
+    "alpha"
+  ],
+  "tx_rollup": [
+    "alpha"
   ]
 }


### PR DESCRIPTION
## Description

Problem: Jakarta protocol introduced new rollup binaries.

Solution: provide static binaries, Ubuntu/Fedora packages,
and brew formulae for new rollup Octez binaries.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #453 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
