### PR TITLE
Add option to create packages from pre-built static binaries

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -43,6 +43,24 @@ Once this is done you should run the following command to build `aarch64` static
 ./docker-static-build.sh aarch64
 ```
 
+### Packages from statically linked binaries
+
+It's possible to create packages (ubuntu/debian & fedora) using already
+built binaries. This means that the build step of the package will be reduced
+to copying the binaries instead of building again from scratch.
+
+Using Ubuntu/Debian and assuming all Tezos binaries are located in the `binaries` directory:
+```sh
+cd .. && ./docker/docker-tezos-packages.sh --os ubuntu --type binary --binaries-dir binaries
+```
+
+Using Fedora and assuming all Tezos binaries are located in the `binaries` directory:
+```sh
+cd .. && ./docker/docker-tezos-packages.sh --os fedora --type binary --binaries-dir binaries
+```
+
+The resulting packages will be located in `../out` directory.
+
 ## Ubuntu packages
 
 We provide a way to build both binary and source native Ubuntu packages.
@@ -142,7 +160,7 @@ dput tezos-rc-serokell ../out/<package>.changes
 
 #### Updating release in scope of the same upstream version
 
-In case you're uploading the same version of the package but with the a different
+In case you're uploading the same version of the package but with a different
 release number, you'll highly likely have to use the same source archive (`.orig.tar.gz` archive)
 that was used for the first release in the scope of the same version, it can be downloaded from
 the launchpad package details (e.g. https://launchpad.net/~serokell/+archive/ubuntu/tezos/+sourcefiles/tezos-client/2:7.4-0ubuntu2/tezos-client_7.4.orig.tar.gz).

--- a/docker/package/fedora.py
+++ b/docker/package/fedora.py
@@ -13,14 +13,15 @@ def build_fedora_package(
     build_deps: List[str],
     run_deps: List[str],
     is_source: bool,
+    binaries_dir: str = None,
 ):
     version = pkg.meta.version.replace("-", "")
     dir = f"{pkg.name}-{version}"
     cwd = os.path.dirname(__file__)
     home = os.environ["HOME"]
 
-    pkg.fetch_sources(dir)
-    pkg.gen_buildfile("/".join([dir, pkg.buildfile]))
+    pkg.fetch_sources(dir, binaries_dir)
+    pkg.gen_buildfile("/".join([dir, pkg.buildfile]), binaries_dir)
     pkg.gen_license(f"{dir}/LICENSE")
     for systemd_unit in pkg.systemd_units:
         if systemd_unit.service_file.service.environment_file is not None:

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -163,7 +163,7 @@ def mk_dh_flags(package):
     )
 
 
-def gen_systemd_rules_contents(package, binaries_dir):
+def gen_systemd_rules_contents(package, binaries_dir=None):
     override_dh_install_init = "override_dh_installinit:\n"
     package_name = package.name.lower()
     for systemd_unit in package.systemd_units:

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -411,6 +411,10 @@ for proto in active_protocols:
         )
     )
 
+sapling_package = TezosSaplingParamsPackage(
+    meta=packages_meta, params_revision="95911b0639ff01807b8fd7b9e36d508e657d80a8"
+)
+
 packages.append(
     TezosBakingServicesPackage(
         target_networks=networks.keys(),

--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -14,6 +14,7 @@ def build_ubuntu_package(
     build_deps: List[str],
     is_source: bool,
     source_archive_path: str = None,
+    binaries_dir: str = None,
 ):
     # ubuntu prohibits uppercase in packages names
     pkg_name = pkg.name.lower()
@@ -24,8 +25,8 @@ def build_ubuntu_package(
     cwd = os.path.dirname(__file__)
     date = subprocess.check_output(["date", "-R"]).decode().strip()
     if source_archive_path is None:
-        pkg.fetch_sources(dir)
-        pkg.gen_buildfile("/".join([dir, pkg.buildfile]))
+        pkg.fetch_sources(dir, binaries_dir)
+        pkg.gen_buildfile("/".join([dir, pkg.buildfile]), binaries_dir)
         subprocess.run(["tar", "-czf", f"{dir}.tar.gz", dir], check=True)
     else:
         shutil.copy(f"{cwd}/../{source_archive_path}", f"{dir}.tar.gz")
@@ -73,7 +74,7 @@ def build_ubuntu_package(
         with open("debian/compat", "w") as f:
             f.write("10")
         pkg.gen_install("debian/install")
-        pkg.gen_rules("debian/rules")
+        pkg.gen_rules("debian/rules", binaries_dir)
         pkg.gen_postinst("debian/postinst")
         pkg.gen_postrm("debian/postrm")
         pkg.gen_control_file(build_deps, ubuntu_version, "debian/control")


### PR DESCRIPTION

## Description 

Currently there is no option to use pre-built static binaries on the Debian/Fedora packages. Creating the packages will always involve building from scratch. This might not be desirable when there is another CI process that builds the binaries.

## Related issue(s)

None

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
