### PR TITLE
[#484] Improve the update message about liquidity toggle vote 

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -494,7 +494,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = "a"
+    letter_version = "b"
 
     buildfile = "setup.py"
 

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -578,9 +578,15 @@ class TezosBakingServicesPackage(AbstractPackage):
         custom_unit.instances = []
         self.systemd_units.append(custom_unit)
         # TODO: we will likely need to remove this once toggle vote isn't new anymore
-        self.postinst_steps = """echo "Please note that the liquidity baking toggle vote option"
-echo "is now mandatory when baking. You can read more about it here:"
-echo "https://tezos.gitlab.io/jakarta/liquidity_baking.html#toggle-vote"
+        self.postinst_steps = """echo ""
+echo "********************************************************************************"
+echo "**  Please note that the liquidity baking toggle vote option"
+echo "**  is now mandatory when baking. It has been automatically set to \"pass\"."
+echo "**  Re-run tezos-setup-wizard if you'd like to change your vote."
+echo "**  You can read more about it here:"
+echo "**  https://tezos.gitlab.io/jakarta/liquidity_baking.html#toggle-vote"
+echo "********************************************************************************"
+echo ""
 """
         self.postrm_steps = ""
 

--- a/meta.json
+++ b/meta.json
@@ -1,4 +1,4 @@
 {
-    "release": "2",
+    "release": "3",
     "maintainer": "Serokell <hi@serokell.io>"
 }


### PR DESCRIPTION
## Description

Problem: On updating (or installing) tezos-baking's latest version
a message is printed about the liquidity toggle vote option that is
mandatory since jakarta, but this does not tell the user what needs
to be done nor how.

Solution: Improve the update message by making it stand out more and
adding info about the default value and using tezos-setup-wizard to
change this option.

## Related issue(s)

Resolves #484

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
