### PR TITLE
[#486] Avoid unnecessary formulae bottles hashes' updates

### DIFF
--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -17,10 +17,13 @@ then
                 bottle_hash=$(sha256sum "$bottle" | cut -d " " -f 1)
                 formula_name="${BASH_REMATCH[1]}"
                 os="${BASH_REMATCH[2]}"
-
-                if [[ -f "./Formula/$formula_name.rb" ]]; then
+                formula_file="./Formula/$formula_name.rb"
+                if [[ -f $formula_file ]]; then
                     line="\    sha256 cellar: :any, $os: \"$bottle_hash\""
-                    sed -i "/root_url.*/a $line" "./Formula/$formula_name.rb"
+                    # Update only when this formula doesn't have a hash for the bottle
+                    if ! grep "$line" "$formula_file" &> /dev/null; then
+                        sed -i "/root_url.*/a $line" "$formula_file"
+                    fi
                 fi
             fi
         done


### PR DESCRIPTION
## Description
Problem: GA tend to create a PR with bottles hashes updates
even though formulae already have these hashes.

Solution: Check if the formula already has the hash of the given bottle
before updating it.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #486

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
