### PR TITLE
[#181] Test systemd services in VM

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+if [[ "$BUILDKITE_STEP_KEY" == "test-systemd-services" ]]; then
+    cd tests/systemd
+    nix shell ../..#legacyPackages.x86_64-linux.vagrant -c vagrant --packages-directory=../../out destroy --force
+fi

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -150,6 +150,20 @@ steps:
      queue: "docker"
    only_changes: *native_packaging_changes_regexes
 
+ - label: build deb packages with static binaries
+   key: build-static-deb
+   depends_on:
+    - "build-via-docker"
+   agents:
+     queue: "docker"
+   commands:
+   - eval "$SET_VERSION"
+   - buildkite-agent artifact download "docker/octez-*" . --step build-via-docker
+   - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --os ubuntu --type binary --binaries-dir docker --distributions focal
+   artifact_paths:
+    - ./out/*
+   only_changes: *native_packaging_changes_regexes
+
  - label: test gen_systemd_service_file.py script
    commands:
    - eval "$SET_VERSION"
@@ -160,6 +174,19 @@ steps:
    only_changes:
    - gen_systemd_service_file.py
    - docker/package/.*
+
+ - label: test bundled systemd services
+   # Used in .buildkite/hooks/pre-exit
+   key: test-systemd-services
+   depends_on:
+    - "build-static-deb"
+   only_changes: *native_packaging_changes_regexes
+   agents:
+     queue: "default"
+   commands:
+    - buildkite-agent artifact download "out/*~focal_amd64.deb" . --step build-static-deb
+    - cd tests/systemd
+    - nix shell ../..#legacyPackages.x86_64-linux.vagrant ../..#legacyPackages.x86_64-linux.curl -c vagrant --packages-directory=../../out up --provider=libvirt
 
  - label: create auto release/pre-release
    key: auto-release

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -242,7 +242,7 @@ def replace_systemd_service_env(service_name, field, value):
         if old is not None:
             new = f"{field}={value}"
             proc_call(
-                f"sudo sed -i 's/{old.group(0)}/{new}/' {env_file.decode('utf8')}"
+                f"sudo sed -i 's|{old.group(0)}|{new}|' {env_file.decode('utf8')}"
             )
 
 

--- a/tests/systemd/README.md
+++ b/tests/systemd/README.md
@@ -1,0 +1,38 @@
+<!--
+   - SPDX-FileCopyrightText: 2022 Oxhead Alpha
+   -
+   - SPDX-License-Identifier: LicenseRef-MIT-OA
+   -->
+
+# Testing systemd services
+
+## Prerequisites
+
+1) [Vagrant](https://www.vagrantup.com/).
+2) [`libvirt`](https://libvirt.org/) and [`qemu`](https://www.qemu.org/).
+3) `.deb` packages with Octez binaries and systemd services to test.
+
+## Getting `.deb` packages
+
+The easiest way to get `.deb` packages with systemd services for testing
+is to download static Octez binaries and build `.deb` packages using them
+instead of compiling Octez from scratch for each package.
+Refer to [this doc](../../docker/README.md#packages-from-statically-linked-binaries)
+for building instructions.
+
+## Testing
+
+Run
+```sh
+vagrant --packages-directory="<dir>" up --provider=libvirt
+```
+
+Where 'PACKAGES_DIRECTORY' is the directory with `.deb` packages.
+
+Tests are run during VM provisioning, so `vagrant up` is expected to fail
+in case some tests are failing.
+
+To clean up the state after VM test run:
+```sh
+vagrant --packages-directory="<dir>" destroy --force
+```

--- a/tests/systemd/Vagrantfile
+++ b/tests/systemd/Vagrantfile
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2022 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'getoptlong'
+
+opts = GetoptLong.new(
+  [ '--packages-directory', GetoptLong::REQUIRED_ARGUMENT ]
+)
+
+packagesDirectory=''
+
+opts.ordering=(GetoptLong::REQUIRE_ORDER)
+
+opts.each do |opt, arg|
+  case opt
+    when '--packages-directory'
+      packagesDirectory=arg
+  end
+end
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2004"
+  config.vm.provision "shell", run: "once", inline: <<-SHELL
+    add-apt-repository -y ppa:serokell/tezos && apt-get update
+    apt-get install -y tezos-sapling-params acl python3-pystemd python3-pytest python3-psutil
+  SHELL
+  config.vm.provision "file", run: "always", source: "#{packagesDirectory}", destination: "$HOME/out"
+  config.vm.provision "file", run: "always", source: "services_tests.py", destination: "$HOME/services_tests.py"
+  config.vm.provision "shell", run: "always", path: "bootstrap.sh"
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
+    pytest-3 services_tests.py
+  SHELL
+  config.vm.provider "qemu" do |qe|
+    qe.qemu_dir = "/tmp/qemu"
+  end
+end

--- a/tests/systemd/bootstrap.sh
+++ b/tests/systemd/bootstrap.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2022 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+set -e
+
+dpkg -i ./out/tezos-client*~focal_amd64.deb
+dpkg -i ./out/tezos-baker*~focal_amd64.deb
+dpkg -i ./out/tezos-accuser*~focal_amd64.deb
+dpkg -i ./out/tezos-node*~focal_amd64.deb
+dpkg -i ./out/tezos-signer*~focal_amd64.deb
+dpkg -i ./out/tezos-baking*~focal_amd64.deb

--- a/tests/systemd/services_tests.py
+++ b/tests/systemd/services_tests.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2022 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+from pystemd.systemd1 import Unit
+from subprocess import CalledProcessError
+from time import sleep
+from typing import List
+
+from tezos_baking.wizard_structure import (
+    get_key_address,
+    proc_call,
+    replace_systemd_service_env,
+    url_is_reachable,
+)
+
+import contextlib
+import os.path
+
+
+@contextlib.contextmanager
+def unit(service_name: str):
+    unit = Unit(service_name.encode(), _autoload=True)
+    unit.Unit.Start("replace")
+    while unit.Unit.ActiveState == b"activating":
+        sleep(1)
+    try:
+        yield unit
+    finally:
+        unit.Unit.Stop("replace")
+        while unit.Unit.ActiveState not in [b"failed", b"inactive"]:
+            sleep(1)
+
+
+@contextlib.contextmanager
+def account(alias: str):
+    # Generate baker key
+    proc_call(f"sudo -u tezos octez-client gen keys {alias} --force")
+    try:
+        yield alias
+    finally:
+        proc_call(f"sudo -u tezos octez-client forget address {alias} --force")
+
+
+def retry(action, name: str, retry_count: int = 20) -> bool:
+    if action(name):
+        return True
+    elif retry_count == 0:
+        return False
+    else:
+        sleep(5)
+        return retry(action, name, retry_count - 1)
+
+
+def check_running_process(process_name: str) -> bool:
+    def check_process(process_name):
+        try:
+            proc_call(f"pgrep -f {process_name}")
+            return True
+        except CalledProcessError:
+            return False
+
+    return retry(check_process, process_name)
+
+
+def check_active_service(service_name: str) -> bool:
+    def check_service(service_name):
+        try:
+            proc_call(f"systemctl is-active --quiet {service_name}")
+            return True
+        except CalledProcessError:
+            return False
+
+    return retry(check_service, service_name)
+
+
+def generate_identity(network):
+    if not os.path.exists(f"/var/lib/tezos/{network}/identity.json"):
+        proc_call(
+            f"sudo -u tezos octez-node identity generate 1 --data-dir /var/lib/tezos/{network}"
+        )
+
+
+def node_service_test(network: str, rpc_endpoint="http://127.0.0.1:8732"):
+    generate_identity(network)
+    with unit(f"tezos-node-{network}.service") as _:
+        # checking that service started 'tezos-node' process
+        assert check_running_process("octez-node")
+        # checking that node is able to respond on RPC requests
+        assert retry(url_is_reachable, f"{rpc_endpoint}/chains/main/blocks/head")
+
+
+def baking_service_test(network: str, protocols: List[str], baker_alias="baker"):
+    with account(baker_alias) as _:
+        generate_identity(network)
+        with unit(f"tezos-baking-{network}.service") as _:
+            assert check_active_service(f"tezos-node-{network}.service")
+            assert check_running_process("octez-node")
+            for protocol in protocols:
+                assert check_active_service(
+                    f"tezos-baker-{protocol.lower()}@{network}.service"
+                )
+                assert check_running_process(f"octez-baker-{protocol}")
+
+
+signer_unix_socket = '"/tmp/signer-socket"'
+
+signer_backends = {
+    "http": "http://localhost:8080/",
+    "tcp": "tcp://localhost:8000/",
+    "unix": f"unix:{signer_unix_socket}?pkh=",
+}
+
+
+def signer_service_test(service_type: str):
+    with unit(f"tezos-signer-{service_type}.service") as _:
+        assert check_running_process(f"octez-signer")
+        proc_call(
+            "sudo -u tezos octez-signer -d /var/lib/tezos/signer gen keys remote --force"
+        )
+        remote_key = get_key_address("-d /var/lib/tezos/signer", "remote")[1]
+        proc_call(
+            f"octez-client import secret key remote-signer {signer_backends[service_type]}{remote_key} --force"
+        )
+        proc_call("octez-client --mode mockup sign bytes 0x1234 for remote-signer")
+
+
+def test_node_mainnet_service():
+    node_service_test("mainnet")
+
+
+def test_node_mumbainet_service():
+    node_service_test("mumbainet")
+
+
+def test_baking_mumbainet_service():
+    baking_service_test("mumbainet", ["PtMumbai"])
+
+
+def test_baking_mainnet_service():
+    baking_service_test("mainnet", ["PtMumbai"])
+
+
+def test_http_signer_service():
+    signer_service_test("http")
+
+
+def test_tcp_signer_service():
+    signer_service_test("tcp")
+
+
+def test_standalone_accuser_service():
+    with unit(f"tezos-node-mumbainet.service") as _:
+        with unit(f"tezos-accuser-ptmumbai.service") as _:
+            assert check_running_process(f"octez-accuser-PtMumbai")
+
+
+def test_unix_signer_service():
+    replace_systemd_service_env("tezos-signer-unix", "SOCKET", signer_unix_socket)
+    signer_service_test("unix")
+
+
+def test_standalone_baker_service():
+    replace_systemd_service_env(
+        "tezos-baker-ptmumbai",
+        "TEZOS_NODE_DIR",
+        "/var/lib/tezos/node-mumbainet",
+    )
+    with account("baker") as _:
+        with unit(f"tezos-node-mumbainet.service") as _:
+            with unit(f"tezos-baker-ptmumbai.service") as _:
+                assert check_active_service(f"tezos-baker-ptmumbai.service")
+                assert check_running_process(f"octez-baker-PtMumbai")
+
+
+def test_nondefault_node_rpc_endpoint():
+    rpc_addr = "127.0.0.1:8735"
+    replace_systemd_service_env("tezos-node-mumbainet", "NODE_RPC_ADDR", rpc_addr)
+    proc_call("cat /etc/default/tezos-node-mumbainet")
+    try:
+        node_service_test("mumbainet", f"http://{rpc_addr}")
+    finally:
+        replace_systemd_service_env(
+            "tezos-node-mumbainet", "NODE_RPC_ADDR", "127.0.0.1:8732"
+        )
+
+
+def test_nondefault_baking_config():
+    replace_systemd_service_env(
+        "tezos-baking-mumbainet", "BAKER_ADDRESS_ALIAS", "another_baker"
+    )
+    replace_systemd_service_env(
+        "tezos-baking-mumbainet", "LIQUIDITY_BAKING_TOGGLE_VOTE", "on"
+    )
+    baking_service_test("mumbainet", ["PtMumbai"], "another_baker")


### PR DESCRIPTION
## Description

This PR introduces tests for systemd services provided by our `.deb` packages with Octez binaries.

Currently, there are tests for `tezos-node`, `tezos-baking`, `tezos-baker`, and `tezos-signer` services.
At the moment, they can only be run locally.
For usage instructions refer to this [README](https://github.com/serokell/tezos-packaging/tree/rvem/%23181-systemd-services-testing/tests/systemd).

Roadmap:
1) ~Integrate these tests into CI. For this, we'll first need to merge #480 to have a fast way of building binary `.deb` packages~
2) ~Provide tests for more services. Perhaps, make these tests a bit safer.~
3) ~Test non-default services configuration~
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #181

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
