### PR TITLE
[#491] 'setup ledger to bake for' only for ledger key

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -33,13 +33,6 @@ snapshot_import_modes = {
     "skip": "Skip snapshot import and synchronize with the network from scratch",
 }
 
-key_import_modes = {
-    "ledger": "From a ledger",
-    "secret-key": "Either the unencrypted or password-encrypted secret key for your address",
-    "remote": "Remote key governed by a signer running on a different machine",
-    "json": "Faucet JSON file from https://teztnets.xyz/",
-}
-
 systemd_enable = {
     "yes": "Enable the services, running them both now and on every boot",
     "no": "Start the services this time only",
@@ -398,18 +391,21 @@ class Setup(Setup):
 
             key_mode_query = get_key_mode_query(key_import_modes)
 
-            ledger_set_up = False
-            while not ledger_set_up:
+            baker_set_up = False
+            while not baker_set_up:
                 self.import_key(key_mode_query, "Baking")
 
-                try:
-                    proc_call(
-                        f"sudo -u tezos {suppress_warning_text} tezos-client {tezos_client_options} "
-                        f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
-                    )
-                    ledger_set_up = True
-                except PermissionError:
-                    print("Going back to the import mode selection.")
+                if self.config["key_import_mode"] == "ledger":
+                    try:
+                        proc_call(
+                            f"sudo -u tezos {suppress_warning_text} tezos-client {tezos_client_options} "
+                            f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
+                        )
+                        baker_set_up = True
+                    except PermissionError:
+                        print("Going back to the import mode selection.")
+                else:
+                    baker_set_up = True
 
     def register_baker(self):
         print()


### PR DESCRIPTION
## Description
Problem: Currently setup wizard attempts to call 'setup ledger to bake
for' for every key type. As a result, an attempt to setup remote or
secret-key baker fails with an error.

Solution: Call this function only when the selected key type is ledger.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #491 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
