### PR TITLE
[#486] Ensure formula have the same version as current tag to update bottle

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -89,9 +89,9 @@ jobs:
       - name: Download Catalina bottles from the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${{ env.tag }}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
+        run: gh release download "${{ github.ref_name }}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
 
       - name: Add bottle hashes to formulae
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: ./scripts/sync-bottle-hashes.sh "${{ env.tag }}" "Catalina"
+        run: ./scripts/sync-bottle-hashes.sh "${{ github.ref_name }}" "Catalina"

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-# This script takes a directory where the bottles are stored as its argument.
+# This script takes a directory where the bottles are stored and release tag as its arguments.
 # Run it from the base directory (tezos-packaging).
 
 set -e
@@ -19,10 +19,13 @@ then
                 os="${BASH_REMATCH[2]}"
                 formula_file="./Formula/$formula_name.rb"
                 if [[ -f $formula_file ]]; then
+                    formula_tag="$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "$formula_file")"
                     line="\    sha256 cellar: :any, $os: \"$bottle_hash\""
-                    # Update only when this formula doesn't have a hash for the bottle
-                    if ! grep "$line" "$formula_file" &> /dev/null; then
+                    # Update only when formula has the same version as provided current tag
+                    if [[ "$formula_tag" == "$2" ]]; then
                         sed -i "/root_url.*/a $line" "$formula_file"
+                    else
+                        echo "Current tag is $2, while formula has $formula_tag version"
                     fi
                 fi
             fi

--- a/scripts/sync-bottle-hashes.sh
+++ b/scripts/sync-bottle-hashes.sh
@@ -29,7 +29,7 @@ fi
 while : ; do
     git fetch --all
     git reset --hard origin/"$branch_name"
-    ./scripts/bottle-hashes.sh "./$2"
+    ./scripts/bottle-hashes.sh "./$2" "$1"
     git commit -a -m "[Chore] Add $1 hashes to brew formulae for $2"
     ! git push || break
 done

--- a/tests/bottle-hashes/test-hash-insert.sh
+++ b/tests/bottle-hashes/test-hash-insert.sh
@@ -41,7 +41,7 @@ dd if=/dev/urandom of=$bottle_dir/$catalina_bottle count=2000 status=none
 dd if=/dev/urandom of=$bottle_dir/$big_sur_bottle count=2000 status=none
 
 # Run the hash inserting script
-../../scripts/bottle-hashes.sh $bottle_dir
+../../scripts/bottle-hashes.sh "$bottle_dir" "v0.0-1"
 
 # Assert the info was inserted correctly
 catalina_hash="$(sha256sum $bottle_dir/$catalina_bottle | cut -d " " -f 1)"


### PR DESCRIPTION
## Description
Problem: In some cases bottles' hashes are updated even when current
release hasn't updated any formulae.

Solution: Assert that the formula version as the same as current tag
before updating bottle hash.

I've tested the changes with `v13.0-test` tag, CI refused to push any changes:
* https://github.com/serokell/tezos-packaging/runs/7250322868
* https://buildkite.com/serokell/tezos-packaging-tags/builds/1887
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #486

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
