### PR TITLE
[Chore] autorelease.sh hotfix

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -87,7 +87,7 @@ steps:
    commands:
    - buildkite-agent artifact download "docker/*" . --step "build-via-docker"
    - chmod +x ./docker/*
-   - nix-build . -A binaries-test.x86_64-linux --no-out-link --arg path-to-binaries ./docker
+   - nix-build . -A binaries-test --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
    depends_on:
     - "build-via-docker"

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -87,7 +87,7 @@ steps:
    commands:
    - buildkite-agent artifact download "docker/*" . --step "build-via-docker"
    - chmod +x ./docker/*
-   - nix-build . -A binaries-test --no-out-link --arg path-to-binaries ./docker
+   - nix-build . -A binaries-test.x86_64-linux --no-out-link --arg path-to-binaries ./docker
    branches: "!master"
    depends_on:
     - "build-via-docker"

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -170,7 +170,7 @@ steps:
    - buildkite-agent artifact download "docker/*" arm-binaries --step "build-arm-via-docker"
    - ls binaries
    - ./scripts/autorelease.sh "$BUILDKITE_MESSAGE"
-   branches: master
+   #branches: master
    depends_on:
     - "build-via-docker"
     - "build-arm-via-docker"

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: 2022 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-(import
+let
+  inherit (import
   (
     let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
     fetchTarball {
       url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
       sha256 = lock.nodes.flake-compat.locked.narHash;
     }
-  )
-  { src = ./.; }
-).defaultNix
+  ) { src = ./.; })
+  defaultNix;
+in defaultNix // defaultNix.devShells.${__currentSystem}
+             // { binaries-test = defaultNix.binaries-test.${__currentSystem};
+                  release = defaultNix.release.${__currentSystem};
+                }

--- a/flake.lock
+++ b/flake.lock
@@ -49,20 +49,6 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -76,7 +62,7 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1656928814,
         "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
@@ -323,7 +309,7 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_3",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json"
@@ -395,7 +381,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -408,7 +393,7 @@
     "serokell-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "gitignore-nix": "gitignore-nix",
         "nix-unstable": "nix-unstable",
         "nixpkgs": "nixpkgs_6"

--- a/flake.lock
+++ b/flake.lock
@@ -49,6 +49,20 @@
     },
     "flake-utils": {
       "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1638122382,
         "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
         "owner": "numtide",
@@ -62,7 +76,7 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1656928814,
         "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
@@ -309,7 +323,7 @@
     "opam-nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_3",
         "opam-repository": "opam-repository",
         "opam2json": "opam2json"
@@ -381,6 +395,7 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -393,7 +408,7 @@
     "serokell-nix": {
       "inputs": {
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils_3",
         "gitignore-nix": "gitignore-nix",
         "nix-unstable": "nix-unstable",
         "nixpkgs": "nixpkgs_6"

--- a/nix/build/zcash.nix
+++ b/nix/build/zcash.nix
@@ -4,7 +4,7 @@
 
 # zcash-params required for building some of the tezos binaries
 # and for running tests
-{ pkgs }:
+{ pkgs, ... }:
 with pkgs;
 let
   sapling-spend-params = fetchurl {

--- a/release.nix
+++ b/release.nix
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
-{ pkgs, sources, meta, protocols, ... }:
+{ pkgs, sources, meta, protocols, ... }: { docker-binaries, docker-arm-binaries }:
 let
   source = sources.tezos;
   commonMeta = {
@@ -13,9 +13,9 @@ let
     licenseFile = "${source}/LICENSE";
   } // meta;
   release = pkgs.callPackage ./tezos-release.nix {
-    binaries = ./binaries/docker;
-    arm-binaries = ./arm-binaries/docker;
+    binaries = docker-binaries;
+    arm-binaries = docker-arm-binaries;
     inherit commonMeta protocols; inherit (pkgs.lib) replaceStrings;
   };
 
-in { tezos-release = release; }
+in release

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -21,7 +21,7 @@ trap finish EXIT
 assets_dir=$TEMPDIR/assets
 
 # Build tezos-release
-nix-build . -A release -o "$TEMPDIR"/"$project" \
+nix-build . -A release.x86_64-linux -o "$TEMPDIR"/"$project" \
           --arg docker-binaries ./binaries/docker --arg docker-arm-binaries ./arm-binaries/docker
 mkdir -p "$assets_dir"
 # Move archive with binaries and tezos license to assets

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell .. -A devShells.x86_64-linux.autorelease -i bash
+#!nix-shell .. -A autorelease -i bash
 # shellcheck shell=bash
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
@@ -21,7 +21,7 @@ trap finish EXIT
 assets_dir=$TEMPDIR/assets
 
 # Build tezos-release
-nix-build . -A release.x86_64-linux -o "$TEMPDIR"/"$project" \
+nix-build . -A release -o "$TEMPDIR"/"$project" \
           --arg docker-binaries ./binaries/docker --arg docker-arm-binaries ./arm-binaries/docker
 mkdir -p "$assets_dir"
 # Move archive with binaries and tezos license to assets

--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -21,7 +21,7 @@ trap finish EXIT
 assets_dir=$TEMPDIR/assets
 
 # Build tezos-release
-nix-build . -A tezos-release -o "$TEMPDIR"/"$project" \
+nix-build . -A release -o "$TEMPDIR"/"$project" \
           --arg docker-binaries ./binaries/docker --arg docker-arm-binaries ./arm-binaries/docker
 mkdir -p "$assets_dir"
 # Move archive with binaries and tezos license to assets

--- a/scripts/build-all-bottles.sh
+++ b/scripts/build-all-bottles.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell .. -A devShells.x86_64-linux.autorelease-macos -i bash
+#! nix-shell .. -A autorelease-macos -i bash
 # shellcheck shell=bash
 
 # SPDX-FileCopyrightText: 2022 Oxhead Alpha

--- a/scripts/publish-native-packages.sh
+++ b/scripts/publish-native-packages.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell .. -A devShells.x86_64-linux.autorelease -i bash
+#! nix-shell .. -A autorelease -i bash
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env nix-shell
-#! nix-shell .. -A devShells.x86_64-linux.autorelease -i bash
+#! nix-shell .. -A autorelease -i bash
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,8 @@ with pkgs; mkShell {
     python3Packages.black
     shellcheck
     vagrant
+    jq
+    buildkite-agent
   ];
-  TEZOS_VERSION="v13.1";
+  TEZOS_VERSION="v13.0";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-{ pkgs, ...  }:
+{ pkgs, meta, ...  }:
 with pkgs; mkShell {
   buildInputs = [
     nix
@@ -15,5 +15,5 @@ with pkgs; mkShell {
     jq
     buildkite-agent
   ];
-  TEZOS_VERSION="v13.0";
+  TEZOS_VERSION= with pkgs.lib; lists.last (strings.splitString "/" (meta.tezos_ref));
 }

--- a/shell.nix
+++ b/shell.nix
@@ -12,6 +12,8 @@ with pkgs; mkShell {
     python3Packages.black
     shellcheck
     vagrant
+    libvirt
+    qemu
     jq
     buildkite-agent
   ];

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -9,7 +9,7 @@ in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
     virtualisation.memorySize = 1024;
     virtualisation.diskSize = 1024;
     environment.sessionVariables.XDG_DATA_DIRS =
-      [ "${pkgs.zcash}" ];
+      [ "${pkgs.zcash-params}" ];
     security.pki.certificateFiles = [ ./ca.cert ];
   };
 


### PR DESCRIPTION
## Description

Problem: release derivation wasn't built due to incorrect
flake output declaration.

Solution: Get rid of misleading flake-utils functions.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
