### PR TITLE
Add ability to override the license version

### DIFF
--- a/docker/package/meta.py
+++ b/docker/package/meta.py
@@ -6,21 +6,27 @@ import os, json
 
 
 class PackagesMeta:
-    def __init__(self, version, release, ubuntu_epoch, fedora_epoch, maintainer):
+    def __init__(
+        self, version, release, ubuntu_epoch, fedora_epoch, maintainer, license_version
+    ):
         self.version = version
         self.release = release
         self.ubuntu_epoch = ubuntu_epoch
         self.fedora_epoch = fedora_epoch
         self.maintainer = maintainer
+        self.license_version = license_version
 
+
+version = os.environ["TEZOS_VERSION"][1:]
 
 meta_json_contents = json.load(
     open(f"{os.path.dirname(__file__)}/../../meta.json", "r")
 )
 packages_meta = PackagesMeta(
-    version=os.environ["TEZOS_VERSION"][1:],
+    version=version,
     release=str(meta_json_contents["release"]),
     ubuntu_epoch=2,
     fedora_epoch=1,
     maintainer=meta_json_contents["maintainer"],
+    license_version=os.getenv("TEZOS_LICENSE_VERSION", f"v{version}"),
 )

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -395,7 +395,7 @@ set -e
                 "-q",
                 "-O",
                 out,
-                f"https://gitlab.com/tezos/tezos/-/raw/v{self.meta.version}/LICENSE",
+                f"https://gitlab.com/tezos/tezos/-/raw/{self.meta.license_version}/LICENSE",
             ],
             check=True,
         )


### PR DESCRIPTION
## Description

We add the option to specify the LICENSE version we're fetching during the build to support package verisons that are not also git tags on the repo.

## Related issue(s)

None

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)
- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
