### PR TITLE
[Chore] Include 014 daemons to formulae build list

### DIFF
--- a/.github/workflows/check-formulas.yml
+++ b/.github/workflows/check-formulas.yml
@@ -7,7 +7,7 @@ on:
       - '.github/workflows/check-formulas.yml'
 jobs:
   check-formulas:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/scripts/build-all-bottles.sh
+++ b/scripts/build-all-bottles.sh
@@ -12,7 +12,7 @@ fi
 set -euo pipefail
 
 # we don't bottle meta-formulas that contain only services
-formulae=("tezos-accuser-013-PtJakart" "tezos-admin-client" "tezos-baker-013-PtJakart" "tezos-client" "tezos-codec" "tezos-node" "tezos-sandbox" "tezos-signer")
+formulae=("tezos-accuser-013-PtJakart" "tezos-accuser-014-PtKathma" "tezos-admin-client" "tezos-baker-013-PtJakart" "tezos-baker-014-PtKathma" "tezos-client" "tezos-codec" "tezos-node" "tezos-sandbox" "tezos-signer")
 
 # tezos-sapling-params is used as a dependency for some of the formulas
 # so we handle it separately.


### PR DESCRIPTION
## Description
Problem: 014 Daemons weren't included into the list of formulae that are
build via BK.

Solution: Extend the list with 014 daemons.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
