### PR TITLE
[Chore] Expose 'overlay' from flake

### DIFF
--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -1,16 +1,18 @@
 # SPDX-FileCopyrightText: 2021-2022 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-{ sources, protocols, pkgs, opam-nix, ... }:
+{ sources, protocols, opam-nix, ... }:
 
 self: super:
-with opam-nix.lib.${pkgs.system}; let
+let
+  pkgs = super;
+in
+with opam-nix.lib.${self.system}; let
   zcash-overlay = import ./zcash-overlay.nix;
   hacks = import ./hacks.nix;
   tezosSourcesResolved =
-    pkgs.runCommand "resolve-tezos-sources" {} "cp --no-preserve=all -Lr ${sources.tezos} $out";
+    self.runCommand "resolve-tezos-sources" {} "cp --no-preserve=all -Lr ${sources.tezos} $out";
   tezosScope = buildOpamProject' {
-    inherit pkgs;
     repos = [sources.opam-repository];
     recursive = true;
     resolveArgs = { };


### PR DESCRIPTION
## Description
Problem: It's required to use specific overlay when using NixOS modules
from 'tezos-packaging' flake.

Solution: Expose 'overlay' that includes all required overlays.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
