### PR TITLE
[Chore] Fix 'build-binary.sh' script

### DIFF
--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -18,5 +18,6 @@ ENV OPAMROOT "/tezos-packaging/docker/opamroot"
 COPY docker/package/*.py /tezos-packaging/docker/package/
 COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
+COPY docker/package/patches /tezos-packaging/docker/package/patches
 COPY LICENSE /tezos-packaging/LICENSE
 ENTRYPOINT ["python3", "-m", "package.package_generator"]

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -206,6 +206,7 @@ class TezosBinaryPackage(AbstractPackage):
         postinst_steps: str = "",
         postrm_steps: str = "",
         additional_native_deps: List[str] = [],
+        patches: List[str] = [],
     ):
         self.name = name
         self.desc = desc
@@ -216,6 +217,7 @@ class TezosBinaryPackage(AbstractPackage):
         self.additional_native_deps = additional_native_deps
         self.meta = meta
         self.dune_filepath = dune_filepath
+        self.patches = patches
 
     def __get_os_specific_native_deps(self, os_name):
         return [
@@ -409,6 +411,7 @@ class TezosSaplingParamsPackage(AbstractPackage):
         self.targetProto = None
         self.meta = meta
         self.params_revision = params_revision
+        self.patches = []
 
     def fetch_sources(self, out_dir, binaries_dir=None):
         os.makedirs(out_dir)
@@ -563,6 +566,7 @@ class TezosBakingServicesPackage(AbstractPackage):
         self.meta = deepcopy(meta)
         self.meta.version = self.meta.version + self.letter_version
         self.target_protos = set()
+        self.patches = []
         for network in target_networks:
             for proto in network_protos[network]:
                 self.target_protos.add(proto)

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 import os, json
+from unittest.mock import patch
 
 from .meta import packages_meta
 
@@ -132,12 +133,16 @@ packages = [
         additional_native_deps=["tezos-sapling-params", "udev"],
         postinst_steps=ledger_udev_postinst,
         dune_filepath="src/bin_client/main_client.exe",
+        # TODO: remove on the next upstream release
+        patches=["build-binary.sh.patch"],
     ),
     TezosBinaryPackage(
         "tezos-admin-client",
         "Administration tool for the node",
         meta=packages_meta,
         dune_filepath="src/bin_client/main_admin.exe",
+        # TODO: remove on the next upstream release
+        patches=["build-binary.sh.patch"],
     ),
     TezosBinaryPackage(
         "tezos-signer",
@@ -147,12 +152,16 @@ packages = [
         systemd_units=signer_units,
         postinst_steps=ledger_udev_postinst,
         dune_filepath="src/bin_signer/main_signer.exe",
+        # TODO: remove on the next upstream release
+        patches=["build-binary.sh.patch"],
     ),
     TezosBinaryPackage(
         "tezos-codec",
         "A client to decode and encode JSON",
         meta=packages_meta,
         dune_filepath="src/bin_codec/codec.exe",
+        # TODO: remove on the next upstream release
+        patches=["build-binary.sh.patch"],
     ),
 ]
 
@@ -256,6 +265,8 @@ packages.append(
         postrm_steps=node_postrm_steps,
         additional_native_deps=["tezos-sapling-params", {"ubuntu": "netbase"}],
         dune_filepath="src/bin_node/main.exe",
+        # TODO: remove on the next upstream release
+        patches=["build-binary.sh.patch"],
     )
 )
 
@@ -385,6 +396,8 @@ for proto in active_protocols:
                 "udev",
             ],
             dune_filepath=f"src/proto_{proto_snake_case}/bin_baker/main_baker_{proto_snake_case}.exe",
+            # TODO: remove on the next upstream release
+            patches=["build-binary.sh.patch"],
         )
     )
     packages.append(
@@ -410,6 +423,8 @@ for proto in active_protocols:
             additional_native_deps=["udev"],
             postinst_steps=daemon_postinst_common + ledger_udev_postinst,
             dune_filepath=f"src/proto_{proto_snake_case}/bin_accuser/main_accuser_{proto_snake_case}.exe",
+            # TODO: remove on the next upstream release
+            patches=["build-binary.sh.patch"],
         )
     )
 

--- a/docker/package/patches/build-binary.sh.patch
+++ b/docker/package/patches/build-binary.sh.patch
@@ -1,0 +1,18 @@
+diff --color -Nru tezos-client-14.0-rc1.orig/build-binary.sh tezos-client-14.0-rc1/build-binary.sh
+--- tezos-client-14.0-rc1.orig/build-binary.sh	2022-07-22 17:37:24.000000000 +0300
++++ tezos-client-14.0-rc1/build-binary.sh	2022-07-27 12:01:58.842885979 +0300
+@@ -13,12 +13,12 @@
+ 
+ cd tezos
+ opam init local ../opam-repository --bare --disable-sandboxing
+-opam switch create . --repositories=local
++opam switch create . --repositories=local --no-install
+ eval "$(opam env)"
+ opams=()
+ while IFS=  read -r -d $'\0'; do
+     opams+=("$REPLY")
+-done < <(find ./vendors ./src ./tezt -name \*.opam -print0)
++done < <(find ./vendors ./src ./tezt ./opam -name \*.opam -print0)
+ opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"
+ eval "$(opam env)"
+ dune build "$dune_filepath"

--- a/docker/package/patches/build-binary.sh.patch.license
+++ b/docker/package/patches/build-binary.sh.patch.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022 Oxhead Alpha
+SPDX-License-Identifier: LicenseRef-MIT-OA

--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -13,12 +13,12 @@ binary_name="$2"
 
 cd tezos
 opam init local ../opam-repository --bare --disable-sandboxing
-opam switch create . --repositories=local
+opam switch create . --repositories=local --no-install
 eval "$(opam env)"
 opams=()
 while IFS=  read -r -d $'\0'; do
     opams+=("$REPLY")
-done < <(find ./vendors ./src ./tezt -name \*.opam -print0)
+done < <(find ./vendors ./src ./tezt ./opam -name \*.opam -print0)
 opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"
 eval "$(opam env)"
 dune build "$dune_filepath"

--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -71,6 +71,17 @@ def build_ubuntu_package(
                     )
                     source_path = f"{cwd}/scripts/{source_script_name}"
                     shutil.copy(source_path, dest_path)
+        # Patches only make sense when we're reusing the old sources that are not static binary
+        if (
+            len(pkg.patches) > 0
+            and source_archive_path is not None
+            and binaries_dir is None
+        ):
+            os.makedirs("debian/patches")
+            with open("debian/patches/series", "w") as f:
+                for patch in pkg.patches:
+                    shutil.copy(f"{cwd}/patches/{patch}", f"debian/patches/{patch}")
+                    f.write(patch)
         with open("debian/compat", "w") as f:
             f.write("10")
         pkg.gen_install("debian/install")

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-    "release": "1",
+    "release": "2",
     "maintainer": "Serokell <hi@serokell.io>",
     "tezos_ref": "refs/tags/v14.0-rc1"
 }


### PR DESCRIPTION
## Description

Problem: Native packages cannot be built on Launchpad due to the fact
build consumes too much disk space because of excessively copied Octez
sources. Also, in the latest release, all packages '.opam' files were
moved to a dedicated directory.

Solution:
1) Avoid installing packages during opam switch creation.
2) Add 'opam' directory to the list in which opam files are searched.

Also, provide a way to propagate this fix to the existing packages via patch file.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
