### PR TITLE
[#508] Use Monterey runners in GA instead of Catalina

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ { id: macos-10.15, name: "catalina" } ]
+        os: [ { id: macos-12, name: "monterey" } ]
         # we don't bottle meta-formulas that contain only services
         formula: [tezos-accuser-013-PtJakart, tezos-accuser-014-PtKathma, tezos-admin-client, tezos-baker-013-PtJakart, tezos-baker-014-PtKathma, tezos-client, tezos-codec, tezos-node, tezos-signer]
 
@@ -64,7 +64,7 @@ jobs:
         run: gh release upload "${{ env.tag }}" *.bottle.*
 
   sync-hashes:
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: build-bottles
     steps:
       - name: Checkout
@@ -86,12 +86,12 @@ jobs:
 
        # It's possible we have had to rerun the building workflow, skipping some jobs and
        # erasing the previously built bottles, so we use the release to download them all
-      - name: Download Catalina bottles from the release
+      - name: Download Monterey bottles from the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${{ github.ref_name }}" -p "*.catalina.bottle.tar.gz" -D "./Catalina"
+        run: gh release download "${{ github.ref_name }}" -p "*.monterey.bottle.tar.gz" -D "./Monterey"
 
       - name: Add bottle hashes to formulae
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: ./scripts/sync-bottle-hashes.sh "${{ github.ref_name }}" "Catalina"
+        run: ./scripts/sync-bottle-hashes.sh "${{ github.ref_name }}" "Monterey"

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -51,7 +51,7 @@ Brew formulae provided by `tezos-packaging` aim to support all maintained macOS 
 * macOS 12 (Monterey)
 
 Unfortunately, the ability to provide pre-compiled brew bottles for formulae has
-a hard dependency on the available build infrastructure. At the moment, the only macOS
-versions for which we provide brew bottles are:
+a hard dependency on the available build infrastructure.
+Thus we only provide brew bottles for two latest macOS versions:
 * macOS 11 (Big Sur) both `x86_64` and `arm64`
-* macOS 10.15 (Catalina) only `x86_64`
+* macOS 12 (Monterey) `x86_64` only

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -11,7 +11,7 @@ if [[ -d ./Formula ]]
 then
     if [[ -d "$1" ]]
     then
-        regex="(tezos-.*)-v.*\.(catalina|big_sur|arm64_big_sur)\.bottle\.tar\.gz"
+        regex="(tezos-.*)-v.*\.(monterey|big_sur|arm64_big_sur)\.bottle\.tar\.gz"
         for bottle in "$1"/tezos-*.bottle.tar.gz; do
             if [[ $bottle =~ $regex ]]; then
                 bottle_hash=$(sha256sum "$bottle" | cut -d " " -f 1)

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -15,6 +15,7 @@ then
             -exec sed -i "s/version \"v.*\"/version \"$tag\"/g" {} \; \
             -exec sed -i "s/:tag => \"v.*\"/:tag => \"$version\"/g" {} \; \
             -exec sed -i "/catalina/d" {} \; \
+            -exec sed -i "/monterey/d" {} \; \
             -exec sed -i "/mojave/d" {} \; \
             -exec sed -i "/big_sur/d" {} \; \
             -exec sed -i "/arm64_big_sur/d" {} \;

--- a/tests/bottle-hashes/test-hash-insert.sh
+++ b/tests/bottle-hashes/test-hash-insert.sh
@@ -33,18 +33,18 @@ class TezosHashTest < Formula
 end
 EOL
 
-catalina_bottle="$formula_name-v0.0-0.catalina.bottle.tar.gz"
+monterey_bottle="$formula_name-v0.0-0.monterey.bottle.tar.gz"
 big_sur_bottle="$formula_name-v0.0-0.big_sur.bottle.tar.gz"
 
 # Generate some dummy bottles
-dd if=/dev/urandom of=$bottle_dir/$catalina_bottle count=2000 status=none
+dd if=/dev/urandom of=$bottle_dir/$monterey_bottle count=2000 status=none
 dd if=/dev/urandom of=$bottle_dir/$big_sur_bottle count=2000 status=none
 
 # Run the hash inserting script
 ../../scripts/bottle-hashes.sh "$bottle_dir" "v0.0-1"
 
 # Assert the info was inserted correctly
-catalina_hash="$(sha256sum $bottle_dir/$catalina_bottle | cut -d " " -f 1)"
+monterey_hash="$(sha256sum $bottle_dir/$monterey_bottle | cut -d " " -f 1)"
 big_sur_hash="$(sha256sum $bottle_dir/$big_sur_bottle | cut -d " " -f 1)"
 
 expected_formula=$(cat << EOF
@@ -59,7 +59,7 @@ class TezosHashTest < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosHashTest.version}/"
-    sha256 cellar: :any, catalina: "$catalina_hash"
+    sha256 cellar: :any, monterey: "$monterey_hash"
     sha256 cellar: :any, big_sur: "$big_sur_hash"
   end
 


### PR DESCRIPTION
## Description

Problem: GA no longer provide runners with Catalina and thus we're
unable to build bottles for Catalina automatically due to lack of
infrastructure.

Solution: Build bottles for `x86` Monterey instead of Catalina since GA
provide such runners. Also, update support policy doc to reflect the
changes.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #508

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
