### PR TITLE
[Chore] Support multiple protocols simultaneously in daemon modules 

### DIFF
--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -1,16 +1,18 @@
 # SPDX-FileCopyrightText: 2021-2022 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-{ sources, protocols, pkgs, opam-nix, ... }:
+{ sources, protocols, opam-nix, ... }:
 
 self: super:
-with opam-nix.lib.${pkgs.system}; let
+let
+  pkgs = super;
+in
+with opam-nix.lib.${self.system}; let
   zcash-overlay = import ./zcash-overlay.nix;
   hacks = import ./hacks.nix;
   tezosSourcesResolved =
-    pkgs.runCommand "resolve-tezos-sources" {} "cp --no-preserve=all -Lr ${sources.tezos} $out";
+    self.runCommand "resolve-tezos-sources" {} "cp --no-preserve=all -Lr ${sources.tezos} $out";
   tezosScope = buildOpamProject' {
-    inherit pkgs;
     repos = [sources.opam-repository];
     recursive = true;
     resolveArgs = { };

--- a/nix/modules/tezos-accuser.nix
+++ b/nix/modules/tezos-accuser.nix
@@ -31,11 +31,12 @@ in {
     };
   };
   config =
-    let accuser-start-script = node-cfg: ''
-        ${tezos-accuser-pkgs.${node-cfg.baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
+    let accuser-start-script = node-cfg: concatMapStringsSep "\n" (baseProtocol:
+      ''
+        ${tezos-accuser-pkgs.${baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
         -E "http://localhost:${toString node-cfg.rpcPort}" \
-        run "$@"
-      '';
+        run "$@" &
+      '') node-cfg.baseProtocols;
     in common.genDaemonConfig {
       instancesCfg = cfg.instances;
       service-name = "accuser";

--- a/nix/modules/tezos-baker.nix
+++ b/nix/modules/tezos-baker.nix
@@ -61,11 +61,12 @@ in {
     let baker-start-script = node-cfg:
       let
         voting-option = "--liquidity-baking-toggle-vote ${node-cfg.liquidityBakingToggleVote}";
-      in ''
-        ${tezos-baker-pkgs.${node-cfg.baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
+      in concatMapStringsSep "\n" (baseProtocol:
+      ''
+        ${tezos-baker-pkgs.${baseProtocol}} -d "$STATE_DIRECTORY/client/data" \
         -E "http://localhost:${toString node-cfg.rpcPort}" \
-        run with local node "$STATE_DIRECTORY/node/data" ${voting-option} ${node-cfg.bakerAccountAlias}
-      '';
+        run with local node "$STATE_DIRECTORY/node/data" ${voting-option} ${node-cfg.bakerAccountAlias} &
+      '') node-cfg.baseProtocols;
         baker-prestart-script = node-cfg: if node-cfg.bakerSecretKey != null then ''
           ${tezos-client} -d "$STATE_DIRECTORY/client/data" import secret key "${node-cfg.bakerAccountAlias}" ${node-cfg.bakerSecretKey} --force
           '' else "";

--- a/scripts/shell.nix
+++ b/scripts/shell.nix
@@ -15,6 +15,7 @@ mkShell {
     rename
     gnupg
     dput
+    copr-cli
     rpm
     debian-devscripts
     which

--- a/tests/tezos-modules.nix
+++ b/tests/tezos-modules.nix
@@ -32,12 +32,12 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
 
     services.tezos-accuser.instances.jakartanet = {
       enable = true;
-      baseProtocol = "013-PtJakart";
+      baseProtocols = ["013-PtJakart" "014-PtKathma"];
     };
 
     services.tezos-baker.instances.jakartanet = {
       enable = true;
-      baseProtocol = "013-PtJakart";
+      baseProtocols = ["013-PtJakart" "014-PtKathma"];
       bakerAccountAlias = "baker";
       bakerSecretKey = "unencrypted:edsk3KaTNj1d8Xd3kMBrZkJrfkqsz4XwwiBXatuuVgTdPye2KpE98o";
     };


### PR DESCRIPTION
## Description
Problem: In some cases, it's required to run bakers for two protocols
simultaneously.

Solution: Update daemons service config to take a list of protocols as
an option and run a daemon for each of listed protocols.

Currently based on #506 for convenience since both of these PRs provide changes needed in single place.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
