### PR TITLE
[Chore] Fix interpolation bug in autorelease.sh

### DIFF
--- a/scripts/autorelease.sh
+++ b/scripts/autorelease.sh
@@ -58,7 +58,10 @@ git tag -f "$tag"
 git push origin "$tag" --force
 
 # Create release
-gh release create -F "$TEMPDIR"/"$project"/release-notes.md "$mode_flag" "$tag" --title "$tag"
+# Note: "mode_flag" should not be quoted here because an empty value results in
+# two consecutive spaces, which gh will interpret incorrectly as an empty param
+# shellcheck disable=SC2086
+gh release create "$tag" --title "$tag" $mode_flag -F "$TEMPDIR"/"$project"/release-notes.md
 
 # Upload assets
 gh release upload "$tag" "$assets_dir"/*


### PR DESCRIPTION
## Description

Problem: in the autorelease.sh script the interpolation of an empty
variable results in two consecutive spaces, which is incorrectly
interpreted as an empty argument by the 'gh' command.

Solution: remove the double quotes to solve the issue and add a
shellcheck ignore to avoid marking this as incorrect.
Note: this partially reverts d7732417d282196f55cc5847b6f4d8dd466c9781

For reference:
1. [recent occurrence of the issue](https://buildkite.com/serokell/tezos-packaging/builds/2886#01825a14-28ca-49f2-b90f-c41c63e2b706)
2. [proof of `gh` failing because of an empty `mode_flag`](https://buildkite.com/serokell/tezos-packaging/builds/2911#01825ecc-a4ef-4c5e-ac18-19924b1b4bb6)
3. [proof of `gh` working as expected without `mode_flag`](https://buildkite.com/serokell/tezos-packaging/builds/2910#01825ecc-4497-4ae6-9fa4-d41b45d3128a)

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
