### PR TITLE
[Chore] Fail in CI when bottles were not built or uploaded

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -42,6 +42,9 @@ steps:
    - nix develop .#autorelease-macos -c ./scripts/build-all-bottles.sh "big_sur"
    artifact_paths:
      - '*.bottle.*'
+   retry:
+     automatic:
+       limit: 1
 
  # To avoid running two brew processes together
  - wait
@@ -55,6 +58,9 @@ steps:
    - nix develop .#autorelease-macos -c ./scripts/build-all-bottles.sh "arm64_big_sur"
    artifact_paths:
      - '*.bottle.*'
+   retry:
+     automatic:
+       limit: 1
 
  # We use the tag that triggered the pipeline here. Normally, this isn't very resilient,
  # but in 'scripts/sync-bottle-hashes.sh' it's only used for informational purposes


### PR DESCRIPTION
## Description

Problem: currently in case a bottle fails to be built, or uploaded,
an error message is printed, but the exit code remains 0.
This is a problem because one can miss this easily in the logs
and also because the successful step cannot be retried on CI.

Solution: return a non-0 exit code when any of the bottles failed to
build or was not uploaded.
Additionally add automated retries of the bottle building steps in CI.

## Related issue(s)

Related to #418 (see last point in acceptance criteria)

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
