### PR TITLE
[Chore] Always remove the initial 'v' from commonMeta.version

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,7 +6,7 @@
 let
   source = sources.tezos;
   commonMeta = {
-    version = builtins.replaceStrings [ "refs/tags/v" ] [ "" ] meta.tezos_ref;
+    version = with pkgs.lib.strings; removePrefix "v" (removePrefix "refs/tags/" meta.tezos_ref);
     license = "MIT";
     dependencies = "";
     branchName = meta.tezos_ref;


### PR DESCRIPTION
## Description

Problem: currently the 'commonMeta.version' as defined in
tezos-release.nix will drop the initial "v" from the 'branchName'
only when this starts with "refs/tags/", but in some cases this
part is missing.

Solution: modify the definition to drop the initial "v" whether
or not there is a "refs/tags/" at the start of the 'branchName'.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
