### PR TITLE
[Chore] Fix fedora packaging

### DIFF
--- a/docker/package/fedora.py
+++ b/docker/package/fedora.py
@@ -24,10 +24,6 @@ def build_fedora_package(
     pkg.gen_buildfile("/".join([dir, pkg.buildfile]), binaries_dir)
     pkg.gen_license(f"{dir}/LICENSE")
     for systemd_unit in pkg.systemd_units:
-        if systemd_unit.service_file.service.environment_file is not None:
-            systemd_unit.service_file.service.environment_file = (
-                systemd_unit.service_file.service.environment_file.lower()
-            )
         if systemd_unit.suffix is None:
             unit_name = pkg.name
         else:


### PR DESCRIPTION

## Description

Problem: Fedora package systemd unit systemd env file
name was lowercased during packaging, which caused
failure to start corresponding service.

Solution: Don't lowercase env file name in fedora packaging.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
