### PR TITLE
[#522] Rework node services startup script

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -186,6 +186,8 @@ def mk_node_unit(
             timeout_start_sec="2400s",
             state_directory="tezos",
             user="tezos",
+            type_="notify",
+            notify_access="all",
         ),
         Install(wanted_by=["multi-user.target"]),
     )
@@ -255,7 +257,7 @@ packages.append(
         systemd_units=node_units,
         postinst_steps=node_postinst_steps,
         postrm_steps=node_postrm_steps,
-        additional_native_deps=["tezos-sapling-params", {"ubuntu": "netbase"}],
+        additional_native_deps=["tezos-sapling-params", "curl", {"ubuntu": "netbase"}],
         dune_filepath="src/bin_node/main.exe",
     )
 )

--- a/docker/package/scripts/tezos-baker-start
+++ b/docker/package/scripts/tezos-baker-start
@@ -42,12 +42,6 @@ launch_baker() {
     fi
 }
 
-# TODO we should use --keep-alive instead of this loop once
-# https://gitlab.com/tezos/tezos/-/issues/2873 is fixed
-# Waiting till node start to respond
-
-while ! "$tezos_client" --endpoint "$NODE_RPC_ENDPOINT" rpc list &> /dev/null; do sleep 1; done
-
 if [[ -z "$BAKER_ADDRESS_ALIAS" ]]; then
     launch_baker "$@"
 else

--- a/docker/package/scripts/tezos-node-start
+++ b/docker/package/scripts/tezos-node-start
@@ -34,8 +34,16 @@ else
     node_run_args=("--data-dir" "$NODE_DATA_DIR" "--config-file" "$config_file" --rpc-addr "$NODE_RPC_ADDR")
 fi
 
-# Launching the node
+ if [[ -z "$CERT_PATH" || -z "$KEY_PATH" ]]; then
+     rpc_endpoint="http://$NODE_RPC_ADDR"
+ else
+     rpc_endpoint="https://$NODE_RPC_ADDR"
+ fi
 
+ # Marking service as active only once the node starts responding to RPC queries
+ (while ! curl -s "$rpc_endpoint/chains/main/blocks/head" &> /dev/null; do sleep 1; done; systemd-notify --ready) &
+
+# Launching the node
 if [[ -z "$CERT_PATH" || -z "$KEY_PATH" ]]; then
     exec "$node" run "${node_run_args[@]}"
 else

--- a/docker/package/systemd.py
+++ b/docker/package/systemd.py
@@ -17,6 +17,7 @@ class Service:
     environment: List[str] = None
     remain_after_exit: bool = False
     type_: str = None
+    notify_access: str = None
     restart: str = None
     keyring_mode: str = None
 
@@ -102,6 +103,7 @@ User={service_file.service.user}
 Group={service_file.service.user}
 {"RemainAfterExit=yes" if service_file.service.remain_after_exit else ""}
 {f"Type={service_file.service.type_}" if service_file.service.type_ is not None else ""}
+{f"NotifyAccess={service_file.service.notify_access}" if service_file.service.notify_access is not None else ""}
 {f"Restart={service_file.service.restart}" if service_file.service.restart is not None else ""}
 {f"KeyringMode={service_file.service.keyring_mode}" if service_file.service.keyring_mode is not None else ""}
 [Install]


### PR DESCRIPTION
## Description
Problem: Currently node services are considered to be up even though it
is yet unable to respond to RPC queries. This requires additional
workarounds for services that depend on node.

Solution: Switch node service to 'Type=notify' and mark service as ready
only once it start to respond to RPC queries.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #522

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
