### PR TITLE
[#482] Remove liquidity baking voting reminder from postinst script

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -601,17 +601,7 @@ class TezosBakingServicesPackage(AbstractPackage):
         custom_unit.poststop_script = "tezos-baking-custom-poststop"
         custom_unit.instances = []
         self.systemd_units.append(custom_unit)
-        # TODO: we will likely need to remove this once toggle vote isn't new anymore
-        self.postinst_steps = """echo ""
-echo "********************************************************************************"
-echo "**  Please note that the liquidity baking toggle vote option"
-echo "**  is now mandatory when baking. It has been automatically set to \"pass\"."
-echo "**  Re-run tezos-setup-wizard if you'd like to change your vote."
-echo "**  You can read more about it here:"
-echo "**  https://tezos.gitlab.io/jakarta/liquidity_baking.html#toggle-vote"
-echo "********************************************************************************"
-echo ""
-"""
+        self.postinst_steps = ""
         self.postrm_steps = ""
 
     def fetch_sources(self, out_dir, binaries_dir=None):


### PR DESCRIPTION
## Description
Problem: Liquidity baking voting toggle is mandatory since v13.0 and
it shouldn't be new anymore for users. However, we'll still notify about
the necessity to change the vote from default on each 'tezos-baking'
package installation/update.

Solution: Remove this reminder from 'tezos-baking' package
postinstallation script.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #482 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
