### PR TITLE
[#525] Support new faucet

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -389,7 +389,7 @@ class Setup(Setup):
         if replace_baker_key:
             if self.config["network"] == "mainnet":
                 key_import_modes.pop("json", None)
-
+                key_import_modes.pop("generate-fresh-key", None)
             key_mode_query = get_key_mode_query(key_import_modes)
 
             baker_set_up = False

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -196,12 +196,15 @@ In order to import such a key, run:
 sudo -u tezos tezos-client import secret key baker <secret-key>
 ```
 
-1) You have a faucet JSON file from https://teztnets.xyz/.
+1) Alternatively, you can generate a fresh baker key and fill it using faucet from https://teztnets.xyz.
 
-In order to activate the account run:
+In order to generate a fresh key run:
 ```
-sudo -u tezos tezos-client activate account baker with <path-to-downloaded-json>
+sudo -u tezos tezos-client gen keys baker
 ```
+The newly generated address will be displayed as a part of the command output.
+
+Then visit https://teztnets.xyz and fill the address with at least 6000 XTZ on the desired testnet.
 
 <a name="registration"></a>
 ### Registering the baker


### PR DESCRIPTION
## Description

1) Remove obsolete JSON-based faucet support.
2) Add an option to generate a fresh key pair for the baker that needs to be manually filled using the new faucet.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #525
#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
