### PR TITLE
[Chore] Add kathmandu support to mainnet

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -517,7 +517,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = ""
+    letter_version = "a"
 
     buildfile = "setup.py"
 

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -22,7 +22,7 @@ networks = {
     "kathmandunet": "kathmandunet",
 }
 networks_protos = {
-    "mainnet": ["013-PtJakart"],
+    "mainnet": ["013-PtJakart", "014-PtKathma"],
     "jakartanet": ["013-PtJakart"],
     "ghostnet": ["013-PtJakart"],
     "kathmandunet": ["014-PtKathma"],

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "1",
+  "release": "2",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v14.0"
 }


### PR DESCRIPTION
## Description

Problem: kathmandu will soon be activated on
mainnet and we we need to support it in our
services.

Solution: update mainnet services to include
a kathmandu baker for the protocol switch-over
and bump version to make a new release.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
