### PR TITLE
[Chore] Fix up binary building on Fedora and CI steps

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -117,7 +117,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-013-PtJakart
+   - ./docker/docker-tezos-packages.sh --os ubuntu --type binary --package tezos-baker-PtKathma
    - rm -rf out
    # It takes much time to build binary package, so we do it only on master
    branches: "master"
@@ -141,7 +141,7 @@ steps:
    - eval "$SET_VERSION"
    # Building all binary packages will take significant amount of time, so we build only one
    # in order to ensure package generation sanity
-   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-013-PtJakart
+   - ./docker/docker-tezos-packages.sh --os fedora --type binary --package tezos-baker-PtKathma
    - rm -rf out
    # It takes much time to build binary package, so we do it only on master
    branches: "master"

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -286,6 +286,7 @@ Description: {self.desc}
             f.write(file_contents)
 
     def gen_spec_file(self, build_deps, run_deps, out):
+        binary_name = self.name.replace("tezos", "octez")
         build_requires = " ".join(build_deps)
         requires = " ".join(run_deps)
         str_additional_native_deps = ", ".join(
@@ -319,13 +320,13 @@ Maintainer: {self.meta.maintainer}
 %setup -q
 %build
 %install
-make %{{name}}
+make {binary_name}
 mkdir -p %{{buildroot}}/%{{_bindir}}
-install -m 0755 %{{name}} %{{buildroot}}/%{{_bindir}}
+install -m 0755 {binary_name} %{{buildroot}}/%{{_bindir}}
 {systemd_install}
 %files
 %license LICENSE
-%{{_bindir}}/%{{name}}
+%{{_bindir}}/{binary_name}
 {systemd_files}
 {systemd_macros}
 """

--- a/docs/distros/fedora.md
+++ b/docs/distros/fedora.md
@@ -11,11 +11,11 @@ E.g. in order to install `tezos-client` or `tezos-baker` run the following comma
 # use dnf
 sudo dnf copr enable @Serokell/Tezos
 sudo dnf install tezos-client
-sudo dnf install tezos-baker-013-PtJakart
+sudo dnf install tezos-baker-PtKathma
 
 # or use yum
 sudo yum copr enable @Serokell/Tezos
-sudo yum install tezos-baker-013-PtJakart
+sudo yum install tezos-baker-PtKathma
 ```
 Once you install such packages the commands `tezos-*` will be available.
 


### PR DESCRIPTION
## Description

CI fails to run test builds of binary packages for Fedora for two reasons:
1. the CI step has not been updated and tries to build a package that no longer exist
2. the build process on Fedora is broken, as the binary name hasn't been replaced everywhere it should have been

This PR is a quick fixup to solve both these issues (more issues may follow to improve these tho).   
 
## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
