### PR TITLE
[Chore] Symlink new and legacy names on fedora

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -323,7 +323,7 @@ Maintainer: {self.meta.maintainer}
 make {binary_name}
 mkdir -p %{{buildroot}}/%{{_bindir}}
 install -m 0755 {binary_name} %{{buildroot}}/%{{_bindir}}
-ln -s %{{_bindir}}/{binary_name} %{{buildroot}}/%{{_bindir}}/{self.name}
+ln -sf %{{_bindir}}/{binary_name} %{{buildroot}}/%{{_bindir}}/{self.name}
 {systemd_install}
 %files
 %license LICENSE

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -323,10 +323,12 @@ Maintainer: {self.meta.maintainer}
 make {binary_name}
 mkdir -p %{{buildroot}}/%{{_bindir}}
 install -m 0755 {binary_name} %{{buildroot}}/%{{_bindir}}
+ln -s %{{_bindir}}/{binary_name} %{{buildroot}}/%{{_bindir}}/{self.name}
 {systemd_install}
 %files
 %license LICENSE
 %{{_bindir}}/{binary_name}
+%{{_bindir}}/{self.name}
 {systemd_files}
 {systemd_macros}
 """

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -226,7 +226,7 @@ cat > /usr/bin/octez-node-{network} <<- 'EOM'
 TEZOS_NODE_DIR="$(cat $(systemctl show -p FragmentPath tezos-node-{network}.service | cut -d'=' -f2) | grep 'DATA_DIR' | cut -d '=' -f3 | cut -d '"' -f1)" octez-node "$@"
 EOM
 chmod +x /usr/bin/octez-node-{network}
-ln -s /usr/bin/octez-node-{network} /usr/bin/tezos-node-{network}
+ln -sf /usr/bin/octez-node-{network} /usr/bin/tezos-node-{network}
 """
     node_postrm_steps += f"""
 rm -f /usr/bin/octez-node-{network} /usr/bin/tezos-node-{network}

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "1",
+  "release": "2",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v15.0-rc1"
 }


### PR DESCRIPTION
Problem: Fedora packages lack `tezos`-based executables.

Solution: Symlink `octez`-based binaries with `tezos` ones.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
