### PR TITLE
Provide tezos packages for nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,5 @@ let
     }
   ) { src = ./.; })
   defaultNix;
-in defaultNix // defaultNix.devShells.${__currentSystem}
-             // { binaries-test = defaultNix.binaries-test.${__currentSystem};
-                  release = defaultNix.release.${__currentSystem};
-                }
+  pkgs = defaultNix.legacyPackages.${__currentSystem};
+in with pkgs.lib; recursiveUpdate defaultNix (attrsets.mapAttrs (_: val: val.${__currentSystem}) defaultNix)

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
       callPackage = pkg: input:
         import pkg (inputs // { inherit sources protocols meta pkgs; } // input);
 
-      binaries = callPackage ./nix {};
+      inherit (callPackage ./nix {}) octez-binaries tezos-binaries;
 
       release = callPackage ./release.nix {};
 
@@ -87,7 +87,8 @@
 
       inherit release;
 
-      packages = binaries // { default = self.packages.${system}.binaries; };
+      packages = octez-binaries // tezos-binaries
+        // { default = pkgs.linkFarmFromDrvs "binaries" (builtins.attrValues octez-binaries); };
 
       devShells = {
         buildkite = callPackage ./.buildkite/shell.nix {};

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@ with pkgs; mkShell {
     python3Packages.black
     shellcheck
     jq
+    gh
     buildkite-agent
   ];
   OCTEZ_VERSION= with pkgs.lib; lists.last (strings.splitString "/" (meta.tezos_ref));


### PR DESCRIPTION
## Description

After rename, tezos-based packages are no longer available. However, they still heavily used in nix infrastructure, as well as 
legacy binary names.

This PR provide it.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #544 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
