### PR TITLE
[#534] Support Fedora 36 and deprecate Fedora 34

### DIFF
--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-FROM fedora:32
+FROM fedora:35
 RUN dnf update -y
 RUN dnf install -y libev-devel gmp-devel hidapi-devel libffi-devel zlib-devel libpq-devel m4 perl git pkg-config \
-  rpmdevtools python3-devel python3-setuptools wget opam rsync which cargo autoconf
+  rpmdevtools python3-devel python3-setuptools wget opam rsync which cargo autoconf systemd systemd-rpm-macros
 ENV USER dockerbuilder
 RUN useradd dockerbuilder && mkdir /tezos-packaging
 ENV HOME /tezos-packaging

--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -19,6 +19,7 @@ opams=()
 while IFS=  read -r -d $'\0'; do
     opams+=("$REPLY")
 done < <(find ./vendors ./src ./tezt ./opam -name \*.opam -print0)
+export CFLAGS="-fPIC ${CFLAGS:-}"
 opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"
 eval "$(opam env)"
 

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -38,8 +38,8 @@ There are packages for `arm64` and `amd64` architectures.
 We aim to provide packages for all [currently supported Fedora releases](https://docs.fedoraproject.org/en-US/releases/).
 
 Currently, these are versions:
-* Fedora 34
 * Fedora 35
+* Fedora 36
 
 There are packages for `x86_64` and `aarch64` architectures.
 


### PR DESCRIPTION
## Description

Problem: Fedora 34 has reached its EOL so,
per our support policy we no longer need to support it. OTOH Fedora 36 is now a stable release so, following the same policy, we should instead support it.

Solution: Support Fedora 36 and deprecate Fedora 34.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #534 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
