### PR TITLE
[#550] Fix instantiated services installation

### DIFF
--- a/docker/package/fedora.py
+++ b/docker/package/fedora.py
@@ -24,10 +24,16 @@ def build_fedora_package(
     pkg.gen_buildfile("/".join([dir, pkg.buildfile]), binaries_dir)
     pkg.gen_license(f"{dir}/LICENSE")
     for systemd_unit in pkg.systemd_units:
+        # lowercase package name for consistency between different os
+        name_lower = pkg.name.lower()
+        if systemd_unit.service_file.service.environment_file is not None:
+            systemd_unit.service_file.service.environment_file = (
+                systemd_unit.service_file.service.environment_file.lower()
+            )
         if systemd_unit.suffix is None:
-            unit_name = pkg.name
+            unit_name = name_lower
         else:
-            unit_name = f"{pkg.name}-{systemd_unit.suffix}"
+            unit_name = f"{name_lower}-{systemd_unit.suffix}"
         out_path = (
             f"{dir}/{unit_name}@.service"
             if systemd_unit.instances is not None

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -99,9 +99,9 @@ def gen_spec_systemd_part(package):
     default_files = ""
     for systemd_unit in package.systemd_units:
         if systemd_unit.suffix is None:
-            service_name = "%{name}"
+            service_name = f"{package.name.lower()}"
         else:
-            service_name = f"%{{name}}-{systemd_unit.suffix}"
+            service_name = f"{package.name.lower()}-{systemd_unit.suffix}"
         if systemd_unit.instances is not None:
             service_name = f"{service_name}@"
         install_unit_files += (


### PR DESCRIPTION
## Description

Problem: Systemd services names supplied by tezos-baking packages were lowercased. But fedora scripts still were awaiting initial proto names, so baking setup was failing with error.

Solution:
* Do not lowercase baker services' names.
* Lowercase required services specifically for ubuntu.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #550 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
