### PR TITLE
[#557] Add `tezos-node` as native dep for `tezos-baking`

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -514,7 +514,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = ""
+    letter_version = "a"
 
     buildfile = "setup.py"
 

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -557,10 +557,12 @@ class TezosBakingServicesPackage(AbstractPackage):
         target_networks: List[str],
         network_protos: Dict[str, List[str]],
         meta: PackagesMeta,
+        additional_native_deps: List[str],
     ):
         self.name = "tezos-baking"
         self.desc = "Package that provides systemd services that orchestrate other services from Tezos packages"
         self.meta = deepcopy(meta)
+        self.additional_native_deps = additional_native_deps
         self.meta.version = self.meta.version + self.letter_version
         self.target_protos = set()
         self.patches = []
@@ -610,9 +612,7 @@ class TezosBakingServicesPackage(AbstractPackage):
         shutil.copy(f"{os.path.dirname(__file__)}/tezos_voting_wizard.py", package_dir)
 
     def gen_control_file(self, deps, ubuntu_version, out):
-        run_deps_list = ["acl"]
-        for proto in self.target_protos:
-            run_deps_list.append(f"tezos-baker-{proto.lower()}")
+        run_deps_list = map(lambda x: x.lower(), self.additional_native_deps)
         run_deps = ", ".join(run_deps_list)
         file_contents = f"""
 Source: {self.name}
@@ -633,9 +633,7 @@ Description: {self.desc}
             f.write(file_contents)
 
     def gen_spec_file(self, build_deps, run_deps, out):
-        run_deps = ", ".join(
-            ["acl"] + [f"tezos-baker-{proto}" for proto in self.target_protos],
-        )
+        run_deps = ", ".join(self.additional_native_deps)
         (
             systemd_deps,
             systemd_install,

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -431,6 +431,8 @@ packages.append(
         target_networks=networks.keys(),
         network_protos=networks_protos,
         meta=packages_meta,
+        additional_native_deps=[f"tezos-baker-{proto}" for proto in active_protocols]
+        + ["tezos-node", "acl"],
     )
 )
 

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "2",
+  "release": "3",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v15.0-rc1"
 }


### PR DESCRIPTION
## Description
Problem: `tezos-baking` does not depends on `tezos-node`, thus does not install it, resulting in error during setup.

Solution: Add `tezos-node` as native dep for `tezos-baking`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #557

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
