### PR TITLE
[Chore] Add timeout for bottle build

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Build the bottle
         if: steps.check-built.outcome == 'failure'
         run: ./scripts/build-one-bottle.sh "${{ matrix.formula }}"
+        timeout-minutes: 120
 
       - name: Upload the bottle to Github Actions
         if: steps.check-built.outcome == 'failure'


### PR DESCRIPTION
## Description

Problem: Something bottle build takes too long
and not finishes successfully that case. Thus,
we shouldn't wait that much.

Solution: Set timeout after 2 hours.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
