### PR TITLE
[#564] Remove dry-run flag

### DIFF
--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -715,13 +715,13 @@ class Setup:
                         f"Waiting for funds to arrive... (Ctrl + C to choose another option)."
                     )
                     try:
-                        # dry-run delegate registration until it succeeds
                         while True:
                             result = get_proc_output(
                                 f"sudo -u tezos {suppress_warning_text} octez-client {tezos_client_options} "
-                                f"register key {baker_alias} as delegate --dry-run"
+                                f"register key {baker_alias} as delegate"
                             )
                             if result.returncode == 0:
+                                print(result.stdout.decode("utf8"))
                                 break
                             else:
                                 proc_call("sleep 1")


### PR DESCRIPTION
## Description

Problem: It's impossible to dry-run delegate registration
on lima due to bug.

Solution: Remove `--dry-run` for now, until
https://gitlab.com/tezos/tezos/-/issues/4200 resolved.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #564

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
