### PR TITLE
[#569] Simplify wizards' names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ setup wizard:
 ```
 sudo add-apt-repository -yu ppa:serokell/tezos
 sudo apt-get install -y tezos-baking
-tezos-setup-wizard
+tezos-setup
 ```
+> :warning: Since [#570](https://github.com/serokell/tezos-packaging/pull/570), this wizard was renamed from `tezos-setup-wizard`.
+
 
 Read [the dedicated article](./docs/baking.md) to find out more about the setup,
 the binaries, and the services used.
@@ -39,8 +41,10 @@ An interactive voting wizard is provided for Ubuntu. After setting up a baking i
 on mainnet, you can vote by running:
 
 ```bash
-tezos-voting-wizard
+tezos-vote
 ```
+> :warning: Since [#570](https://github.com/serokell/tezos-packaging/pull/570), this wizard was renamed from `tezos-voting-wizard`.
+
 
 Read the [documentation on voting](./docs/voting.md) to find out more details about
 voting on custom networks.

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -674,7 +674,7 @@ echo "**************************************************************************
 echo "**  Note: this version adds context pruning, which will prevent the disk"
 echo "**  space used by the node from growing indefinitely. If you have an"
 echo "**  existing node or baking setup running, it is recommended to import"
-echo "**  a fresh snapshot. You can re-run tezos-setup-wizard to do so."
+echo "**  a fresh snapshot. You can re-run tezos-setup to do so."
 echo ""
 echo "**  You can read more about it here:"
 echo "**  http://tezos.gitlab.io/releases/version-15.html#context-pruning-requirements"
@@ -745,8 +745,8 @@ Maintainer: {self.meta.maintainer}
 %py3_install
 {systemd_install}
 %files
-%{{_bindir}}/tezos-setup-wizard
-%{{_bindir}}/tezos-voting-wizard
+%{{_bindir}}/tezos-setup
+%{{_bindir}}/tezos-vote
 %{{python3_sitelib}}/tezos_baking-*.egg-info/
 %{{python3_sitelib}}/tezos_baking/
 %license LICENSE
@@ -766,8 +766,8 @@ setup(
     version='{self.meta.version}',
     entry_points=dict(
         console_scripts=[
-            'tezos-setup-wizard=tezos_baking.tezos_setup_wizard:main',
-            'tezos-voting-wizard=tezos_baking.tezos_voting_wizard:main',
+            'tezos-setup=tezos_baking.tezos_setup_wizard:main',
+            'tezos-vote=tezos_baking.tezos_voting_wizard:main',
         ]
     )
 )

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -557,7 +557,7 @@ def main():
                 + ".service"
             )
         print("Error in Tezos Setup Wizard, exiting.")
-        logfile = "tezos_setup_wizard.log"
+        logfile = "tezos_setup.log"
         with open(logfile, "a") as f:
             f.write(str(e) + "\n")
         print("The error has been logged to", os.path.abspath(logfile))

--- a/docker/package/tezos_voting_wizard.py
+++ b/docker/package/tezos_voting_wizard.py
@@ -192,7 +192,7 @@ class Setup(Setup):
             return True
         except:
             print(f"No local baking services for {net} running on this machine.")
-            print("If there should be, you can run 'tezos-setup-wizard' to set it up.")
+            print("If there should be, you can run 'tezos-setup' to set it up.")
             print()
 
             return False
@@ -468,7 +468,7 @@ def main():
         sys.exit(1)
     except Exception as e:
         print("Error in Tezos Voting Wizard, exiting.")
-        logfile = "tezos_voting_wizard.log"
+        logfile = "tezos_vote.log"
         with open(logfile, "a") as f:
             f.write(str(e) + "\n")
         print("The error has been logged to", os.path.abspath(logfile))

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -40,7 +40,7 @@ The most convenient way to orchestrate all these binaries is to use the `tezos-b
 package, which provides predefined services for running baking instances on different
 networks.
 
-This package also provides a `tezos-setup-wizard` CLI utility, designed to
+This package also provides a `tezos-setup` CLI utility, designed to
 query all necessary configuration options and use the answers to automatically set up
 a baking instance.
 
@@ -94,7 +94,7 @@ protocol is activated, the `tezos-baking` package is updated again to stop runni
 If at this point you want to set up the baking instance, or just a node, using the wizard, run:
 
 ```
-tezos-setup-wizard
+tezos-setup
 ```
 
 This wizard closely follows this guide, so for most setups it won't be necessary to follow
@@ -306,7 +306,7 @@ multipass shell tezos
 
 1) Install `tezos-baking` package following [these instructions](#add-repository).
 
-2) Run `tezos-setup-wizard` and follow the instructions there.
+2) Run `tezos-setup` and follow the instructions there.
 
 <details>
  <summary>

--- a/docs/service-options.md
+++ b/docs/service-options.md
@@ -27,12 +27,12 @@ sudo systemctl restart tezos-node-mainnet.service
 ```
 in order for the changes to take effect.
 
-In case you [set up baking using the `tezos-setup-wizard`](./baking.md), running:
+In case you [set up baking using the `tezos-setup`](./baking.md), running:
 ```sh
 sudo systemctl restart tezos-baking-<network>.service
 ```
 will be sufficient, as all the services involved will be restarted.
-Running again `tezos-setup-wizard` and following the setup process is also an option.
+Running again `tezos-setup` and following the setup process is also an option.
 
 ## Utility node scripts
 

--- a/docs/tests/voting.md
+++ b/docs/tests/voting.md
@@ -74,7 +74,7 @@ The script will stop at the beginning of each voting period that requires voting
 Launch the wizard by running:
 
 ```bash
-tezos-voting-wizard --network voting
+tezos-vote --network voting
 ```
 
 Under normal conditions, you won't have to adjust any information about your baking service.

--- a/docs/voting.md
+++ b/docs/voting.md
@@ -19,7 +19,7 @@ it is Tezos Setup Wizard. See the [baking](./baking.md#prerequisites) article fo
 After all the services required for baking have been set up, run:
 
 ```bash
-tezos-voting-wizard
+tezos-vote
 ```
 
 The wizard displays the voting period and offers approppriate possible actions for that period.
@@ -28,26 +28,26 @@ The wizard displays the voting period and offers approppriate possible actions f
 
 ## Using custom networks
 
-`tezos-voting-wizard` supports voting on custom networks, in turn enabled by `tezos-packaging`'s
+`tezos-vote` supports voting on custom networks, in turn enabled by `tezos-packaging`'s
 support for custom chain systemd services. The process to set up a custom baking instance is
 documented [here](./baking.md#using-a-custom-chain).
 
 After the custom baking instance is fully set up, you can vote or propose amendments on it by running:
 
 ```bash
-tezos-voting-wizard --network <custom-network-name>
+tezos-vote --network <custom-network-name>
 ```
 
 E.g. if you have a custom baking instance `tezos-baking-custom@voting`, you can run:
 
 ```bash
-tezos-voting-wizard --network voting
+tezos-vote --network voting
 ```
 
 ## Using testnets
 
-`tezos-voting-wizard` also supports voting on currently running testnets, for example:
+`tezos-vote` also supports voting on currently running testnets, for example:
 
 ```bash
-tezos-voting-wizard --network kathmandunet
+tezos-vote --network kathmandunet
 ```


### PR DESCRIPTION
## Description

Problem: The names are unnecessarily long and word "wizard" at the end is not all that useful, especially if/when these tools get non-interactive mode implemented.

Solution: Rename to tezos-setup and tezos-vote.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #569 

#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
