### PR TITLE
[#571] Handle empty or missing node data dirs in setup wizard

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -212,7 +212,7 @@ class Setup(Setup):
             node_dir_contents = set(os.listdir(node_dir))
         except FileNotFoundError:
             print("The Tezos node data directory does not exist.")
-            print("Creating it now")
+            print("  Creating directory: " + node_dir)
             proc_call("sudo mkdir " + node_dir)
             proc_call("sudo chown tezos:tezos " + node_dir)
 
@@ -222,8 +222,7 @@ class Setup(Setup):
         # Configure data dir if the config is missing
         if not node_dir_config.issubset(node_dir_contents):
             print("The Tezos node data directory has not been configured yet.")
-            print("Configuring it now.")
-            print()
+            print("  Configuring directory: " + node_dir)
             proc_call(
                 "sudo -u tezos octez-node-"
                 + self.config["network"]
@@ -237,8 +236,7 @@ class Setup(Setup):
         diff = node_dir_contents - node_dir_config
         if diff:
             print("The Tezos node data directory already has some blockchain data:")
-            print("\n".join(diff))
-            print()
+            print("\n".join(["- " + os.path.join(node_dir, path) for path in diff]))
             if yes_or_no("Delete this data and bootstrap the node again? <y/N> ", "no"):
                 for path in diff:
                     try:

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -207,9 +207,34 @@ class Setup(Setup):
     # and ask the user if it can be overwritten.
     def check_blockchain_data(self):
         node_dir = get_data_dir(self.config["network"])
-        node_dir_contents = os.listdir(node_dir)
-        clean = ["config.json", "version.json"]
-        diff = set(node_dir_contents) - set(clean)
+        node_dir_contents = set()
+        try:
+            node_dir_contents = set(os.listdir(node_dir))
+        except FileNotFoundError:
+            print("The Tezos node data directory does not exist.")
+            print("Creating it now")
+            proc_call("sudo mkdir " + node_dir)
+            proc_call("sudo chown tezos:tezos " + node_dir)
+
+        # Content expected in a configured and clean node data dir
+        node_dir_config = set(["config.json", "version.json"])
+
+        # Configure data dir if the config is missing
+        if not node_dir_config.issubset(node_dir_contents):
+            print("The Tezos node data directory has not been configured yet.")
+            print("Configuring it now.")
+            print()
+            proc_call(
+                "sudo -u tezos octez-node-"
+                + self.config["network"]
+                + " config init"
+                + " --network "
+                + self.config["network"]
+                + " --rpc-addr "
+                + self.config["node_rpc_addr"]
+            )
+
+        diff = node_dir_contents - node_dir_config
         if diff:
             print("The Tezos node data directory already has some blockchain data:")
             print("\n".join(diff))

--- a/docker/package/wizard_structure.py
+++ b/docker/package/wizard_structure.py
@@ -634,10 +634,14 @@ class Setup:
             "TEZOS_CLIENT_DIR",
             "/var/lib/tezos/.tezos-client",
         )
-        self.config["node_rpc_endpoint"] = "http://" + baking_env.get(
+
+        node_rpc_addr = baking_env.get(
             "NODE_RPC_ADDR",
             "localhost:8732",
         )
+        self.config["node_rpc_addr"] = node_rpc_addr
+        self.config["node_rpc_endpoint"] = "http://" + node_rpc_addr
+
         self.config["baker_alias"] = baking_env.get("BAKER_ADDRESS_ALIAS", "baker")
 
     def fill_remote_signer_infos(self):


### PR DESCRIPTION
## Description

This modifies the wizard to handle missing and empty node data directory (most likely to happen when setting a custom one), by creating and configuring them if necessary.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #571

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
