### PR TITLE
Remove dev deps v15.1 release hotfix

### DIFF
--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -17,7 +17,10 @@ opam switch create . --repositories=local --no-install
 eval "$(opam env)"
 opams=()
 while IFS=  read -r -d $'\0'; do
-    opams+=("$REPLY")
+    # we exclude optional development packages
+    if [ "$REPLY" != "./opam/virtual/octez-dev-deps.opam" ]; then
+        opams+=("$REPLY")
+    fi
 done < <(find ./vendors ./src ./tezt ./opam -name \*.opam -print0)
 export CFLAGS="-fPIC ${CFLAGS:-}"
 opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,16 @@
   outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, flake-utils, serokell-nix, nix, ... }:
   let
     pkgs-darwin = nixpkgs-unstable.legacyPackages."aarch64-darwin";
-
     protocols = nixpkgs.lib.importJSON ./protocols.json;
     meta = nixpkgs.lib.importJSON ./meta.json;
-    sources = { inherit (inputs) tezos opam-repository; };
+
+    tezos = builtins.path {
+      path = inputs.tezos;
+      name = "tezos";
+      # we exclude optional development packages
+      filter = path: _: baseNameOf path != "octez-dev-deps.opam";
+    };
+    sources = { inherit tezos; inherit (inputs) opam-repository; };
 
     ocaml-overlay = import ./nix/build/ocaml-overlay.nix (inputs // { inherit sources protocols meta; });
   in pkgs-darwin.lib.recursiveUpdate

--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -13,10 +13,7 @@ with opam-nix.lib.${self.system}; let
   octezSourcesResolved =
     self.runCommand "resolve-octez-sources" {} "cp --no-preserve=all -Lr ${sources.tezos} $out";
   octezScope = buildOpamProject' {
-    repos = [
-      sources.opam-repository
-      opam-nix.inputs.opam-repository
-    ];
+    repos = [sources.opam-repository];
     recursive = true;
     resolveArgs = { };
   } octezSourcesResolved { };


### PR DESCRIPTION
## Description

`tezos` repo on v15.1 tag contains `octez-dev-deps.opam` file, which is redundant, but breaks building through `opam`.
That PR filter it out from both native packages and nix packages build process.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
