### PR TITLE
[Chore] Bump nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1632495107,
-        "narHash": "sha256-4NGE56r+FJGBaCYu3CTH4O83Ys4TrtnEPXrvdwg1TDs=",
+        "lastModified": 1667318090,
+        "narHash": "sha256-AvxgT+t1BWZs8IfdseHl8+7wvWWm9pvysupMT9wXdH0=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "be220b2dc47092c1e739bf6aaf630f29e71fe1c4",
+        "rev": "4bce79cf151aad3c0bed46a32bdb4b165f00cb7e",
         "type": "github"
       },
       "original": {

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -28,7 +28,7 @@ def run_node(network, use_tls):
         + tls_args
         + "--no-bootstrap-peers --network "
         + network
-        + " &"
+        + " >/dev/null &"
     )
     tls_endpoint = (
         " --endpoint https://localhost:8732/ "
@@ -50,9 +50,9 @@ def run_node_with_daemons(network, use_tls):
     machine.succeed(
         f"{octez_baker} -d client-dir"
         + tls_endpoint
-        + "run with local node node-dir baker --liquidity-baking-toggle-vote on &"
+        + "run with local node node-dir baker --liquidity-baking-toggle-vote on >/dev/null &"
     )
-    machine.succeed(octez_accuser + tls_endpoint + "-d client-dir run &")
+    machine.succeed(octez_accuser + tls_endpoint + "-d client-dir run >/dev/null &")
 
 
 def kill_node_with_daemons():
@@ -92,7 +92,7 @@ with subtest("test remote signer"):
         f'{octez_signer} -d signer-dir show address signer | tail -n +1 | head -n 1 | sed -e s/^"Hash: "//g'
     )
     machine.succeed(
-        f"{octez_signer} -d signer-dir launch socket signer -a 127.0.0.1 -p 22000 &"
+        f"{octez_signer} -d signer-dir launch socket signer -a 127.0.0.1 -p 22000 >/dev/null &"
     )
     machine.succeed(
         f"{octez_client} -d client-dir import secret key remote-signer-tcp tcp://127.0.0.1:22000/{signer_addr}"

--- a/tests/tezos-binaries.nix
+++ b/tests/tezos-binaries.nix
@@ -5,6 +5,7 @@
 let
 in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
 {
+  name = "tezos-binaries-test";
   nodes.machine = { ... }: {
     virtualisation.memorySize = 2048;
     virtualisation.diskSize = 1024;

--- a/tests/tezos-modules.nix
+++ b/tests/tezos-modules.nix
@@ -6,6 +6,7 @@ let
 in
 import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
 {
+  name = "tezos-modules-test";
   machine = { ... }: {
     virtualisation.memorySize = 1024;
     virtualisation.diskSize = 1024;

--- a/tests/tezos-nix-binaries.nix
+++ b/tests/tezos-nix-binaries.nix
@@ -7,6 +7,7 @@ let
     octez-accuser-PtKathma octez-baker-PtKathma;
 in import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ ... }:
 {
+  name = "tezos-nix-binaries-test";
   nodes.machine = { ... }: {
     virtualisation.memorySize = 1024;
     virtualisation.diskSize = 1024;


### PR DESCRIPTION
## Description
Problem: We recently updated our nixpkgs fork. However, this repo still uses the old revision.

Solution: Bump nixpkgs.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
