### PR TITLE
[Chore] Add option to fetch sources from launchpad

### DIFF
--- a/docker/docker-tezos-packages.py
+++ b/docker/docker-tezos-packages.py
@@ -111,6 +111,11 @@ octez_version = os.getenv("OCTEZ_VERSION", None)
 if not octez_version:
     raise Exception("Environment variable OCTEZ_VERSION is not set.")
 
+if args.sources_dir and args.launchpad_sources:
+    raise Exception(
+        "--sources-dir and --launchpad-sources options are mutually exclusive."
+    )
+
 # copr build infrastructure uses latest stable fedora and `mock` for builds
 # so we should also keep that way
 # for ubuntu builds, since we lack `pbuilder` for now,

--- a/docker/docker-tezos-packages.py
+++ b/docker/docker-tezos-packages.py
@@ -111,6 +111,9 @@ octez_version = os.getenv("OCTEZ_VERSION", None)
 if not octez_version:
     raise Exception("Environment variable OCTEZ_VERSION is not set.")
 
+if (args.sources_dir or args.launchpad_sources) and target_os != "ubuntu":
+    raise Exception("Sources-related options are only supported for Ubuntu.")
+
 if args.sources_dir and args.launchpad_sources:
     raise Exception(
         "--sources-dir and --launchpad-sources options are mutually exclusive."

--- a/docker/docker-tezos-packages.py
+++ b/docker/docker-tezos-packages.py
@@ -141,6 +141,7 @@ for image in images:
             f"--sources-dir {sources_dir_name}" if sources_dir_name else "",
             f"--type {args.type}",
             f"--distributions {' '.join(distros)}",
+            f"--launchpad-sources" if args.launchpad_sources else "",
             f"--packages {' '.join(packages_to_build.keys())}",
         ]
     )


### PR DESCRIPTION
## Description

Problem: When we make new release based on the same upstream octez version, we have to use previous source archive to upload packages to launchpad. Since they are available on predictable urls, we should have option to fetch them automatically during build.

Solution: Add flag to get sources from launchpad if relevant source archive is absent under `sources-dir` (or it's not defined).

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
