### PR TITLE
[Chore] Add 'cmake' to brew build dependencies

### DIFF
--- a/Formula/tezos-accuser-PtLimaPt.rb
+++ b/Formula/tezos-accuser-PtLimaPt.rb
@@ -13,7 +13,7 @@ class TezosAccuserPtlimapt < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -13,7 +13,7 @@ class TezosAdminClient < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-baker-PtLimaPt.rb
+++ b/Formula/tezos-baker-PtLimaPt.rb
@@ -13,7 +13,7 @@ class TezosBakerPtlimapt < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -13,7 +13,7 @@ class TezosClient < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -13,7 +13,7 @@ class TezosCodec < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -13,7 +13,7 @@ class TezosNode < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -13,7 +13,7 @@ class TezosSigner < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-smart-rollup-client-PtMumbai.rb
+++ b/Formula/tezos-smart-rollup-client-PtMumbai.rb
@@ -14,7 +14,7 @@ class TezosSmartRollupClientPtmumbai < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-smart-rollup-node-PtMumbai.rb
+++ b/Formula/tezos-smart-rollup-node-PtMumbai.rb
@@ -15,7 +15,7 @@ class TezosSmartRollupNodePtmumbai < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-tx-rollup-client-PtLimaPt.rb
+++ b/Formula/tezos-tx-rollup-client-PtLimaPt.rb
@@ -13,7 +13,7 @@ class TezosTxRollupClientPtlimapt < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/Formula/tezos-tx-rollup-node-PtLimaPt.rb
+++ b/Formula/tezos-tx-rollup-node-PtLimaPt.rb
@@ -15,7 +15,7 @@ class TezosTxRollupNodePtlimapt < Formula
 
   version "v16.0-rc1-1"
 
-  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init]
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
   build_dependencies.each do |dependency|
     depends_on dependency => :build
   end

--- a/flake.lock
+++ b/flake.lock
@@ -261,16 +261,18 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1674621699,
-        "narHash": "sha256-kOrPJmbrmoxuggREz1AfWYagh0MXbp1qi4pRxfTaduU=",
+        "lastModified": 1674736538,
+        "narHash": "sha256-/DszFMkAgYyB9dTWKkoZa9i0zcrA6Z4hYrOr/u/FSxY=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "0c9ef2694255a9db805af7c86b210d529b4d5eca",
+        "rev": "1dfdbb65d77430fc0935e8592d0abc4addcce711",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "1dfdbb65d77430fc0935e8592d0abc4addcce711",
+        "type": "github"
       }
     },
     "nixpkgs_3": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,8 @@
   inputs = {
 
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    # TODO: remove once https://github.com/serokell/nixpkgs/pull/61 is merged
+    nixpkgs.url = "github:serokell/nixpkgs?rev=1dfdbb65d77430fc0935e8592d0abc4addcce711";
 
     nix.url = "github:nixos/nix";
 


### PR DESCRIPTION
## Description
Problem: Octez now has 'conf-cmake' opam dependency that requires
'cmake' to be present.

Solution: Add 'cmake' to list of build dependencies for brew formulae.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
