### PR TITLE
[#600] Exchange fedoras

### DIFF
--- a/docker/docker-tezos-packages.py
+++ b/docker/docker-tezos-packages.py
@@ -18,8 +18,8 @@ ubuntu_versions = [
 ]
 
 fedora_versions = [
-    "35",
     "36",
+    "37",
 ]
 
 

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -38,8 +38,8 @@ There are packages for `arm64` and `amd64` architectures.
 We aim to provide packages for all [currently supported Fedora releases](https://docs.fedoraproject.org/en-US/releases/).
 
 Currently, these are versions:
-* Fedora 35
 * Fedora 36
+* Fedora 37
 
 There are packages for `x86_64` and `aarch64` architectures.
 


### PR DESCRIPTION
## Description

Problem: Fedora 35 got deprecated. Meanwhile, Fedora 37 is new stable version.

Solution: Deprecate fedora 35. Support fedora 37.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
