### PR TITLE
[#601] Reset letter_version automatically

### DIFF
--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -49,6 +49,11 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
     git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       echo "release number wasn't updated"
 
+    sed -i 's/letter_version *= *"[a-z]"/letter_version = ""/' ./docker/package/model.py
+    # Commit may fail when the letter version wasn't updated since the last release
+    git commit -a -m "[Chore] Reset letter_version for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+      echo "letter_version wasn't reset"
+
     git push --set-upstream origin "$branch_name"
 
     gh pr create -B master -t "[Chore] $latest_upstream_tag release" -F .github/release_pull_request_template.md


### PR DESCRIPTION

## Description

Problem: On every new octez upsteam release we reset `letter_version` manually.

Solution: Reset it automatically with script.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #601

#### Related changes (conditional)

- [] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
