### PR TITLE
[#588] Update tezos-setup wizard to changes in snapshot metadata format

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -263,7 +263,7 @@ class Setup(Setup):
         json_url = "https://xtz-shots.io/tezos-snapshots.json"
         try:
             with urllib.request.urlopen(json_url) as url:
-                snapshot_array = json.load(url)
+                snapshot_array = json.load(url)["data"]
                 snapshot_array.sort(reverse=True, key=lambda x: int(x["block_height"]))
         except (urllib.error.URLError, ValueError):
             print(f"Couldn't collect snapshot metadata from {json_url}")

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -264,7 +264,7 @@ class Setup(Setup):
         try:
             with urllib.request.urlopen(json_url) as url:
                 snapshot_array = json.load(url)["data"]
-                snapshot_array.sort(reverse=True, key=lambda x: int(x["block_height"]))
+                snapshot_array.sort(reverse=True, key=lambda x: x["block_height"])
         except (urllib.error.URLError, ValueError):
             print(f"Couldn't collect snapshot metadata from {json_url}")
             return


### PR DESCRIPTION
## Description

The format of the snapshot metadata provided by xtz-shots.io has changed and since the `tezos-setup` wizard uses it, this needs to be updated.

See individual commits for more on the specific changes.

## Related issue(s)

Resolves #588 

Related to #441 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
