### PR TITLE
[Chore] Change logic for tezos-baking sources

### DIFF
--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -135,18 +135,17 @@ def main():
     if is_source and source_archives:
         errors = []
         for package in packages:
-            if getattr(package, "letter_version", None) is None:
-                source_archive = (
-                    f"{package.name.lower()}_{package.meta.version}.orig.tar.gz"
+            source_archive = (
+                f"{package.name.lower()}_{package.meta.version}.orig.tar.gz"
+            )
+            if source_archive in source_archives:
+                package.source_archive = os.path.join(args.sources_dir, source_archive)
+            elif getattr(package, "letter_version", None) is None:
+                # We throw an error if the source is missing, unless the package is
+                # tezos-baking, for which we don't need new sources.
+                errors.append(
+                    f"ERROR: supplied source dir does not contain source archive for {package.name}"
                 )
-                if source_archive in source_archives:
-                    package.source_archive = os.path.join(
-                        args.sources_dir, source_archive
-                    )
-                else:
-                    errors.append(
-                        f"ERROR: supplied source dir does not contain source archive for {package.name}"
-                    )
         if errors:
             print("\n" + "\n".join(errors) + "\n")
             sys.exit(1)


### PR DESCRIPTION

## Description

Problem: Currently there is no way to provide sources for `tezos-baking` package. But what do we really need is ignore absence of it.

Solution: Let sources for tezos-baking be provided and ignore if they are not.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
