### PR TITLE
[Chore] Change way to retrieve opam repository tag

### DIFF
--- a/docker/fetch_tezos_sources.py
+++ b/docker/fetch_tezos_sources.py
@@ -28,12 +28,18 @@ shutil.rmtree(os.path.join("tezos", ".git"))
 
 subprocess.run(["git", "clone", "https://gitlab.com/tezos/opam-repository.git"])
 
-with open("tezos/scripts/version.sh", "r") as f:
-    opam_repository_tag = re.search(
-        "^export opam_repository_tag=([0-9a-z]*)", f.read(), flags=re.MULTILINE
-    ).group(1)
-    os.chdir("opam-repository")
-    subprocess.run(["git", "checkout", opam_repository_tag])
-    subprocess.run(["rm", "-rf", ".git"])
-    subprocess.run(["rm", "-r", "zcash-params"])
-    subprocess.run(["opam", "admin", "cache"])
+opam_repository_tag = (
+    subprocess.run(
+        ". ./tezos/scripts/version.sh; echo $opam_repository_tag",
+        stdout=subprocess.PIPE,
+        shell=True,
+    )
+    .stdout.decode()
+    .strip()
+)
+
+os.chdir("opam-repository")
+subprocess.run(["git", "checkout", opam_repository_tag])
+subprocess.run(["rm", "-rf", ".git"])
+subprocess.run(["rm", "-r", "zcash-params"])
+subprocess.run(["opam", "admin", "cache"])


### PR DESCRIPTION
## Description

Problem: Since last release our way to parse tag from `version.sh` is not relevant anymore.

Solution: Evaluate and output variable contents instead of parsing it.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
