### PR TITLE
[Chore] Use python3 package in Ubuntu focal packages

### DIFF
--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -13,10 +13,13 @@ RUN apt-get install -y libev-dev libgmp-dev libhidapi-dev libffi-dev \
                        software-properties-common
 
 ARG dist
-RUN if [ "$dist" != "jammy" ]; then \
+RUN if [ "$dist" = "bionic" ]; then \
         apt-get install -y python3.8 dh-systemd; \
         add-apt-repository ppa:avsm/ppa -y; \
         install -m 0755 /usr/bin/python3.8 /usr/bin/builder; \
+    elif [ "$dist" = "focal" ]; then \
+        apt-get install -y dh-systemd; \
+        install -m 0755 /usr/bin/python3 /usr/bin/builder; \
     else \
         install -m 0755 /usr/bin/python3 /usr/bin/builder; \
     fi

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -230,7 +230,7 @@ export BLST_PORTABLE=yes
 {splice_if(binaries_dir)("export DEB_BUILD_OPTIONS=nostrip")}
 {pybuild_splice(f'''
 export PYBUILD_NAME={package_name}
-export PYBUILD_INTERPRETERS={"python3.8" if ubuntu_version != "jammy" else "python3"}
+export PYBUILD_INTERPRETERS={"python3.8" if ubuntu_version == "bionic" else "python3"}
 ''')}
 export DEB_CFLAGS_APPEND=-fPIC
 
@@ -695,14 +695,14 @@ Source: {self.name}
 Section: utils
 Priority: optional
 Maintainer: {self.meta.maintainer}
-Build-Depends: debhelper (>=11), {"dh-systemd (>= 1.5), python3.8" if ubuntu_version != "jammy" else "python3-all"}, autotools-dev, dh-python, python3-setuptools
+Build-Depends: debhelper (>=11), {"dh-systemd (>= 1.5), " if ubuntu_version != "jammy" else ""}{"python3.8" if ubuntu_version == "bionic" else "python3-all"}, autotools-dev, dh-python, python3-setuptools
 Standards-Version: 3.9.6
 Homepage: https://gitlab.com/tezos/tezos/
 X-Python3-Version: >= 3.8
 
 Package: {self.name.lower()}
 Architecture: amd64 arm64
-Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {run_deps}, ${{python3:Depends}}{", python3.8" if ubuntu_version != "jammy" else ""}
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {run_deps}, ${{python3:Depends}}{", python3.8" if ubuntu_version == "bionic" else ""}
 Description: {self.desc}
 """
         with open(out, "w") as f:
@@ -753,7 +753,7 @@ Maintainer: {self.meta.maintainer}
             f.write(file_contents)
 
     def gen_buildfile(self, out, ubuntu_version, binaries_dir=None):
-        interpreter = "python3.8" if ubuntu_version != "jammy" else "python3"
+        interpreter = "python3.8" if ubuntu_version == "bionic" else "python3"
         file_contents = f"""
 from setuptools import setup
 


### PR DESCRIPTION
## Description

Problem: in bd2ecfbf38b22ffd1f744b403e93317889c0ce0c we introduced a lower bound of python to version 3.8 and to do so a specific package is used instead of the generic python3 on both Ubuntu bionic and focal.
This is however only necessary for bionic and it's causing problems on Raspberry Pi OS installations, as there installing python3.8 is not simple (and there is no need to, as the python3 package is for 3.9).

Solution: use the python3 package on both focal and jammy, only use the python3.8 package on bionic.

## Related issue(s)

None, this started because a user reported being unable to install the latest packages on Rasperry Pi OS.
#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
