### PR TITLE
[#612] Do not fail on unexpected snapshot metadata formats

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -11,6 +11,7 @@ Asks questions, validates answers, and executes the appropriate steps using the 
 import os, sys, shutil
 import readline
 import re
+import traceback
 import urllib.request
 import json
 from typing import List
@@ -583,7 +584,7 @@ def main():
         print("Error in Tezos Setup Wizard, exiting.")
         logfile = "tezos_setup.log"
         with open(logfile, "a") as f:
-            f.write(str(e) + "\n")
+            f.write(traceback.format_exc() + "\n")
         print("The error has been logged to", os.path.abspath(logfile))
         sys.exit(1)
 

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -262,31 +262,33 @@ class Setup(Setup):
 
         json_url = "https://xtz-shots.io/tezos-snapshots.json"
         try:
+            snapshot_array = None
             with urllib.request.urlopen(json_url) as url:
                 snapshot_array = json.load(url)["data"]
-                snapshot_array.sort(reverse=True, key=lambda x: x["block_height"])
+            snapshot_array.sort(reverse=True, key=lambda x: x["block_height"])
+
+            snapshot_metadata = next(
+                filter(
+                    lambda artifact: artifact["artifact_type"] == "tezos-snapshot"
+                    and artifact["chain_name"] == self.config["network"]
+                    and (
+                        artifact["history_mode"] == self.config["history_mode"]
+                        or (
+                            self.config["history_mode"] == "archive"
+                            and artifact["history_mode"] == "full"
+                        )
+                    ),
+                    iter(snapshot_array),
+                ),
+                {"url": None, "block_hash": None},
+            )
+
+            self.config["snapshot_url"] = snapshot_metadata["url"]
+            self.config["snapshot_block_hash"] = snapshot_metadata["block_hash"]
         except (urllib.error.URLError, ValueError):
             print(f"Couldn't collect snapshot metadata from {json_url}")
-            return
-
-        snapshot_metadata = next(
-            filter(
-                lambda artifact: artifact["artifact_type"] == "tezos-snapshot"
-                and artifact["chain_name"] == self.config["network"]
-                and (
-                    artifact["history_mode"] == self.config["history_mode"]
-                    or (
-                        self.config["history_mode"] == "archive"
-                        and artifact["history_mode"] == "full"
-                    )
-                ),
-                iter(snapshot_array),
-            ),
-            {"url": None, "block_hash": None},
-        )
-
-        self.config["snapshot_url"] = snapshot_metadata["url"]
-        self.config["snapshot_block_hash"] = snapshot_metadata["block_hash"]
+        except Exception as e:
+            print(f"Unexpected error handling snapshot metadata:\n{e}\n")
 
     # Importing the snapshot for Node bootstrapping
     def import_snapshot(self):


### PR DESCRIPTION
## Description

This PR mainly prevents the setup wizard from failing/quitting when there is something unexpected in the snapshot metadata format. 

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #612 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
