### PR TITLE
[Chore] Remove only_changes from pipeline for tags

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -45,11 +45,6 @@ steps:
      - ./docker/octez-*
    agents:
      queue: "docker"
-   only_changes:
-   - docker/build/.*
-   - docker/docker-static-build.sh
-   - meta.json
-   - protocols.json
 
  - label: Build source packages from static binaries
    key: build-source-packages-from-static-binaries


### PR DESCRIPTION
## Description

Problem: we recently copied a pipeline step from the standard pipeline definition to the one for tags, including 'only_changes' fields that don't work in the latter.

Solution: remove the 'only_changes' settings from the pipeline for tags.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
