### PR TITLE
[#593] Re-enable arm build steps in CI

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -64,24 +64,23 @@ steps:
    - docker/docker-static-build.sh
    - meta.json
    - protocols.json
- # TODO #593 re-enable the following commented-out step
- # arm builder is an ubuntu machine without nix
- #  - label: build-arm-via-docker
+
+ - label: build-arm-via-docker
    # this step is used as a dependency, so we're defining 'key' explicitely
- #    key: build-arm-via-docker
- #    commands:
- #    - eval "$SET_VERSION"
- #    - cd docker
- #    - ./docker-static-build.sh
- #    - >
- #      for f in ./octez-*; do
- #        mv "\$f" "\$f-arm64"
- #      done
- #    artifact_paths:
- #      - ./docker/octez-*
- #    agents:
- #      queue: "arm64-build"
- #    only_changes: *static_binaries_changes_regexes
+   key: build-arm-via-docker
+   commands:
+   - eval "$SET_VERSION"
+   - cd docker
+   - ./docker-static-build.sh
+   - >
+     for f in ./octez-*; do
+       mv "\$f" "\$f-arm64"
+     done
+   artifact_paths:
+     - ./docker/octez-*
+   agents:
+     queue: "arm64-darwin"
+   only_changes: *static_binaries_changes_regexes
 
  - label: test docker-built binaries
    commands:
@@ -161,21 +160,19 @@ steps:
    - gen_systemd_service_file.py
    - docker/package/.*
 
- # TODO #593 re-enable the commented-out arm parts
  - label: create auto release/pre-release
    key: auto-release
    commands:
    - mkdir binaries
    - mkdir arm-binaries
    - buildkite-agent artifact download "docker/*" binaries --step "build-via-docker"
-   # - buildkite-agent artifact download "docker/*" arm-binaries --step "build-arm-via-docker"
-   - mkdir arm-binaries/docker
+   - buildkite-agent artifact download "docker/*" arm-binaries --step "build-arm-via-docker"
    - ls binaries
    - nix develop .#autorelease -c ./scripts/autorelease.sh "$BUILDKITE_MESSAGE"
    branches: master
    depends_on:
     - "build-via-docker"
-    # - "build-arm-via-docker"
+    - "build-arm-via-docker"
    only_changes:
    - scripts/autorelease.sh
    - scripts/shell.nix


### PR DESCRIPTION
## Description

Problem: we now have a new Mac-based queue for docker builds based on arm64, but the CI steps for the builds are still commented out.

Solution: un-comment and re-enable arm static build CI step.

## Related issue(s)

Resolves #593

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
