### PR TITLE
[Chore] Output artifact list from container

### DIFF
--- a/docker/docker-tezos-packages.py
+++ b/docker/docker-tezos-packages.py
@@ -140,6 +140,8 @@ packages_to_build = get_packages_to_build(args.packages)
 if not args.build_sapling_package:
     packages_to_build.pop("tezos-sapling-params", None)
 
+artifacts = []
+
 for image in images:
     distros = [image] if target_os == "ubuntu" else distributions
     cmd_args = " ".join(
@@ -180,6 +182,11 @@ for image in images:
     """
     )
 
+    with open(os.path.join(args.output_dir, ".artifact_list"), "r") as f:
+        artifacts += f.read().splitlines()
+
+    call(f"rm -f {os.path.join(args.output_dir, '.artifact_list')}")
+
     call(f"{virtualisation_engine} rm -v {container_id}")
 
     if exit_code:
@@ -193,7 +200,6 @@ for image in images:
             f" -v {args.output_dir}:/tezos-packaging/docker/{sources_dir_name}/"
         )
 
-artifacts = (os.path.join(args.output_dir, x) for x in os.listdir(args.output_dir))
 if args.gpg_sign and args.type == "source":
     if target_os == "ubuntu":
         for f in artifacts:

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -227,10 +227,12 @@ def main():
         subdir = "SRPMS" if is_source else "RPMS/x86_64"
         artifacts_dir = f"{home}/rpmbuild/{subdir}"
 
-    for f in os.listdir(artifacts_dir):
-        for ext in exts:
-            if f.endswith(ext):
-                shutil.copy(f"{artifacts_dir}/{f}", os.path.join(output_dir, f))
+    with open(os.path.join(output_dir, ".artifact_list"), "w") as artifact_list:
+        for f in os.listdir(artifacts_dir):
+            for ext in exts:
+                if f.endswith(ext):
+                    artifact_list.write(f"{f}\n")
+                    shutil.copy(f"{artifacts_dir}/{f}", os.path.join(output_dir, f))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Problem: For now, we don't really know which artifacts were output
from container. This results in resigning issues because we just
list all files from output folder.

Solution: Get information about exact resulting artifacts from container.
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
