### PR TITLE
[Chore] Optimize native packages' builds

### DIFF
--- a/docker/package/Dockerfile-fedora
+++ b/docker/package/Dockerfile-fedora
@@ -29,4 +29,7 @@ COPY docker/package/defaults /tezos-packaging/docker/package/defaults
 COPY docker/package/scripts /tezos-packaging/docker/package/scripts
 COPY LICENSE /tezos-packaging/LICENSE
 
-ENTRYPOINT ["python3", "-m", "package.package_generator"]
+RUN install -m 0755 /usr/bin/python3 /usr/bin/builder
+COPY docker/package/scripts/container-entrypoint.sh /container-entrypoint.sh
+ARG args
+RUN /container-entrypoint.sh

--- a/docker/package/Dockerfile-ubuntu
+++ b/docker/package/Dockerfile-ubuntu
@@ -46,5 +46,6 @@ COPY docker/package/scripts /tezos-packaging/docker/package/scripts
 # Uncomment once patches are needed once again
 # COPY docker/package/patches /tezos-packaging/docker/package/patches
 COPY LICENSE /tezos-packaging/LICENSE
-
-ENTRYPOINT ["builder", "-m", "package.package_generator"]
+COPY docker/package/scripts/container-entrypoint.sh /container-entrypoint.sh
+ARG args
+RUN /container-entrypoint.sh

--- a/docker/package/scripts/container-entrypoint.sh
+++ b/docker/package/scripts/container-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+set -euo pipefail
+
+IFS=' ' read -ra cmd_args <<<"${args:-}"
+builder -m package.package_generator "${cmd_args[@]}"


### PR DESCRIPTION


## Description

Problem: We used to use `ENTRYPOINT` command to run builds, which prevents caching of results.

Solution: Provide command line arguments as build argument and use `RUN` instead of `ENTRYPOINT`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
