### PR TITLE
[#628] Preserve tezos git folder

### DIFF
--- a/docker/fetch_tezos_sources.py
+++ b/docker/fetch_tezos_sources.py
@@ -24,8 +24,6 @@ subprocess.run(
     ]
 )
 
-shutil.rmtree(os.path.join("tezos", ".git"))
-
 subprocess.run(["git", "clone", "https://gitlab.com/tezos/opam-repository.git"])
 
 opam_repository_tag = (


### PR DESCRIPTION
## Description

Problem: Seems like octez binaries infer their version
from git tag, which get erased because `fetch_tezos_sources.py`
deletes `tezos/.git` folder, resulting in
`unknown (not-available) (0.0+dev)`
output instead of actual version.

Solution: Preserve `tezos/.git` folder.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #628 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
