### PR TITLE
[Chore] Bump release number

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -585,7 +585,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = ""
+    letter_version = "a"
 
     buildfile = "setup.py"
 

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "1",
+  "release": "2",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v16.0"
 }


### PR DESCRIPTION
## Description

Problem: we want to make a new native release to correct the bug that caused #628, so we need to bump the release number.

Solution: bump the release number.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
