### PR TITLE
[Chore] Add letter version to all packages

### DIFF
--- a/docker/package/meta.py
+++ b/docker/package/meta.py
@@ -23,7 +23,8 @@ meta_json_contents = json.load(
     open(f"{os.path.dirname(__file__)}/../../meta.json", "r")
 )
 packages_meta = PackagesMeta(
-    version=version,
+    # TODO: remove this in the next release
+    version=version + "b",
     release=str(meta_json_contents["release"]),
     ubuntu_epoch=2,
     fedora_epoch=1,

--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -585,7 +585,8 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = "a"
+    # NOTE: do not change this until the related TODO in meta.py has been resolved
+    letter_version = ""
 
     buildfile = "setup.py"
 


### PR DESCRIPTION
## Description

Problem: v16.0 release was made with slighly malformed sources, resulting in losing version information. Thus, to update sources, it's not enough to bump release version.

Solution: Add letter `b` to all packages' version.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
