### PR TITLE
[Chore] Add sapling package for fedora upload

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -21,7 +21,7 @@ steps:
    commands:
    - eval "$SET_VERSION"
    - nix develop .#docker-tezos-packages -c ./docker/docker-tezos-packages.py --os ubuntu --type source -s "Serokell <tezos-packaging@serokell.io>"
-   - nix develop .#docker-tezos-packages -c ./docker/docker-tezos-packages.py --os fedora --type source -s "Serokell <tezos-packaging@serokell.io>"
+   - nix develop .#docker-tezos-packages -c ./docker/docker-tezos-packages.py --os fedora --type source --build-sapling-package -s "Serokell <tezos-packaging@serokell.io>"
    artifact_paths:
      - ./out/*
 


### PR DESCRIPTION
## Description

Problem: In contrast from launchpad, copr does not reuse sapling package from older releases. Thus
we should make sure that it is always available.

Solution: Upload sapling params every release among other packages.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
