### PR TITLE
[#642] Stop node service when removing its data

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -238,6 +238,14 @@ class Setup(Setup):
             print("The Tezos node data directory already has some blockchain data:")
             print("\n".join(["- " + os.path.join(node_dir, path) for path in diff]))
             if yes_or_no("Delete this data and bootstrap the node again? <y/N> ", "no"):
+                # We first stop the node service, because it's possible that it
+                # will re-create some of the files while we go on with the wizard
+                print("Stopping node service")
+                proc_call(
+                    "sudo systemctl stop tezos-node-"
+                    + setup.config["network"]
+                    + ".service"
+                )
                 for path in diff:
                     try:
                         proc_call("sudo rm -r " + os.path.join(node_dir, path))


### PR DESCRIPTION
## Description

Problem: the setup wizard can remove (most of) the content of a node data dir if the user chooses to do so instead of keeping it. However, if there is a node service still running, this data dir can be partially re-filled while the wizard is still running and so cause issues, because some node commands need the data dir to be clean.

Solution: Stop the node service in the wizard before cleaning its data directory.

## Related issue(s)

Resolves #642

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
