### PR TITLE
[Chore] Fix broken link in voting doc

### DIFF
--- a/docs/voting.md
+++ b/docs/voting.md
@@ -18,7 +18,7 @@ An easy way to configure one is with the Tezos Setup wizard, see the [baking](./
 If a local baking setup is detected, the voting wizard will attempt to figure out
 as many as the necessary info as possible from it.
 
-With the [`tezos-baking`](./ubuntu.md/tezos-baking) package installed, launch the
+With the [`tezos-baking`](./ubuntu.md#tezos-baking) package installed, launch the
 interactive wizard with:
 ```bash
 tezos-vote


### PR DESCRIPTION
## Description

Problem: there is a broken link in the voting documentation, which is referencing a file that doesn't exists.

Solution: fix the link to point at a section, as it was intended.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
