### PR TITLE
[#654] Fix local snapshot import

### DIFF
--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -82,12 +82,12 @@ def fetch_snapshot(url):
     return filename
 
 
-def is_full_snapshot(import_mode):
+def is_full_snapshot(snapshot_file, import_mode):
     if import_mode == "download full":
         return True
     if import_mode == "file" or import_mode == "url":
         output = get_proc_output(
-            "sudo -u tezos octez-node snapshot info " + TMP_SNAPSHOT_LOCATION
+            "sudo -u tezos octez-node snapshot info " + snapshot_file
         ).stdout
         return re.search(b"at level [0-9]+ in full", output) is not None
     return False
@@ -336,10 +336,7 @@ class Setup(Setup):
                 return
             elif self.config["snapshot"] == "file":
                 self.query_step(snapshot_file_query)
-                if self.config["snapshot_file"] != TMP_SNAPSHOT_LOCATION:
-                    snapshot_file = shutil.copyfile(
-                        self.config["snapshot_file"], TMP_SNAPSHOT_LOCATION
-                    )
+                snapshot_file = self.config["snapshot_file"]
             elif self.config["snapshot"] == "url":
                 self.query_step(snapshot_url_query)
                 try:
@@ -366,7 +363,7 @@ class Setup(Setup):
             valid_choice = True
 
             import_flag = ""
-            if is_full_snapshot(self.config["snapshot"]):
+            if is_full_snapshot(snapshot_file, self.config["snapshot"]):
                 if self.config["history_mode"] == "archive":
                     import_flag = "--reconstruct "
 

--- a/docker/package/tezos_setup_wizard.py
+++ b/docker/package/tezos_setup_wizard.py
@@ -243,7 +243,7 @@ class Setup(Setup):
                 print("Stopping node service")
                 proc_call(
                     "sudo systemctl stop tezos-node-"
-                    + setup.config["network"]
+                    + self.config["network"]
                     + ".service"
                 )
                 for path in diff:


### PR DESCRIPTION
## Description

Problem: When snapsnot is provided as local file, it takes a lot of time, because it gets copied under `/tmp` folder, which is excess.

Solution: Use provided snapshot file in-place.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #654 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
