### PR TITLE
[Chore] Install 'brew' formulae deps prior to bottle building

### DIFF
--- a/scripts/build-one-bottle.sh
+++ b/scripts/build-one-bottle.sh
@@ -12,6 +12,15 @@ if [ -z "$1" ] ; then
     exit 1
 fi
 
+# 'brew install' doesn't allow building dependencies from sources if
+# there is a bottle available. At the same time some bottles require
+# specific values for 'HOMEBREW_CELLAR' and 'HOMEBREW_PREFIX'.
+# As a result, they cannot be installed with a user-specific brew installation
+# (when all brew directories are directly in user HOME directory).
+# So we're installing all dependencies preliminary to the actual bottle build
+
+# shellcheck disable=SC2046
+brew install $(brew deps --include-build --formula "./Formula/$1.rb")
 brew install --formula --build-bottle "./Formula/$1.rb"
 # Newer brew versions fail when checking for a rebuild version of non-core taps.
 # So for now we skip the check with '--no-rebuild'


### PR DESCRIPTION
## Description
Problem: 'brew install' doesn't allow building dependencies from sources if there is a bottle available. At the same time some bottles require specific values for 'HOMEBREW_CELLAR' and 'HOMEBREW_PREFIX'. As a result, they cannot be installed with a user-specific brew installation (when all brew directories are directly in user HOME directory).

Solution: Install all dependencies prior to the actual bottle build.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
