### PR TITLE
[#644] Allow setup to resume snapshot download

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -303,11 +303,11 @@ class TezosBinaryPackage(AbstractPackage):
 
         os.chdir("..")
 
-    def gen_control_file(self, deps, ubuntu_version, out):
-        str_build_deps = ", ".join(deps)
-        str_additional_native_deps = ", ".join(
-            self.__get_os_specific_native_deps("ubuntu")
+    def gen_control_file(self, build_deps, run_deps, ubuntu_version, out):
+        str_run_deps = ", ".join(
+            run_deps + self.__get_os_specific_native_deps("ubuntu")
         )
+        str_build_deps = ", ".join(build_deps)
         file_contents = f"""
 Source: {self.name.lower()}
 Section: utils
@@ -319,7 +319,7 @@ Homepage: https://gitlab.com/tezos/tezos/
 
 Package: {self.name.lower()}
 Architecture: amd64 arm64
-Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {str_additional_native_deps}
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {str_run_deps}
 Description: {self.desc}
 """
         with open(out, "w") as f:
@@ -500,7 +500,7 @@ class TezosSaplingParamsPackage(AbstractPackage):
             ]
         )
 
-    def gen_control_file(self, deps, ubuntu_version, out):
+    def gen_control_file(self, build_deps, run_deps, ubuntu_version, out):
         file_contents = f"""
 Source: {self.name}
 Section: utils
@@ -685,9 +685,9 @@ class TezosBakingServicesPackage(AbstractPackage):
             f"{os.path.dirname(__file__)}/baking/", out_dir, dirs_exist_ok=True
         )
 
-    def gen_control_file(self, deps, ubuntu_version, out):
-        run_deps_list = map(lambda x: x.lower(), self.additional_native_deps)
-        run_deps = ", ".join(run_deps_list)
+    def gen_control_file(self, build_deps, run_deps, ubuntu_version, out):
+        native_run_deps_list = [x.lower() for x in self.additional_native_deps]
+        str_run_deps = ", ".join(run_deps + native_run_deps_list)
         file_contents = f"""
 Source: {self.name}
 Section: utils
@@ -700,7 +700,7 @@ X-Python3-Version: >= 3.8
 
 Package: {self.name.lower()}
 Architecture: amd64 arm64
-Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {run_deps}, ${{python3:Depends}}
+Depends: ${{shlibs:Depends}}, ${{misc:Depends}}, {str_run_deps}, ${{python3:Depends}}
 Description: {self.desc}
 """
         with open(out, "w") as f:

--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -9,6 +9,7 @@ import urllib.request
 from .fedora import build_fedora_package
 from .ubuntu import build_ubuntu_package
 from .packages import packages as all_packages
+from .model import TezosBinaryPackage
 
 # fixed output dir in container
 output_dir = "out"
@@ -120,11 +121,7 @@ def build_fedora(args):
 
     binaries_dir = args.binaries_dir
 
-    run_deps = get_fedora_run_deps(binaries_dir)
-
     build_deps = get_build_deps(binaries_dir)
-
-    common_deps = run_deps + build_deps
 
     home = os.environ["HOME"]
 
@@ -138,6 +135,11 @@ def build_fedora(args):
         packages.append(all_packages[package_name])
 
     for package in packages:
+        run_deps = (
+            get_fedora_run_deps(binaries_dir)
+            if isinstance(package, TezosBinaryPackage)
+            else []
+        )
         build_fedora_package(
             package,
             build_deps,
@@ -172,11 +174,7 @@ def build_ubuntu(args):
 
     binaries_dir = args.binaries_dir
 
-    run_deps = get_ubuntu_run_deps(binaries_dir)
-
     build_deps = get_build_deps(binaries_dir)
-
-    common_deps = run_deps + build_deps
 
     home = os.environ["HOME"]
 
@@ -241,10 +239,16 @@ def build_ubuntu(args):
             sys.exit(1)
 
     for package in packages:
+        run_deps = (
+            get_ubuntu_run_deps(binaries_dir)
+            if isinstance(package, TezosBinaryPackage)
+            else []
+        )
         build_ubuntu_package(
             package,
             distributions,
-            common_deps,
+            build_deps,
+            run_deps,
             is_source,
             getattr(package, "source_archive", None),
             binaries_dir,

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -478,7 +478,7 @@ packages.append(
             additional_native_deps=[
                 f"tezos-baker-{proto}" for proto in active_protocols
             ]
-            + ["tezos-node", "acl"],
+            + ["tezos-node", "acl", "wget"],
         )
     }
 )

--- a/docker/package/ubuntu.py
+++ b/docker/package/ubuntu.py
@@ -12,6 +12,7 @@ def build_ubuntu_package(
     pkg: AbstractPackage,
     ubuntu_versions: List[str],
     build_deps: List[str],
+    run_deps: List[str],
     is_source: bool,
     source_archive_path: str = None,
     binaries_dir: str = None,
@@ -103,7 +104,7 @@ def build_ubuntu_package(
         pkg.gen_rules("debian/rules", ubuntu_version, binaries_dir)
         pkg.gen_postinst("debian/postinst")
         pkg.gen_postrm("debian/postrm")
-        pkg.gen_control_file(build_deps, ubuntu_version, "debian/control")
+        pkg.gen_control_file(build_deps, run_deps, ubuntu_version, "debian/control")
         # License is downloaded from the tezos repo, thus version should be without workarounds
         pkg.meta.version = old_version
         pkg.gen_license("debian/copyright")


### PR DESCRIPTION
## Description

Problem: Currently, if node snapshot download fails (e.g. for network issues)
this step fails and the user needs to download a snapshot again. This can be very inconvenient as some snapshots are very large and downloading them can take a long time.

Solution: Use `wget` with `--continue` option to be able to resume download.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
