### PR TITLE
[Chore] Run BigSur bottle builds in parallel

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -145,9 +145,6 @@ steps:
      automatic:
        limit: 1
 
- # To avoid running two brew processes together
- - wait
-
  - label: Build Big Sur arm64 bottles
    key: build-bottles-big-sur-arm64
    if: build.tag =~ /^v.*/


### PR DESCRIPTION
## Description

Problem: our infrastructure now supports running ARM and x64 bottle builds in parallel, but we still avoid that in our pipelines.

Problem: change the pipeline definition to allow ARM and x64 mac builds to run at the same time.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
