### PR TITLE
[Chore] Add PtNairob instances for nets

### DIFF
--- a/docker/package/model.py
+++ b/docker/package/model.py
@@ -585,7 +585,7 @@ class TezosBakingServicesPackage(AbstractPackage):
     # native releases, so we append an extra letter to the version of
     # the package.
     # This should be reset to "" whenever the native version is bumped.
-    letter_version = ""
+    letter_version = "a"
 
     buildfile = "setup.py"
 

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -23,8 +23,8 @@ networks = {
     "nairobinet": "https://teztnets.xyz/nairobinet",
 }
 networks_protos = {
-    "mainnet": ["PtMumbai"],
-    "ghostnet": ["PtMumbai"],
+    "mainnet": ["PtMumbai", "PtNairob"],
+    "ghostnet": ["PtMumbai", "PtNairob"],
     "mumbainet": ["PtMumbai"],
     "nairobinet": ["PtNairob"],
 }

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "1",
+  "release": "2",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v17.0"
 }


### PR DESCRIPTION

## Description

Problem: PtNairob baker should be included already as an option for baking services for ghostnet and mainnet.

Solution: Include it.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
