### PR TITLE
[Chore] Fix fedora upload

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -40,8 +40,6 @@ steps:
    depends_on:
    - "build-ubuntu-source-packages"
    key: sign-ubuntu-source-packages
-   agents:
-     queue: "docker"
    commands:
    - eval "$SET_VERSION"
    - buildkite-agent artifact download "out/*" . --step build-ubuntu-source-packages
@@ -54,8 +52,6 @@ steps:
    depends_on:
    - "build-fedora-source-packages"
    key: sign-fedora-source-packages
-   agents:
-     queue: "docker"
    commands:
    - eval "$SET_VERSION"
    - buildkite-agent artifact download "out/*" . --step build-fedora-source-packages
@@ -111,8 +107,6 @@ steps:
  - label: Sign source packages built from static binaries
    key: sign-source-packages-built-from-static-binaries
    if: build.tag =~ /^v.*-1/
-   agents:
-     queue: "docker"
    depends_on:
    - "build-via-docker"
    commands:

--- a/docker/build/ubuntu/upload.py
+++ b/docker/build/ubuntu/upload.py
@@ -71,7 +71,7 @@ login       = anonymous
 
     for f in filter(lambda x: x.endswith(".changes"), packages):
         subprocess.call(
-            f"execute-dput -c dput.cfg {launchpad_ppa} {os.path.join(source_packages_path, f)}",
+            f"execute-dput -c dput.cfg {launchpad_ppa} {f}",
             shell=True,
         )
 

--- a/docker/build/util/upload.py
+++ b/docker/build/util/upload.py
@@ -15,8 +15,7 @@ parser.add_argument(
     "--directory",
     "-d",
     help="provide a directory with packages to upload",
-    default=f"{os.path.join(os.getcwd(), '.')}",
-    type=os.path.abspath,
+    default=".",
 )
 parser.add_argument(
     "--os",


### PR DESCRIPTION
## Description

Problem: Albali machine provides copr token only
under `copr-uploader` user, which is different from
buildkite one. Using absolute paths make impossible
for `copr-cli` to upload that files under `sudo -u`.

On the other hand, it doesn't really change script's
intended behavior.

Solution: Use relative paths to artifacts.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
