### PR TITLE
[Chore] Fix epel packages sign step's dependency

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -108,7 +108,7 @@ steps:
    key: sign-source-packages-built-from-static-binaries
    if: build.tag =~ /^v.*-1/
    depends_on:
-   - "build-via-docker"
+   - "build-source-packages-from-static-binaries"
    commands:
    - eval "$SET_VERSION"
    - buildkite-agent artifact download "epel/*" . --step build-source-packages-from-static-binaries


### PR DESCRIPTION
## Description

Problem: The 'sign-source-packages-built-from-static-binaries' pipeline step depends on the 'build-via-docker' one, but it actually needs the artifacts from
'build-source-packages-from-static-binaries'.
This can cause these steps to run in the incorrect order, which results in failure.

Solution: Fix the step's dependency.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
