### PR TITLE
[#671] Fix epel chroot name

### DIFF
--- a/docker/build/fedora/sign.py
+++ b/docker/build/fedora/sign.py
@@ -24,7 +24,7 @@ def sign_fedora(args: Arguments):
 
     for f in artifacts:
         if f.endswith(".src.rpm"):
-            subprocess.call(
+            subprocess.check_call(
                 f'rpmsign --define="%_gpg_name {identity}" --define="%__gpg {gpg}" --addsign {f}',
                 shell=True,
             )

--- a/docker/build/fedora/upload.py
+++ b/docker/build/fedora/upload.py
@@ -44,7 +44,7 @@ def upload_fedora(args: Arguments):
     destination = args.destination
 
     if destination == "epel":
-        chroots = ["epel-x86_64"]
+        chroots = ["epel-7-x86_64"]
     else:
         archs = ["x86_64", "aarch64"]
         chroots = [

--- a/docker/build/fedora/upload.py
+++ b/docker/build/fedora/upload.py
@@ -54,7 +54,7 @@ def upload_fedora(args: Arguments):
     chroots = " ".join(f"-r {chroot}" for chroot in chroots)
 
     for f in filter(lambda x: x.endswith(".src.rpm"), packages):
-        subprocess.call(
+        subprocess.check_call(
             f"copr-cli build {chroots} --nowait {copr_project} {f}",
             shell=True,
         )

--- a/docker/build/ubuntu/sign.py
+++ b/docker/build/ubuntu/sign.py
@@ -24,10 +24,10 @@ def sign_ubuntu(args: Arguments):
 
     for f in artifacts:
         if f.endswith(".changes"):
-            subprocess.call(
+            subprocess.check_call(
                 f"sed -i 's/^Changed-By: .*$/Changed-By: {identity}/' {f}", shell=True
             )
-            subprocess.call(f"debsign {f}", shell=True)
+            subprocess.check_call(f"debsign {f}", shell=True)
 
 
 def main(args: Optional[Arguments] = None):

--- a/docker/build/ubuntu/upload.py
+++ b/docker/build/ubuntu/upload.py
@@ -70,7 +70,7 @@ login       = anonymous
     packages = get_artifact_list(args)
 
     for f in filter(lambda x: x.endswith(".changes"), packages):
-        subprocess.call(
+        subprocess.check_call(
             f"execute-dput -c dput.cfg {launchpad_ppa} {f}",
             shell=True,
         )


### PR DESCRIPTION
## Description

Problem: copr epel chroot name lacks of version
number, resulting in error during upload.

Solution: Specify correct name.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #671 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
