### PR TITLE
[#641] Add tezos binaries tests

### DIFF
--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -1,0 +1,19 @@
+name: Test Tezos binaries
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test_binaries:
+    name: Install and test binaries
+    runs-on: [self-hosted, Linux, X64, nix-with-docker]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Test fedora binaries
+        run: nix develop .#buildkite -c ./docker/tests/scripts/test-fedora-binaries.sh
+
+      - name: Test ubuntu binaries
+        run: nix develop .#buildkite -c ./docker/tests/scripts/test-ubuntu-binaries.sh

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,6 +4,6 @@ Files: .github/* nix/nix/* nix/build/install_topfind_196.patch protocols.json me
 Copyright: 2022 Oxhead Alpha
 License: LicenseRef-MIT-OA
 
-Files: nix/build/install_topfind_196.patch baking/src/tezos_baking/__init__.py
+Files: nix/build/install_topfind_196.patch baking/src/tezos_baking/__init__.py docker/tests/binaries.json
 Copyright: 2023 Oxhead Alpha
 License: LicenseRef-MIT-OA

--- a/docker/tests/Dockerfile-fedora-test
+++ b/docker/tests/Dockerfile-fedora-test
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+ARG dist
+FROM fedora:${dist}
+
+WORKDIR /tezos-packaging/docker
+
+RUN dnf update -y
+RUN dnf install -y python3-devel python3-setuptools 'dnf-command(copr)'
+
+ARG repo
+RUN dnf copr enable -y @Serokell/${repo}
+
+ENV IS_RELEASED=${repo}
+
+COPY docker/tests/test-fedora-binaries.py /tezos-packaging/docker/tests/test-fedora-binaries.py
+COPY docker/tests/binaries.json /tezos-packaging/binaries.json
+CMD [ "python3", "/tezos-packaging/docker/tests/test-fedora-binaries.py"]

--- a/docker/tests/Dockerfile-ubuntu-test
+++ b/docker/tests/Dockerfile-ubuntu-test
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+ARG dist
+FROM ubuntu:${dist}
+
+WORKDIR /tezos-packaging/docker
+
+RUN apt update -y
+RUN apt install -y python3-all python3-setuptools software-properties-common
+
+ARG repo
+RUN add-apt-repository -yu ppa:serokell/${repo}
+
+ENV IS_RELEASED=${repo}
+
+COPY docker/tests/test-ubuntu-binaries.py /tezos-packaging/docker/tests/test-ubuntu-binaries.py
+COPY docker/tests/binaries.json /tezos-packaging/binaries.json
+CMD [ "python3", "/tezos-packaging/docker/tests/test-ubuntu-binaries.py"]

--- a/docker/tests/binaries.json
+++ b/docker/tests/binaries.json
@@ -1,0 +1,41 @@
+{
+    "released": [
+        "tezos-smart-rollup-client-Proxford",
+        "tezos-smart-rollup-client-PtNairob",
+        "tezos-smart-rollup-node-Proxford",
+        "tezos-smart-rollup-node-PtNairob",
+        "tezos-baking",
+        "tezos-sapling-params",
+        "tezos-accuser-Proxford",
+        "tezos-baker-Proxford",
+        "tezos-accuser-PtNairob",
+        "tezos-baker-PtNairob",
+        "tezos-node",
+        "tezos-dac-node",
+        "tezos-dac-client",
+        "tezos-codec",
+        "tezos-signer",
+        "tezos-admin-client",
+        "tezos-client",
+        "tezos-smart-rollup-wasm-debugger"
+    ],
+    "candidates": [
+        "tezos-smart-rollup-client-Proxford",
+        "tezos-smart-rollup-client-PtNairob",
+        "tezos-smart-rollup-node-Proxford",
+        "tezos-smart-rollup-node-PtNairob",
+        "tezos-baking",
+        "tezos-sapling-params",
+        "tezos-accuser-Proxford",
+        "tezos-baker-Proxford",
+        "tezos-accuser-PtNairob",
+        "tezos-baker-PtNairob",
+        "tezos-node",
+        "tezos-dac-node",
+        "tezos-dac-client",
+        "tezos-codec",
+        "tezos-signer",
+        "tezos-admin-client",
+        "tezos-client"
+    ]
+}

--- a/docker/tests/scripts/test-fedora-binaries.sh
+++ b/docker/tests/scripts/test-fedora-binaries.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+set -euo pipefail
+
+for version in $(jq -r '.fedora[]' docker/supported_versions.json); do
+    docker build --build-arg dist="$version" --build-arg repo="Tezos" -t fedora-test -f docker/tests/Dockerfile-fedora-test .
+    docker run -rm fedora-test
+    docker build --build-arg dist="$version" --build-arg repo="Tezos-rc" -t fedora-test -f docker/tests/Dockerfile-fedora-test .
+    docker run -rm fedora-test
+done

--- a/docker/tests/scripts/test-ubuntu-binaries.sh
+++ b/docker/tests/scripts/test-ubuntu-binaries.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+set -euo pipefail
+
+for version in $(jq -r '.ubuntu[]' docker/supported_versions.json); do
+    docker build --build-arg dist="$version" --build-arg repo="tezos" -t ubuntu-test -f docker/tests/Dockerfile-ubuntu-test .
+    docker run -rm ubuntu-test
+    docker build --build-arg dist="$version" --build-arg repo="tezos-rc" -t ubuntu-test -f docker/tests/Dockerfile-ubuntu-test .
+    docker run -rm ubuntu-test
+done

--- a/docker/tests/test-fedora-binaries.py
+++ b/docker/tests/test-fedora-binaries.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+import subprocess
+import sys
+import json
+import os
+
+
+def test(binaries):
+    subprocess.run("dnf update -y", shell=True, capture_output=True)
+    for binary in binaries:
+        try:
+            subprocess.run(
+                f"dnf install -y {binary}", shell=True, capture_output=True, check=True
+            )
+            if binary != "tezos-sapling-params" and binary != "tezos-baking":
+                print(f"{binary}: ", end="", flush=True)
+                subprocess.check_call(
+                    f"{binary.replace('tezos', 'octez')} --version", shell=True
+                )
+        except Exception as e:
+            print(f"Exception happened when trying to execute tests for {binary}.\n")
+            raise e
+
+
+if __name__ == "__main__":
+    data = {}
+    with open("/tezos-packaging/binaries.json") as f:
+        data = json.load(f)
+
+    binaries = []
+    is_released = os.environ["IS_RELEASED"]
+    if is_released == "Tezos":
+        binaries = data["released"]
+    elif is_released == "Tezos-rc":
+        binaries = data["candidates"]
+    else:
+        raise "Incorrect argument"
+
+    test(binaries)

--- a/docker/tests/test-ubuntu-binaries.py
+++ b/docker/tests/test-ubuntu-binaries.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+import subprocess
+import sys
+import json
+import os
+
+
+def test(binaries):
+    subprocess.run("apt update -y", shell=True, capture_output=True)
+    for binary in binaries:
+        try:
+            subprocess.run(
+                f"apt install -y {binary.lower()}",
+                shell=True,
+                capture_output=True,
+                check=True,
+            )
+            if binary != "tezos-sapling-params" and binary != "tezos-baking":
+                print(f"{binary}: ", end="", flush=True)
+                subprocess.check_call(
+                    f"{binary.replace('tezos', 'octez')} --version", shell=True
+                )
+        except Exception as e:
+            print(f"Exception happened when trying to execute tests for {binary}.\n")
+            raise e
+
+
+if __name__ == "__main__":
+    data = {}
+    with open("/tezos-packaging/binaries.json") as f:
+        data = json.load(f)
+
+    binaries = []
+    is_released = os.environ["IS_RELEASED"]
+    if is_released == "tezos":
+        binaries = data["released"]
+    elif is_released == "tezos-rc":
+        binaries = data["candidates"]
+    else:
+        raise "Incorrect argument"
+
+    test(binaries)


### PR DESCRIPTION
## Description
This PR adds checks that Tezos binaries can be installed on the latest Ubuntu and Fedora can be installed and work fine. The tests run once every day.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #641 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
