### PR TITLE
[Chore] Fix baking package update in tezos update script

### DIFF
--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -46,7 +46,7 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
 
     sed -i 's/"release": "[0-9]\+"/"release": "1"/' ./meta.json
     # Update version of tezos-baking package
-    sed -i "s/version = .*/version = \"$latest_upstream_tag\"/" ./code/pyproject.toml
+    sed -i "s/version = .*/version = \"$latest_upstream_tag\"/" ./baking/pyproject.toml
     # Commit may fail when release number wasn't updated since the last release
     git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       echo "release number wasn't updated"


### PR DESCRIPTION
## Description

Problem: a recent change to the update_tezos.sh script breaks it, due to an incorrect path being used in a 'sed' invocation. See #658

Solution: Use the correct path to fix the script.

## Related issue(s)

None

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
