### PR TITLE
[#591] Remove unnecessary tezos-client deps

### DIFF
--- a/Formula/tezos-accuser-Proxford.rb
+++ b/Formula/tezos-accuser-Proxford.rb
@@ -18,7 +18,7 @@ class TezosAccuserProxford < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-accuser-PtNairob.rb
+++ b/Formula/tezos-accuser-PtNairob.rb
@@ -18,7 +18,7 @@ class TezosAccuserPtnairob < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -18,7 +18,7 @@ class TezosAdminClient < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-baker-Proxford.rb
+++ b/Formula/tezos-baker-Proxford.rb
@@ -18,7 +18,7 @@ class TezosBakerProxford < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-baker-PtNairob.rb
+++ b/Formula/tezos-baker-PtNairob.rb
@@ -18,7 +18,7 @@ class TezosBakerPtnairob < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev  tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -18,7 +18,7 @@ class TezosClient < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -18,7 +18,7 @@ class TezosCodec < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-dac-client.rb
+++ b/Formula/tezos-dac-client.rb
@@ -18,7 +18,7 @@ class TezosDacClient < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-dac-node.rb
+++ b/Formula/tezos-dac-node.rb
@@ -18,7 +18,7 @@ class TezosDacNode < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -18,7 +18,7 @@ class TezosNode < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev  tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -18,7 +18,7 @@ class TezosSigner < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi]
+  dependencies = %w[gmp hidapi libev]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-smart-rollup-client-Proxford.rb
+++ b/Formula/tezos-smart-rollup-client-Proxford.rb
@@ -19,7 +19,7 @@ class TezosSmartRollupClientProxford < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end

--- a/Formula/tezos-smart-rollup-client-PtNairob.rb
+++ b/Formula/tezos-smart-rollup-client-PtNairob.rb
@@ -19,7 +19,7 @@ class TezosSmartRollupClientPtnairob < Formula
     depends_on dependency => :build
   end
 
-  dependencies = %w[gmp hidapi libev libffi tezos-sapling-params]
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
   dependencies.each do |dependency|
     depends_on dependency
   end


### PR DESCRIPTION
## Description

This MR removes unnecessary dependency of `libffi` from tezos-client build. This seems to be the only dependency that is unnecessary, as without others brew fails to build it.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)
Closes: #591 

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
#### Related changes (conditional)

- [X] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [X] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [X] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
