### PR TITLE
[Chore] Remove redundant tox config

### DIFF
--- a/baking/pyproject.toml
+++ b/baking/pyproject.toml
@@ -22,11 +22,3 @@ where= ["src"]
 [project.scripts]
 tezos-setup = "tezos_baking.tezos_setup_wizard:main"
 tezos-vote = "tezos_baking.tezos_voting_wizard:main"
-
-[tool.tox]
-legacy_tox_ini = """
-  [tox]
-  env_list =
-    py38
-    type
-"""


### PR DESCRIPTION


## Description

Problem: `tox` config is ignored by
fedora 38 build and causes fedora 37 build
to crash.

Solution: Remove it.
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
