### PR TITLE
[Chore] Brew bottles hotfixes for v17.2 

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -139,24 +139,24 @@ steps:
      automatic:
        limit: 1
 
- - label: Build Big Sur arm64 bottles
-   key: build-bottles-big-sur-arm64
-   if: build.tag =~ /^v.*/
-   agents:
-     queue: "arm64-darwin"
-   commands:
-   - nix develop .#autorelease-macos -c ./scripts/build-all-bottles.sh "arm64_big_sur"
-   artifact_paths:
-     - '*.bottle.*'
-   retry:
-     automatic:
-       limit: 1
+ #  - label: Build Big Sur arm64 bottles
+ #    key: build-bottles-big-sur-arm64
+ #    if: build.tag =~ /^v.*/
+ #    agents:
+ #      queue: "arm64-darwin"
+ #    commands:
+ #    - nix develop .#autorelease-macos -c ./scripts/build-all-bottles.sh "arm64_big_sur"
+ #    artifact_paths:
+ #      - '*.bottle.*'
+ #    retry:
+ #      automatic:
+ #        limit: 1
 
  # We use the tag that triggered the pipeline here. Normally, this isn't very resilient,
  # but in 'scripts/sync-bottle-hashes.sh' it's only used for informational purposes
  - label: Add Big Sur bottle hashes to formulae
    depends_on:
-   - "build-bottles-big-sur-arm64"
+ #    - "build-bottles-big-sur-arm64"
    - "build-bottles-big-sur-x86_64"
    if: build.tag =~ /^v.*/
    soft_fail: true # No artifacts to download if all the bottles are already built

--- a/Formula/tezos-accuser-PtMumbai.rb
+++ b/Formula/tezos-accuser-PtMumbai.rb
@@ -82,36 +82,15 @@ class TezosAccuserPtmumbai < Formula
                      "octez-accuser-PtMumbai"
   end
 
-  plist_options manual: "tezos-accuser-PtMumbai run"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-accuser-PtMumbai-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>NODE_RPC_SCHEME</key>
-              <string>http</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>localhost:8732</string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run opt_bin/"tezos-accuser-PtMumbai-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_SCHEME: "http", NODE_RPC_ADDR: "localhost:8732"
+    keep_alive true
+    log_path var/"log/tezos-accuser-PtMumbai.log"
+    error_log_path var/"log/tezos-accuser-PtMumbai.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end

--- a/Formula/tezos-accuser-PtNairob.rb
+++ b/Formula/tezos-accuser-PtNairob.rb
@@ -82,36 +82,15 @@ class TezosAccuserPtnairob < Formula
                      "octez-accuser-PtNairob"
   end
 
-  plist_options manual: "tezos-accuser-PtNairob run"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-accuser-PtNairob-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>NODE_RPC_SCHEME</key>
-              <string>http</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>localhost:8732</string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run opt_bin/"tezos-accuser-PtNairob-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_SCHEME: "http", NODE_RPC_ADDR: "localhost:8732"
+    keep_alive true
+    log_path var/"log/tezos-accuser-PtNairob.log"
+    error_log_path var/"log/tezos-accuser-PtNairob.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end

--- a/Formula/tezos-baker-PtMumbai.rb
+++ b/Formula/tezos-baker-PtMumbai.rb
@@ -91,40 +91,16 @@ class TezosBakerPtmumbai < Formula
                      "_build/default/src/proto_016_PtMumbai/bin_baker/main_baker_016_PtMumbai.exe",
                      "octez-baker-PtMumbai"
   end
-  plist_options manual: "tezos-baker-PtMumbai run with local node"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-baker-PtMumbai-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>TEZOS_NODE_DIR</key>
-              <string></string>
-              <key>NODE_RPC_SCHEME</key>
-              <string>http</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>localhost:8732</string>
-              <key>BAKER_ACCOUNT</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-baker-PtMumbai-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", TEZOS_NODE_DIR: "", NODE_RPC_SCHEME: "http", NODE_RPC_ADDR: "localhost:8732", BAKER_ACCOUNT: ""
+    keep_alive true
+    log_path var/"log/tezos-baker-PtMumbai.log"
+    error_log_path var/"log/tezos-baker-PtMumbai.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end

--- a/Formula/tezos-baker-PtNairob.rb
+++ b/Formula/tezos-baker-PtNairob.rb
@@ -91,40 +91,16 @@ class TezosBakerPtnairob < Formula
                      "_build/default/src/proto_017_PtNairob/bin_baker/main_baker_017_PtNairob.exe",
                      "octez-baker-PtNairob"
   end
-  plist_options manual: "tezos-baker-PtNairob run with local node"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-baker-PtNairob-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>TEZOS_NODE_DIR</key>
-              <string></string>
-              <key>NODE_RPC_SCHEME</key>
-              <string>http</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>localhost:8732</string>
-              <key>BAKER_ACCOUNT</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-baker-PtNairob-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", TEZOS_NODE_DIR: "", NODE_RPC_SCHEME: "http", NODE_RPC_ADDR: "localhost:8732", BAKER_ACCOUNT: ""
+    keep_alive true
+    log_path var/"log/tezos-baker-PtNairob.log"
+    error_log_path var/"log/tezos-baker-PtNairob.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end

--- a/Formula/tezos-node-ghostnet.rb
+++ b/Formula/tezos-node-ghostnet.rb
@@ -47,37 +47,16 @@ class TezosNodeGhostnet < Formula
     bin.install "tezos-node-ghostnet-start"
     print "Installing tezos-node-ghostnet service"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-node-ghostnet-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/node-ghostnet</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>127.0.0.1:8732</string>
-              <key>CERT_PATH</key>
-              <string></string>
-              <key>KEY_PATH</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-node-ghostnet-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ADDR: "127.0.0.1:8732", CERT_PATH: "", KEY_PATH: ""
+    keep_alive true
+    log_path var/"log/tezos-node-ghostnet.log"
+    error_log_path var/"log/tezos-node-ghostnet.log"
   end
+
   def post_install
     mkdir_p "#{var}/lib/tezos/node-ghostnet"
     system "octez-node", "config", "init", "--data-dir" "#{var}/lib/tezos/node-ghostnet", "--network", "ghostnet"

--- a/Formula/tezos-node-mainnet.rb
+++ b/Formula/tezos-node-mainnet.rb
@@ -47,37 +47,16 @@ class TezosNodeMainnet < Formula
     bin.install "tezos-node-mainnet-start"
     print "Installing tezos-node-mainnet service"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-node-mainnet-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/node-mainnet</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>127.0.0.1:8732</string>
-              <key>CERT_PATH</key>
-              <string></string>
-              <key>KEY_PATH</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-node-mainnet-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ADDR: "127.0.0.1:8732", CERT_PATH: "", KEY_PATH: ""
+    keep_alive true
+    log_path var/"log/tezos-node-mainnet.log"
+    error_log_path var/"log/tezos-node-mainnet.log"
   end
+
   def post_install
     mkdir_p "#{var}/lib/tezos/node-mainnet"
     system "octez-node", "config", "init", "--data-dir" "#{var}/lib/tezos/node-mainnet", "--network", "mainnet"

--- a/Formula/tezos-node-mumbainet.rb
+++ b/Formula/tezos-node-mumbainet.rb
@@ -49,37 +49,16 @@ class TezosNodeMumbainet < Formula
     bin.install "tezos-node-mumbainet-start"
     print "Installing tezos-node-mumbainet service"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-node-mumbainet-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/node-mumbainet</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>127.0.0.1:8732</string>
-              <key>CERT_PATH</key>
-              <string></string>
-              <key>KEY_PATH</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-node-mumbainet-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ADDR: "127.0.0.1:8732", CERT_PATH: "", KEY_PATH: ""
+    keep_alive true
+    log_path var/"log/tezos-node-mumbainet.log"
+    error_log_path var/"log/tezos-node-mumbainet.log"
   end
+
   def post_install
     mkdir_p "#{var}/lib/tezos/node-mumbainet"
     system "octez-node", "config", "init", "--data-dir" "#{var}/lib/tezos/node-mumbainet", "--network", "mumbainet"

--- a/Formula/tezos-node-nairobinet.rb
+++ b/Formula/tezos-node-nairobinet.rb
@@ -49,37 +49,16 @@ class TezosNodeNairobinet < Formula
     bin.install "tezos-node-nairobinet-start"
     print "Installing tezos-node-nairobinet service"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-node-nairobinet-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/node-nairobinet</string>
-              <key>NODE_RPC_ADDR</key>
-              <string>127.0.0.1:8732</string>
-              <key>CERT_PATH</key>
-              <string></string>
-              <key>KEY_PATH</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-node-nairobinet-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ADDR: "127.0.0.1:8732", CERT_PATH: "", KEY_PATH: ""
+    keep_alive true
+    log_path var/"log/tezos-node-nairobinet.log"
+    error_log_path var/"log/tezos-node-nairobinet.log"
   end
+
   def post_install
     mkdir_p "#{var}/lib/tezos/node-nairobinet"
     system "octez-node", "config", "init", "--data-dir" "#{var}/lib/tezos/node-nairobinet", "--network", "https://teztnets.xyz/nairobinet"

--- a/Formula/tezos-signer-http.rb
+++ b/Formula/tezos-signer-http.rb
@@ -43,41 +43,15 @@ class TezosSignerHttp < Formula
     File.write("tezos-signer-http-start", startup_contents)
     bin.install "tezos-signer-http-start"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-signer-http-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>ADDRESS</key>
-              <string>127.0.0.1</string>
-              <key>PORT</key>
-              <string>8080</string>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/signer-http</string>
-              <key>PIDFILE</key>
-              <string></string>
-              <key>MAGIC_BYTES</key>
-              <string></string>
-              <key>CHECK_HIGH_WATERMARK</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-signer-http-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", ADDRESS: "127.0.0.1", PORT:"8080", PIDFILE: "", MAGIC_BYTES: "", CHECK_HIGH_WATERMARK: ""
+    log_path var/"log/tezos-signer-http.log"
+    error_log_path var/"log/tezos-signer-http.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/signer-http"
   end

--- a/Formula/tezos-signer-https.rb
+++ b/Formula/tezos-signer-https.rb
@@ -43,45 +43,15 @@ class TezosSignerHttps < Formula
     File.write("tezos-signer-https-start", startup_contents)
     bin.install "tezos-signer-https-start"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-signer-https-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>ADDRESS</key>
-              <string>127.0.0.1</string>
-              <key>PORT</key>
-              <string>8080</string>
-              <key>CERT_PATH</key>
-              <string></string>
-              <key>KEY_PATH</key>
-              <string></string>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/signer-https</string>
-              <key>PIDFILE</key>
-              <string></string>
-              <key>MAGIC_BYTES</key>
-              <string></string>
-              <key>CHECK_HIGH_WATERMARK</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-signer-https-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", ADDRESS: "127.0.0.1", PORT:"8080", PIDFILE: "", MAGIC_BYTES: "", CHECK_HIGH_WATERMARK: "", CERT_PATH: "", KEY_PATH: ""
+    log_path var/"log/tezos-signer-https.log"
+    error_log_path var/"log/tezos-signer-https.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/signer-https"
   end

--- a/Formula/tezos-signer-tcp.rb
+++ b/Formula/tezos-signer-tcp.rb
@@ -43,43 +43,15 @@ class TezosSignerTcp < Formula
     File.write("tezos-signer-tcp-start", startup_contents)
     bin.install "tezos-signer-tcp-start"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-signer-tcp-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>ADDRESS</key>
-              <string>127.0.0.1</string>
-              <key>PORT</key>
-              <string>8000</string>
-              <key>TIMEOUT</key>
-              <string>1</string>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/signer-tcp</string>
-              <key>PIDFILE</key>
-              <string></string>
-              <key>MAGIC_BYTES</key>
-              <string></string>
-              <key>CHECK_HIGH_WATERMARK</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-signer-tcp-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", TIMEOUT: "1", ADDRESS: "127.0.0.1", PORT:"8080", PIDFILE: "", MAGIC_BYTES: "", CHECK_HIGH_WATERMARK: ""
+    log_path var/"log/tezos-signer-tcp.log"
+    error_log_path var/"log/tezos-signer-tcp.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/signer-tcp"
   end

--- a/Formula/tezos-signer-unix.rb
+++ b/Formula/tezos-signer-unix.rb
@@ -40,41 +40,18 @@ class TezosSignerUnix < Formula
         ${pid_file_args[@]+"${pid_file_args[@]}"} ${magic_bytes_args[@]+"${magic_bytes_args[@]}"} \
         ${check_high_watermark_args[@]+"${check_high_watermark_args[@]}"} "$@"
     EOS
-    File.write("tezos-signer-http-start", startup_contents)
-    bin.install "tezos-signer-http-start"
+    File.write("tezos-signer-unix-start", startup_contents)
+    bin.install "tezos-signer-unix-start"
   end
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-signer-unix-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>SOCKET</key>
-              <string></string>
-              <string>#{var}/lib/tezos/signer-unix</string>
-              <key>PIDFILE</key>
-              <string></string>
-              <key>MAGIC_BYTES</key>
-              <string></string>
-              <key>CHECK_HIGH_WATERMARK</key>
-              <string></string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-signer-unix-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", SOCKET: var/"lib/tezos/signer-unix", PIDFILE: "", MAGIC_BYTES: "", CHECK_HIGH_WATERMARK: ""
+    log_path var/"log/tezos-signer-unix.log"
+    error_log_path var/"log/tezos-signer-unix.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/signer-unix"
   end

--- a/Formula/tezos-smart-rollup-node-PtMumbai.rb
+++ b/Formula/tezos-smart-rollup-node-PtMumbai.rb
@@ -79,39 +79,16 @@ class TezosSmartRollupNodePtmumbai < Formula
                      "octez-smart-rollup-node-PtMumbai"
   end
   plist_options manual: "tezos-smart-rollup-node-PtMumbai run for"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-smart-rollup-node-PtMumbai-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>NODE_RPC_ENDPOINT</key>
-              <string>http://localhost:8732</string>
-              <key>ROLLUP_NODE_RPC_ENDPOINT</key>
-              <string>127.0.0.1:8472</string>
-              <key>ROLLUP_MODE</key>
-              <string>observer</string>
-              <key>ROLLUP_ALIAS</key>
-              <string>rollup</string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-smart-rollup-node-PtMumbai-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ENDPOINT: "http://localhost:8732", ROLLUP_NODE_RPC_ENDPOINT: "127.0.0.1:8472", ROLLUP_MODE: "observer", ROLLUP_ALIAS: "rollup"
+    keep_alive true
+    log_path var/"log/tezos-smart-rollup-node-PtMumbai.log"
+    error_log_path var/"log/tezos-smart-rollup-node-PtMumbai.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end

--- a/Formula/tezos-smart-rollup-node-PtNairob.rb
+++ b/Formula/tezos-smart-rollup-node-PtNairob.rb
@@ -78,40 +78,16 @@ class TezosSmartRollupNodePtnairob < Formula
                      "_build/default/src/proto_017_PtNairob/bin_sc_rollup_node/main_sc_rollup_node_017_PtNairob.exe",
                      "octez-smart-rollup-node-PtNairob"
   end
-  plist_options manual: "tezos-smart-rollup-node-PtNairob run for"
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
-      "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>Program</key>
-          <string>#{opt_bin}/tezos-smart-rollup-node-PtNairob-start</string>
-          <key>EnvironmentVariables</key>
-            <dict>
-              <key>TEZOS_CLIENT_DIR</key>
-              <string>#{var}/lib/tezos/client</string>
-              <key>NODE_RPC_ENDPOINT</key>
-              <string>http://localhost:8732</string>
-              <key>ROLLUP_NODE_RPC_ENDPOINT</key>
-              <string>127.0.0.1:8472</string>
-              <key>ROLLUP_MODE</key>
-              <string>observer</string>
-              <key>ROLLUP_ALIAS</key>
-              <string>rollup</string>
-          </dict>
-          <key>RunAtLoad</key><true/>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/#{name}.log</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/#{name}.log</string>
-        </dict>
-      </plist>
-    EOS
+
+  service do
+    run opt_bin/"tezos-smart-rollup-node-PtNairob-start"
+    require_root true
+    environment_variables TEZOS_CLIENT_DIR: var/"lib/tezos/client", NODE_RPC_ENDPOINT: "http://localhost:8732", ROLLUP_NODE_RPC_ENDPOINT: "127.0.0.1:8472", ROLLUP_MODE: "observer", ROLLUP_ALIAS: "rollup"
+    keep_alive true
+    log_path var/"log/tezos-smart-rollup-node-PtNairob.log"
+    error_log_path var/"log/tezos-smart-rollup-node-PtNairob.log"
   end
+
   def post_install
     mkdir "#{var}/lib/tezos/client"
   end


### PR DESCRIPTION
## Description

This PR has two changes needed for Octez 17.2 release(s):
1. updates formulae after the deprecation of `plist`s
2. stops CI from trying to build for arm64 BigSur

See individual commit messages for additional info.

## Related issue(s)

None

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
