### PR TITLE
[#687] Fix typo in tezos-setup

### DIFF
--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -715,7 +715,7 @@ class Setup:
                     print(
                         f"Before proceeding with baker registration you'll need to provide this address with some XTZ.\n"
                         f"Note that you need at least 6000 XTZ in order to receive baking and endorsing rights.\n"
-                        f"You can do fill your address using faucet: https://faucet.{network}.teztnets.xyz/.\n"
+                        f"You can fill your address using the faucet: https://faucet.{network}.teztnets.xyz/.\n"
                         f"Waiting for funds to arrive... (Ctrl + C to choose another option)."
                     )
                     try:


### PR DESCRIPTION
Problem: Output during generated key import
contains typo.

Solution: Fix it.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #687 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
