### PR TITLE
[#689] Do not display baker address value

### DIFF
--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -668,8 +668,7 @@ class Setup:
             value, address = baker_key_value
             print()
             print("An account with the '" + baker_alias + "' alias already exists.")
-            print("Its current value is", value)
-            print("With a corresponding address:", address)
+            print("Its current address is", address)
 
             return yes_or_no(
                 "Would you like to import a new key and replace this one? <y/N> ", "no"


### PR DESCRIPTION
## Description

Problem: If the baker key is present already, `tezos-setup` displays its value. It is unnecessary and insecure.

Solution: Display address only.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #689 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
