### PR TITLE
[#633] Allow users to specify snapshot provider

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -222,7 +222,7 @@ liquidity_toggle_vote_query = Step(
 # We define this step as a function to better tailor snapshot options to the chosen history mode
 def get_snapshot_mode_query(modes):
     return Step(
-        id="snapshot",
+        id="snapshot_mode",
         prompt="The Tezos node can take a significant time to bootstrap from scratch.\n"
         "Bootstrapping from a snapshot is suggested instead.\n"
         "How would you like to proceed?",
@@ -477,12 +477,12 @@ block timestamp: {timestamp} ({time_ago})
             snapshot_file = TMP_SNAPSHOT_LOCATION
             snapshot_block_hash = None
 
-            if self.config["snapshot"] == "skip":
+            if self.config["snapshot_mode"] == "skip":
                 return
-            elif self.config["snapshot"] == "file":
+            elif self.config["snapshot_mode"] == "file":
                 self.query_step(snapshot_file_query)
                 snapshot_file = self.config["snapshot_file"]
-            elif self.config["snapshot"] == "url":
+            elif self.config["snapshot_mode"] == "url":
                 self.query_step(snapshot_url_query)
                 try:
                     self.query_step(snapshot_sha256_query)
@@ -526,7 +526,7 @@ block timestamp: {timestamp} ({time_ago})
             valid_choice = True
 
             import_flag = ""
-            if is_full_snapshot(snapshot_file, self.config["snapshot"]):
+            if is_full_snapshot(snapshot_file, self.config["snapshot_mode"]):
                 if self.config["history_mode"] == "archive":
                     import_flag = "--reconstruct "
 

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -65,7 +65,7 @@ def reachable_url_validator(suffix=None):
     def _validator(input):
         full_url = mk_full_url(input, suffix)
         if url_is_reachable(full_url):
-            return input
+            return full_url
         else:
             raise ValueError(f"{full_url} is unreachable. Please input a valid URL.")
 
@@ -277,10 +277,17 @@ def yes_or_no(prompt, default=None):
 
 
 def mk_full_url(host_name, path):
-    if path is None:
-        return host_name.rstrip("/")
-    else:
-        return "/".join([host_name.rstrip("/"), path.lstrip("/")])
+    from urllib.parse import urlparse
+
+    url = host_name
+    if path is not None:
+        url = os.path.join(host_name, path)
+
+    # urllib doesn't make an assumption which scheme to use by default in case of absence
+    if urlparse(url).scheme == "":
+        url = "https://" + url
+
+    return url
 
 
 def url_is_reachable(url):


### PR DESCRIPTION
## Description

Problem: The setup wizard currently has an option to use
the metadata provided by xtz-shots (see #441) to download
a snapshot for its node. There are however other snapshot
providers that are adopting the same metadata format, so we want
to let the users pick a different provider too.

Solution: Add the step to choose provider.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #633
Resolves #692 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
