### PR TITLE
[#539] Load BigSur bottles from release instead of artifacts

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -152,15 +152,15 @@ steps:
      automatic:
        limit: 1
 
- # We use the tag that triggered the pipeline here. Normally, this isn't very resilient,
- # but in 'scripts/sync-bottle-hashes.sh' it's only used for informational purposes
+ # We use the tag that triggered the pipeline here.
+ # However, this requires that the tag and the release name are the same, which
+ # in practice it's always the case in this repo.
  - label: Add Big Sur bottle hashes to formulae
    depends_on:
    - "build-bottles-big-sur-arm64"
    - "build-bottles-big-sur-x86_64"
    if: build.tag =~ /^v.*/
-   soft_fail: true # No artifacts to download if all the bottles are already built
    commands:
    - mkdir -p "Big Sur"
-   - buildkite-agent artifact download "*bottle.tar.gz" "Big Sur/"
+   - nix develop .#buildkite -c gh release download "$BUILDKITE_TAG" -D "Big Sur/" -p "*big_sur.bottle.tar.gz"
    - nix develop .#autorelease -c ./scripts/sync-bottle-hashes.sh "$BUILDKITE_TAG" "Big Sur"


### PR DESCRIPTION
## Description

Problem: when some bottles are build but then the step fails, the build restarts
without re-building the existing bottles.
This causes issues because we pick the bottles from the job's artifacts and we
only receive those from the second run of the job.

Solution: we take the BigSur bottles (after all have been built) from the GitHub
release where they have already been uploaded.

## Related issue(s)

Resolves #539 

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
