### PR TITLE
[Chore] Complement ubuntu build deps

### DIFF
--- a/docker/package/package_generator.py
+++ b/docker/package/package_generator.py
@@ -244,10 +244,11 @@ def build_ubuntu(args):
             if isinstance(package, TezosBinaryPackage)
             else []
         )
+        common_deps = build_deps + run_deps
         build_ubuntu_package(
             package,
             distributions,
-            build_deps,
+            common_deps,
             run_deps,
             is_source,
             getattr(package, "source_archive", None),


### PR DESCRIPTION

## Description

Problem: Since `9b9cfbb`, ubuntu packages got
runtime deps installed correctly. But they were
excluded from the build deps, though they still
have to be around during build.

Solution: Supply runtime deps as build deps too.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
