### PR TITLE
[Chore] v18.0-rc1 hotfixes

### DIFF
--- a/docker/package/scripts/build-binary.sh
+++ b/docker/package/scripts/build-binary.sh
@@ -14,18 +14,14 @@ binary_name="$2"
 cd tezos
 opam init local ../opam-repository --bare --disable-sandboxing
 opam switch create . --repositories=local --no-install
-eval "$(opam env)"
-opams=()
-while IFS=  read -r -d $'\0'; do
-    # we exclude optional development packages
-    if [ "$REPLY" != "./opam/virtual/octez-dev-deps.opam" ]; then
-        opams+=("$REPLY")
-    fi
-done < <(find ./vendors ./src ./tezt ./opam -name \*.opam -print0)
-export CFLAGS="-fPIC ${CFLAGS:-}"
-opam install "${opams[@]}" --deps-only --criteria="-notuptodate,-changed,-removed"
-eval "$(opam env)"
 
+eval "$(opam env)"
+OPAMASSUMEDEPEXTS=true opam install conf-rust conf-rust-2021
+
+export CFLAGS="-fPIC ${CFLAGS:-}"
+opam install opam/virtual/octez-deps.opam --deps-only --criteria="-notuptodate,-changed,-removed"
+
+eval "$(opam env)"
 dune build "$dune_filepath"
 cp "./_build/default/$dune_filepath" "../$binary_name"
 cd ..

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       path = inputs.tezos;
       name = "tezos";
       # we exclude optional development packages
-      filter = path: _: baseNameOf path != "octez-dev-deps.opam";
+      filter = path: _: !(builtins.elem (baseNameOf path) [ "octez-dev-deps.opam" "tezos-time-measurement.opam" ]);
     };
     sources = { inherit tezos; inherit (inputs) opam-repository; };
 

--- a/meta.json
+++ b/meta.json
@@ -1,5 +1,5 @@
 {
-  "release": "2",
+  "release": "1",
   "maintainer": "Serokell <hi@serokell.io>",
   "tezos_ref": "v18.0-rc1"
 }

--- a/nix/build/ocaml-overlay.nix
+++ b/nix/build/ocaml-overlay.nix
@@ -13,7 +13,6 @@ with opam-nix.lib.${self.system}; let
   octezSourcesResolved =
     self.runCommand "resolve-octez-sources" {} ''
       cp --no-preserve=all -Lr ${sources.tezos} $out
-      cp ${./tezos-event-logging.opam} $out/opam/tezos-event-logging.opam
     '';
   octezScope = buildOpamProject' {
     repos = with sources; [opam-repository];

--- a/nix/build/tezos-event-logging.opam
+++ b/nix/build/tezos-event-logging.opam
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2023 Oxhead Alpha
-# SPDX-License-Identifier: LicenseRef-MIT-OA
-opam-version: "2.0"
-build: [
-  ["rm" "-r" "vendors"]
-  ["dune" "build" "-p" name "-j" jobs]
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
-]


### PR DESCRIPTION
## Description

Native packages binary build seem to be broken too, the same reason as the nix build's one. 
The reason is we recursively search for `opam` files in the `tezos` repo and try to use them all. We exclude `octez-dev-deps.opam`, but one more file now should be excluded for the correct build.

Regarding native builds, there is no need to search all opam files recursively at all. All deps are located in one opam file. Commands for binary build are taken from the `tezos` Makefile scripts.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
