### PR TITLE
[Chore] Utilize OCTEZ_EXECUTABLES env var

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -19,7 +19,7 @@ Static binaries building using custom alpine image.
 image defined in [Dockerfile](build/Dockerfile). In order to build them you should specify
 `OCTEZ_VERSION` env variable and run the script:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 ./docker-static-build.sh
 ```
 After that, directory will contain built static binaries.
@@ -32,7 +32,7 @@ one can build native binaries for current architecture or build `aarch64` binari
 In order to build only specific binaries, or experimental/dev ones, you should specify
 `OCTEZ_EXECUTABLES` env variable:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 export OCTEZ_EXECUTABLES="octez-smart-rollup-wasm-debugger octez-protocol-compiler octez-dal-node"
 ./docker-static-build.sh
 ```
@@ -92,7 +92,7 @@ To see all available options, run:
 In order to build binary `.deb` packages specify `OCTEZ_VERSION` and
 run the following command:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os ubuntu --type binary
 ```
 
@@ -101,14 +101,14 @@ It is also possible to specify packages to build with `-p` or `--packages` optio
 ```
 # cd .. && ./docker/package.py -os ubuntu --type binary --packages <tezos-binary-1> <tezos-binary-2>
 # Example for baker
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os ubuntu --type binary -p tezos-client tezos-node
 ```
 
 In order to choose specific ubuntu distribution to build for (see [support policy](../docs/support-policy.md)),
 use `-d` or `--distributions` option:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os ubuntu --type binary -d focal jammy -p tezos-client tezos-node
 ```
 
@@ -126,7 +126,7 @@ sudo apt install <path to deb file>
 
 In order to build source packages run the following commands:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os ubuntu --type source
 # you can also build single source package
 cd .. && ./docker/package.py --os ubuntu --type source --packages tezos-client
@@ -145,7 +145,7 @@ the submitter info and signed.
 
 If you want to sign resulted source packages automatically, you can provide signer identity through `--gpg-sign` or `-s` option:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os ubuntu --type source -d focal jammy -p tezos-client -s <signer_info>
 ```
 For example, `signer_info` can be the following: `Roman Melnikov <roman.melnikov@serokell.io>`
@@ -219,7 +219,7 @@ To see all available options, run:
 In order to build binary `.rpm` packages specify `OCTEZ_VERSION` and
 run the following command:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os fedora --type binary
 ```
 
@@ -227,14 +227,14 @@ It is also possible to specify packages to build with `-p` or `--packages` optio
 ```
 # cd .. && ./docker/package.py --os fedora --type binary --packages <tezos-binary-1> <tezos-binary-2>
 # Example for baker
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os fedora --type binary -p tezos-client tezos-node
 ```
 
 In order to build packages for specific Fedora distribution (see [support policy](../docs/support-policy.md)),
 use `-d` or `--distributions` option:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os fedora -d 38 --type binary -p tezos-baking
 ```
 
@@ -255,7 +255,7 @@ sudo dnf install <path to rpm file>
 
 In order to build source packages run the following commands:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os fedora --type source
 # you can also build single source package
 cd .. && ./docker/package.py --os fedora --type source -p tezos-client
@@ -263,7 +263,7 @@ cd .. && ./docker/package.py --os fedora --type source -p tezos-client
 
 If you want to sign resulted source packages automatically, you can provide signer identity through `--gpg-sign` or `-s` option:
 ```
-export OCTEZ_VERSION="v14.1"
+export OCTEZ_VERSION="v17.3"
 cd .. && ./docker/package.py --os fedora --type source -p tezos-client -s <signer_info>
 ```
 For example, `signer_info` can be the following: `Roman Melnikov <roman.melnikov@serokell.io>`

--- a/docker/README.md
+++ b/docker/README.md
@@ -29,6 +29,14 @@ Currently supported architectures are: `host` and `aarch64`, so that
 one can build native binaries for current architecture or build `aarch64` binaries on
 `x86_64` machine.
 
+In order to build only specific binaries, or experimental/dev ones, you should specify
+`OCTEZ_EXECUTABLES` env variable:
+```
+export OCTEZ_VERSION="v14.1"
+export OCTEZ_EXECUTABLES="octez-smart-rollup-wasm-debugger octez-protocol-compiler octez-dal-node"
+./docker-static-build.sh
+```
+
 ### Compiling for `aarch64` on `x86_64` prerequisites
 
 Docker image defined in [`Dockerfile.aarch64`](build/Dockerfile.aarch64) uses qemu for

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -19,5 +19,6 @@ ENV OPAMYES true
 COPY ./build/build-deps.sh /build-deps.sh
 RUN /build-deps.sh
 COPY ./build/build-tezos.sh /build-tezos.sh
+ARG OCTEZ_EXECUTABLES
 RUN /build-tezos.sh
 RUN upx octez-*

--- a/docker/build/Dockerfile.aarch64
+++ b/docker/build/Dockerfile.aarch64
@@ -26,5 +26,6 @@ ENV OPAMYES true
 COPY ./build/build-deps.sh /build-deps.sh
 RUN /build-deps.sh
 COPY ./build/build-tezos.sh /build-tezos.sh
+ARG OCTEZ_EXECUTABLES
 RUN /build-tezos.sh
 RUN upx octez-*


### PR DESCRIPTION
## Description

Problem: `make static` command utilizes `OCTEZ_EXECUTABLES` variable,
which we can use to specify exact binaries to build. Also, it
could be used to build experimental or development binaries.

Solution: Let user provide `OCTEZ_EXECUTABLES` env var and pass
it to the build.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
