### PR TITLE
[Chore] Support octez-smart-rollup-wasm-debugger 

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ { id: macos-12, name: "monterey" } ]
         # we don't bottle meta-formulas that contain only services
-        formula: [tezos-accuser-PtNairob, tezos-accuser-Proxford, tezos-admin-client, tezos-baker-PtNairob, tezos-baker-Proxford, tezos-client, tezos-codec, tezos-node, tezos-signer, tezos-smart-rollup-client-PtNairob, tezos-smart-rollup-client-Proxford, tezos-smart-rollup-node-PtNairob, tezos-smart-rollup-node-Proxford, tezos-dac-client, tezos-dac-node]
+        formula: [tezos-accuser-PtNairob, tezos-accuser-Proxford, tezos-admin-client, tezos-baker-PtNairob, tezos-baker-Proxford, tezos-client, tezos-codec, tezos-node, tezos-signer, tezos-smart-rollup-client-PtNairob, tezos-smart-rollup-client-Proxford, tezos-smart-rollup-node-PtNairob, tezos-smart-rollup-node-Proxford, tezos-dac-client, tezos-dac-node, tezos-smart-rollup-wasm-debugger]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Formula/tezos-smart-rollup-wasm-debugger.rb
+++ b/Formula/tezos-smart-rollup-wasm-debugger.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+class TezosSmartRollupWasmDebugger < Formula
+  @all_bins = []
+
+  class << self
+    attr_accessor :all_bins
+  end
+  homepage "https://gitlab.com/tezos/tezos"
+
+  url "https://gitlab.com/tezos/tezos.git", :tag => "v18.0-rc1", :shallow => false
+
+  version "v18.0-rc1-1"
+
+  build_dependencies = %w[pkg-config coreutils autoconf rsync wget rustup-init cmake]
+  build_dependencies.each do |dependency|
+    depends_on dependency => :build
+  end
+
+  dependencies = %w[gmp hidapi libev tezos-sapling-params]
+  dependencies.each do |dependency|
+    depends_on dependency
+  end
+  desc "Smart contract rollup wasm debugger"
+
+  bottle do
+    root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSmartRollupWasmDebugger.version}/"
+  end
+
+  def make_deps
+    ENV.deparallelize
+    ENV["CARGO_HOME"]="./.cargo"
+    # Disable usage of instructions from the ADX extension to avoid incompatibility
+    # with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+    ENV["BLST_PORTABLE"]="yes"
+    # Here is the workaround to use opam 2.0.9 because Tezos is currently not compatible with opam 2.1.0 and newer
+    arch = RUBY_PLATFORM.include?("arm64") ? "arm64" : "x86_64"
+    system "curl", "-L", "https://github.com/ocaml/opam/releases/download/2.0.9/opam-2.0.9-#{arch}-macos", "--create-dirs", "-o", "#{ENV["HOME"]}/.opam-bin/opam"
+    system "chmod", "+x", "#{ENV["HOME"]}/.opam-bin/opam"
+    ENV["PATH"]="#{ENV["HOME"]}/.opam-bin:#{ENV["PATH"]}"
+    system "rustup-init", "--default-toolchain", "1.64.0", "-y"
+    system "opam", "init", "--bare", "--debug", "--auto-setup", "--disable-sandboxing"
+    system ["source .cargo/env",  "make build-deps"].join(" && ")
+  end
+
+  def install_template(dune_path, exec_path, name)
+    bin.mkpath
+    self.class.all_bins << name
+    system ["eval $(opam env)", "dune build #{dune_path}", "cp #{exec_path} #{name}"].join(" && ")
+    bin.install name
+    ln_sf "#{bin}/#{name}", "#{bin}/#{name.gsub("octez", "tezos")}"
+  end
+
+  def install
+    make_deps
+    install_template "src/bin_wasm_debugger/main_wasm_debugger.exe",
+                     "_build/default/src/bin_wasm_debugger/main_wasm_debugger.exe",
+                     "octez-smart-rollup-wasm-debugger"
+  end
+end

--- a/docker/docker-static-build.sh
+++ b/docker/docker-static-build.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 if [ -z ${OCTEZ_EXECUTABLES+x} ]; then
 
-    binaries=("octez-admin-client" "octez-dac-client" "octez-dac-node" "octez-client" "octez-node" "octez-signer" "octez-codec")
+    binaries=("octez-admin-client" "octez-dac-client" "octez-dac-node" "octez-client" "octez-node" "octez-signer" "octez-codec" "octez-smart-rollup-wasm-debugger")
 
     for proto in $(jq -r ".active | .[]" ../protocols.json); do
         binaries+=("octez-accuser-$proto" "octez-baker-$proto" "octez-smart-rollup-client-$proto" "octez-smart-rollup-node-$proto")

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -192,6 +192,14 @@ packages = [
             dune_filepath="src/bin_dac_node/main_dac.exe",
         )
     },
+    {
+        "tezos-smart-rollup-wasm-debugger": TezosBinaryPackage(
+            "tezos-smart-rollup-wasm-debugger",
+            "Smart contract rollup wasm debugger",
+            meta=packages_meta,
+            dune_filepath="src/bin_wasm_debugger/main_wasm_debugger.exe",
+        )
+    },
 ]
 
 

--- a/nix/build/release-binaries.nix
+++ b/nix/build/release-binaries.nix
@@ -43,6 +43,11 @@ in [
     description = "A client to decode and encode JSON";
     supports = protocolsFormatted;
   }
+  {
+    name = "octez-smart-rollup-wasm-debugger";
+    description = "Smart contract rollup wasm debugger";
+    supports = protocolsFormatted;
+  }
 ] ++ builtins.concatMap (protocol: [
   {
     name = "octez-baker-${protocol}";

--- a/scripts/build-all-bottles.sh
+++ b/scripts/build-all-bottles.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 retval="0"
 
 # we don't bottle meta-formulas that contain only services
-formulae=("tezos-accuser-PtNairob" "tezos-accuser-Proxford" "tezos-admin-client" "tezos-baker-PtNairob" "tezos-baker-Proxford" "tezos-client" "tezos-codec" "tezos-node" "tezos-signer" "tezos-smart-rollup-client-PtNairob" "tezos-smart-rollup-client-Proxford" "tezos-smart-rollup-node-PtNairob" "tezos-smart-rollup-node-Proxford" "tezos-dac-client" "tezos-dac-node")
+formulae=("tezos-accuser-PtNairob" "tezos-accuser-Proxford" "tezos-admin-client" "tezos-baker-PtNairob" "tezos-baker-Proxford" "tezos-client" "tezos-codec" "tezos-node" "tezos-signer" "tezos-smart-rollup-client-PtNairob" "tezos-smart-rollup-client-Proxford" "tezos-smart-rollup-node-PtNairob" "tezos-smart-rollup-node-Proxford" "tezos-dac-client" "tezos-dac-node" "tezos-smart-rollup-wasm-debugger")
 
 # tezos-sapling-params is used as a dependency for some of the formulas
 # so we handle it separately.


### PR DESCRIPTION
## Description

There is a demand for octez-smart-rollup-wasm-debugger to be included into release.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
