### PR TITLE
[#714] Improve ledger prompts

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -709,6 +709,12 @@ block timestamp: {timestamp} ({time_ago})
 
                 if self.config["key_import_mode"] == "ledger":
                     try:
+                        print(
+                            color(
+                                "Waiting for your respond to the prompt on your Ledger Device...",
+                                color_green,
+                            )
+                        )
                         proc_call(
                             f"sudo -u tezos {suppress_warning_text} octez-client {tezos_client_options} "
                             f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
@@ -727,6 +733,13 @@ block timestamp: {timestamp} ({time_ago})
         print()
         tezos_client_options = self.get_tezos_client_options()
         baker_alias = self.config["baker_alias"]
+        if self.config["key_import_mode"] == "ledger":
+            print(
+                color(
+                    "Waiting for your respond to the prompt on your Ledger Device...",
+                    color_green,
+                )
+            )
         proc_call(
             f"sudo -u tezos {suppress_warning_text} octez-client {tezos_client_options} "
             f"register key {baker_alias} as delegate"

--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -714,7 +714,11 @@ block timestamp: {timestamp} ({time_ago})
                             f"setup ledger to bake for {baker_alias} --main-hwm {self.get_current_head_level()}"
                         )
                         baker_set_up = True
-                    except PermissionError:
+                    except Exception as e:
+                        print("Something went wrong when calling octez-client:")
+                        print(str(e))
+                        print()
+                        print("Please check your input and try again.")
                         print("Going back to the import mode selection.")
                 else:
                     baker_set_up = True

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -271,9 +271,17 @@ class Setup:
                 else:
                     print(f"Please open the Tezos {ledger_app} app on your ledger or")
                     print("press Ctrl+C to go back to the key import mode selection.")
+                    print(
+                        color(
+                            "Waiting for the Ledger Device to appear...", color_green
+                        ),
+                        end="",
+                        flush=True,
+                    )
                     ledgers_derivations = wait_for_ledger_app(
                         ledger_app, self.config["client_data_dir"]
                     )
+                    print()
                     if ledgers_derivations is None:
                         print("Going back to the import mode selection.")
                         continue
@@ -318,6 +326,13 @@ class Setup:
                                     )
                         else:
                             baker_ledger_url = self.config["ledger_derivation"]
+
+                    print(
+                        color(
+                            "Waiting for your respond to the prompt on your Ledger Device...",
+                            color_green,
+                        )
+                    )
                     proc_call(
                         f"sudo -u tezos {suppress_warning_text} octez-client {tezos_client_options} "
                         f"import secret key {baker_alias} {baker_ledger_url} --force"


### PR DESCRIPTION
## Description

Problem: The setup wizard support a setup with a Ledger device. It often
isn't clear from the wizard itself, however, when an action is expected
from the user, which leads to unnecessary waiting and/or confusion.

Solution: Add visible prompts that an action from user is expected.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
