### PR TITLE
[Chore] Set correct `only_changes` field for steps

### DIFF
--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -170,7 +170,7 @@ steps:
    commands:
    - eval "$SET_VERSION"
    - buildkite-agent artifact download "docker/octez-*" . --step build-via-docker
-   - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --os ubuntu --type binary --binaries-dir docker --distributions focal
+   - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --type binary --binaries-dir docker --distributions focal
    artifact_paths:
     - ./out/*
    only_changes: *ubuntu_native_packaging_changes_regexes

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -60,7 +60,8 @@ steps:
    agents:
      queue: "docker"
    only_changes: &static_binaries_changes_regexes
-   - docker/build/.*
+   - docker/build/.*.sh
+   - docker/build/Dockerfile
    - docker/docker-static-build.sh
    - meta.json
    - protocols.json
@@ -106,12 +107,14 @@ steps:
    timeout_in_minutes: 60
    agents:
      queue: "docker"
-   only_changes: &native_packaging_changes_regexes
+   only_changes: &ubuntu_native_packaging_changes_regexes
    - docker/package/.*
    - docker/build/ubuntu/build.py
    - docker/build/util/build.py
+   - docker/baking/.*
    - meta.json
    - protocols.json
+
  - label: test deb binary packages via docker
    commands:
    - eval "$SET_VERSION"
@@ -124,7 +127,8 @@ steps:
    timeout_in_minutes: 240
    agents:
      queue: "docker"
-   only_changes: *native_packaging_changes_regexes
+   only_changes: *ubuntu_native_packaging_changes_regexes
+
  - label: test rpm source packages via docker
    commands:
    - eval "$SET_VERSION"
@@ -135,7 +139,14 @@ steps:
    timeout_in_minutes: 60
    agents:
      queue: "docker"
-   only_changes: *native_packaging_changes_regexes
+   only_changes: &fedora_native_packaging_changes_regexes
+   - docker/package/.*
+   - docker/build/fedora/build.py
+   - docker/build/util/build.py
+   - docker/baking/.*
+   - meta.json
+   - protocols.json
+
  - label: test rpm binary packages via docker
    commands:
    - eval "$SET_VERSION"
@@ -148,7 +159,7 @@ steps:
    timeout_in_minutes: 180
    agents:
      queue: "docker"
-   only_changes: *native_packaging_changes_regexes
+   only_changes: *fedora_native_packaging_changes_regexes
 
  - label: build deb packages with static binaries
    key: build-static-deb
@@ -162,7 +173,7 @@ steps:
    - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --os ubuntu --type binary --binaries-dir docker --distributions focal
    artifact_paths:
     - ./out/*
-   only_changes: *native_packaging_changes_regexes
+   only_changes: *ubuntu_native_packaging_changes_regexes
 
  - label: test gen_systemd_service_file.py script
    commands:
@@ -180,7 +191,9 @@ steps:
    key: test-systemd-services
    depends_on:
     - "build-static-deb"
-   only_changes: *native_packaging_changes_regexes
+   only_changes:
+   - :<< *ubuntu_native_packaging_changes_regexes
+   - tests/systemd/.*
    agents:
      queue: "default"
    commands:


### PR DESCRIPTION
## Description

Problem: listed `only_changes` files that trigger pipeline steps are outdated.

Solution: Update them.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
