### PR TITLE
[#725] Fix reference to config

### DIFF
--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -429,7 +429,7 @@ class Setup(Setup):
 
         # if a ledger is used for baking, ask to open Tezos Wallet app on it before proceeding
         if self.check_ledger_use():
-            wait_for_ledger_app("Wallet", config["client_data_dir"])
+            wait_for_ledger_app("Wallet", self.config["client_data_dir"])
 
         # process 'tezos-client show voting period'
         self.fill_voting_period_info()
@@ -458,7 +458,7 @@ class Setup(Setup):
         # if a ledger was used for baking on this machine, ask to open Tezos Baking app on it,
         # then restart the relevant baking service (due to issue: tezos/#4486)
         if self.config.get("is_local_baking_setup", False) and self.check_ledger_use():
-            wait_for_ledger_app("Baking", config["client_data_dir"])
+            wait_for_ledger_app("Baking", self.config["client_data_dir"])
             net = self.config["network"]
             print(f"Restarting local {net} baking setup")
             proc_call(f"sudo systemctl restart tezos-baking-{net}.service")


### PR DESCRIPTION
## Description

Problem: Reference to `config` wasn't qualified with `self`, resulting in exception.

Solution: Qualify it properly.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #725

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
