### PR TITLE
[#728] Expand tilde char in user provided path

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -12,6 +12,7 @@ import os, sys, shutil
 import readline
 import re
 import traceback
+import time
 import urllib.request
 import json
 from typing import List
@@ -574,6 +575,8 @@ block timestamp: {timestamp} ({time_ago})
             for name, url in default_providers.items():
                 self.get_snapshot_metadata(name, url)
 
+            os.makedirs(TMP_SNAPSHOT_LOCATION, exist_ok=True)
+
         else:
             return
 
@@ -589,7 +592,11 @@ block timestamp: {timestamp} ({time_ago})
                     return
                 elif self.config["snapshot_mode"] == "file":
                     self.query_step(snapshot_file_query)
-                    snapshot_file = self.config["snapshot_file"]
+                    snapshot_file = os.path.join(
+                        TMP_SNAPSHOT_LOCATION, f"file-{time.time()}.snapshot"
+                    )
+                    # not copying since it can take a lot of time
+                    os.link(self.config["snapshot_file"], snapshot_file)
                 elif self.config["snapshot_mode"] == "direct url":
                     self.query_step(snapshot_url_query)
                     url = self.config["snapshot_url"]

--- a/baking/src/tezos_baking/validators.py
+++ b/baking/src/tezos_baking/validators.py
@@ -38,9 +38,9 @@ def dirpath(input):
 
 
 def filepath(input):
-    if input and not os.path.isfile(input):
+    if input and not os.path.isfile(os.path.expanduser(input)):
         raise ValueError("Please input a valid file path.")
-    return input
+    return os.path.expanduser(input)
 
 
 def reachable_url(suffix=None):


### PR DESCRIPTION
## Description

Problem: User provided paths with tilde char does not
pass the validation check.

Solution: Expand tilde char to the home directory.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #728 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
