### PR TITLE
[#732] Fix typo in 'tezos-setup' prompt

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -863,7 +863,7 @@ block timestamp: {timestamp} ({time_ago})
                     try:
                         print(
                             color(
-                                "Waiting for your respond to the prompt on your Ledger Device...",
+                                "Waiting for your response to the prompt on your Ledger Device...",
                                 color_green,
                             )
                         )
@@ -888,7 +888,7 @@ block timestamp: {timestamp} ({time_ago})
         if self.config["key_import_mode"] == "ledger":
             print(
                 color(
-                    "Waiting for your respond to the prompt on your Ledger Device...",
+                    "Waiting for your response to the prompt on your Ledger Device...",
                     color_green,
                 )
             )

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -329,7 +329,7 @@ class Setup:
 
                     print(
                         color(
-                            "Waiting for your respond to the prompt on your Ledger Device...",
+                            "Waiting for your response to the prompt on your Ledger Device...",
                             color_green,
                         )
                     )


### PR DESCRIPTION
Problem: There is a typo in 'tezos-setup' prompt
message.

Solution: Fix the typo.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #732

#### Related changes (conditional)

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
