### PR TITLE
[#734] Do not add udev rules in k8s environment

### DIFF
--- a/docker/package/scripts/udev-rules
+++ b/docker/package/scripts/udev-rules
@@ -8,8 +8,10 @@
 
 # Don't add udev rules in case the package is installed inside either docker or podman container.
 # Otherwise, post-installation script will fail due to inability to non-zero exit code of the
-# 'udevadm control --reload-rules' call
-if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ] ; then
+# 'udevadm control --reload-rules' call.
+# Since containers orchestrated by Kubernetes don't contain any indicator files, check k8s-specific
+# env var.
+if [ ! -f /.dockerenv ] && [ ! -f /.containerenv ] && [ -z "${KUBERNETES_SERVICE_HOST++}" ] ; then
     cat <<EOF > /etc/udev/rules.d/20-hw1.rules
 # HW.1 / Nano
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2581", ATTRS{idProduct}=="1b7c|2b7c|3b7c|4b7c", TAG+="uaccess", TAG+="udev-acl", MODE="0660", GROUP="plugdev"


### PR DESCRIPTION
## Description

Problem: Post-install script adding udev rules will fail running in container environement and it has checks for it. It doesn't cover all cases though. Specifically, it does not recognize running in k8s environment. According to the
[docs](https://kubernetes.io/docs/tutorials/services/connect-applications-service/#environment-variables) k8s always export `KUBERNETES_SERVICE_HOST` variable.

Solution: Check if `KUBERNETES_SERVICE_HOST` variable is set.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
