### PR TITLE
[#735] Set BLST_PORTABLE env var on correct stage

### DIFF
--- a/docker/build/build-deps.sh
+++ b/docker/build/build-deps.sh
@@ -6,8 +6,5 @@
 set -euo pipefail
 
 source "$HOME/.cargo/env"
-# Disable usage of instructions from the ADX extension to avoid incompatibility
-# with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
-export BLST_PORTABLE="yes"
 opam init --bare --disable-sandboxing
 make build-deps

--- a/docker/build/build-tezos.sh
+++ b/docker/build/build-tezos.sh
@@ -8,5 +8,8 @@
 set -euo pipefail
 
 eval "$(opam env)"
+# Disable usage of instructions from the ADX extension to avoid incompatibility
+# with old CPUs, see https://gitlab.com/dannywillems/ocaml-bls12-381/-/merge_requests/135/
+export BLST_PORTABLE="yes"
 make static
 chmod +w octez-*


### PR DESCRIPTION
## Description

Problem: Since
[!8631](https://gitlab.com/tezos/tezos/-/merge_requests/8631), ocaml-bls12-381 library was moved into tezos/tezos tree, so BLST_PORTABLE set for deps build was ignored.

Solution: Set it for tezos build.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
