### PR TITLE
[#729] Introduce better prompts for `tezos-vote`

### DIFF
--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -513,6 +513,7 @@ class Setup(Setup):
 
         print()
         print("Thank you for voting!")
+        logging.info("Exiting the Tezos Voting Wizard.")
 
 
 def main():

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -139,7 +139,6 @@ ballot_outcome_query = Step(
 def get_node_rpc_endpoint_query(network, default=None):
     url_path = "chains/main/blocks/head/header"
     node_is_alive = lambda host: url_is_reachable(mk_full_url(host, url_path))
-    custom_url_validator = validators.reachable_url(url_path)
 
     relevant_nodes = {
         url: provider
@@ -160,7 +159,7 @@ def get_node_rpc_endpoint_query(network, default=None):
                 validators.required_field,
                 validators.any_of(
                     validators.enum_range(relevant_nodes),
-                    validators.custom_url,
+                    validators.reachable_url(url_path),
                 ),
             ]
         ),

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -77,7 +77,12 @@ Type in 'exit' to quit.
 def wait_for_ledger_app(app_name, client_dir):
     logging.info(f"Waiting for the ledger {app_name} app to be opened")
     print(f"Please make sure the Tezos {app_name} app is open on your ledger.")
-    print()
+    print(
+        color(
+            f"Waiting for the Tezos {app_name} app to be opened...",
+            color_green,
+        )
+    )
     search_string = b"Found a Tezos " + bytes(app_name, "utf8")
     output = b""
     while re.search(search_string, output) is None:
@@ -337,6 +342,13 @@ class Setup(Setup):
             hash_to_submit = self.config["new_proposal_hash"]
 
         logging.info("Submitting proposals")
+        if self.check_ledger_use():
+            print(
+                color(
+                    "Waiting for your response to the prompt on your Ledger Device...",
+                    color_green,
+                )
+            )
         result = get_proc_output(
             f"sudo -u tezos {suppress_warning_text} octez-client {self.config['tezos_client_options']} "
             f"submit proposals for {self.config['baker_alias']} {hash_to_submit}"
@@ -400,6 +412,13 @@ class Setup(Setup):
         self.query_step(ballot_outcome_query)
 
         logging.info("Submitting ballot")
+        if self.check_ledger_use():
+            print(
+                color(
+                    "Waiting for your response to the prompt on your Ledger Device...",
+                    color_green,
+                )
+            )
         result = get_proc_output(
             f"sudo -u tezos {suppress_warning_text} octez-client {self.config['tezos_client_options']} "
             f"submit ballot for {self.config['baker_alias']} {self.config['proposal_hashes'][0]} "

--- a/baking/src/tezos_baking/util.py
+++ b/baking/src/tezos_baking/util.py
@@ -9,6 +9,7 @@ import sys, subprocess, shlex
 import re
 import urllib.request
 import json
+import os
 
 # Regexes
 

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -313,7 +313,8 @@ class Setup:
                     print("press Ctrl+C to go back to the key import mode selection.")
                     print(
                         color(
-                            "Waiting for the Ledger Device to appear...", color_green
+                            f"Waiting for the Tezos {ledger_app} to be opened...",
+                            color_green,
                         ),
                         end="",
                         flush=True,

--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -217,7 +217,7 @@ def mk_node_unit(
             part_of=[f"tezos-baking-{dependencies_suffix}.service"],
         ),
         Service(
-            environment_files=[f"/etc/default/tezos-node-{suffix}"],
+            environment_files=[f"/etc/default/tezos-node-{dependencies_suffix}"],
             exec_start="/usr/bin/tezos-node-start",
             exec_start_pre=["/usr/bin/tezos-node-prestart"],
             timeout_start_sec="2400s",

--- a/docs/voting-test.md
+++ b/docs/voting-test.md
@@ -11,79 +11,102 @@ amendment periods.
 ## Prerequisites
 
 1) Install `tezos-baking` package should on your system.
-2) Clone [local-chain repository](https://gitlab.com/morley-framework/local-chain).
+2) Create a temporary directory where the node's data directory and the local-chain will reside:
+
+```bash
+mkdir -m 777 /tmp/voting
+cd /tmp/voting
+git clone https://gitlab.com/morley-framework/local-chain
+```
 
 ## Test scenario workflow
 
 1) Generate a pair of keys associated with `baker` alias:
 
-```bash
-sudo -u tezos tezos-client gen keys baker
-```
+    ```bash
+    sudo -u tezos tezos-client gen keys baker
+    ```
+
+    If you want to use your ledger device for voting, you should import its encrypted private key instead:
+
+    First, run this command:
+
+    ```
+    sudo -u tezos tezos-client list connected ledgers
+    ```
+
+    This will display some instructions to import the Ledger encrypted private key. Then run
+
+    ```
+    sudo -u tezos tezos-client import secret key baker ledger://XXXXXXXXXX
+    ```
+
+    And confirm providing the public key using the prompt on the ledger device.
 
 2) In a separate terminal start a [voting scenario script](https://gitlab.com/morley-framework/local-chain#voting-scenario) from the local-chain repo.
 
-This script will provide you a path to the node config that will be used by the custom baking service.
+    This script will provide you a path to the node config that will be used by the custom baking service.
 
 3) Provide address generated on the first step to the `voting.py` script. This address will receive some amount of XTZ.
 
-4) Create a config for the custom baking service that will be used by the voting wizard:
+4) Create environment files for the custom baking service that will be used by the voting wizard:
 
-```bash
-sudo cp /etc/default/tezos-baking-custom@ /etc/default/tezos-baking-custom@voting
-```
+    ```bash
+    sudo cp /etc/default/tezos-node-custom@ /etc/default/tezos-node-custom@voting
+    sudo cp /etc/default/tezos-baking-custom@ /etc/default/tezos-baking-custom@voting
+    ```
 
-Edit with the config provided by the voting script on the second step:
+    Edit the node environment file with the config provided by the voting script on the second step:
 
-```
-DATA_DIR="/var/lib/tezos/.tezos-client"
-NODE_RPC_ADDR="http://localhost:8732"
-BAKER_ADDRESS_ALIAS="baker"
-CUSTOM_NODE_CONFIG="<paste your path to the node config here>"
-RESET_ON_STOP=""
-LIQUIDITY_BAKING_TOGGLE_VOTE="pass"
-```
+    ```
+    NODE_RPC_ADDR="127.0.0.1:8732"
+    CERT_PATH=""
+    KEY_PATH=""
+    TEZOS_NODE_DIR=/tmp/voting/node-custom
+    CUSTOM_NODE_CONFIG=/tmp/voting/local-chain/voting-config.json
+    RESET_ON_STOP=""
+    ```
 
-Additionally, you can set `RESET_ON_STOP="true"` to enable automatic node directory removal which will
-be triggered once custom baking service will be stopped.
+    Additionally, you can set `RESET_ON_STOP="true"` to enable automatic node directory removal which will
+    be triggered once custom baking service will be stopped.
 
 5) Start custom baking service:
 
-```bash
-sudo systemctl start tezos-baking-custom@voting
-```
+    ```bash
+    sudo systemctl start tezos-baking-custom@voting
+    ```
 
-Note that `tezos-node` service may take some time to generate a fresh identity and start.
+    Note that `tezos-node` service may take some time to generate a fresh identity and start.
 
-To check the status of the node service run:
+    To check the status of the node service run:
 
-```bash
-systemctl status tezos-node-custom@voting
-```
+    ```bash
+    systemctl status tezos-node-custom@voting
+    ```
 
 6) Register `baker` key as delegate once `tezos-node` is up and running:
 
-```bash
-sudo -u tezos tezos-client register key baker as delegate
-```
+    ```bash
+    sudo -u tezos tezos-client register key baker as delegate
+    ```
 
 7) After that `voting.py` will start going through the voting cycle.
 
-The script will stop at the beginning of each voting period that requires voting and ask you to vote.
+    The script will stop at the beginning of each voting period that requires voting and ask you to vote.
 
-Launch the wizard by running:
+    Launch the wizard by running:
 
-```bash
-tezos-vote --network voting
-```
+    ```bash
+    tezos-vote --network voting
+    ```
 
-Under normal conditions, you won't have to adjust any information about your baking service.
-Confirm the information and submit your vote.
+    Under normal conditions, you won't have to adjust any information about your baking service.
+    Confirm the information and submit your vote.
 
-Once you'll vote, you should prompt the `voting.py` script to continue going through the voting cycle.
+    Once you'll vote, you should prompt the `voting.py` script to continue going through the voting cycle.
 
 8) Stop custom baking service once voting cycle is over:
 
-```bash
-sudo systemctl stop tezos-baking-custom@voting
-```
+    ```bash
+    sudo systemctl stop tezos-baking-custom@voting
+    ```


### PR DESCRIPTION
## Description

Problem: Currently, `tezos-vote` does not provide
adequate user prompts and feedback when used with
ledger devices.

Solution: Provide visible prompts requesting action from user.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #729

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
