### PR TITLE
[#705] Better show the error logs of the wizards

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -11,7 +11,6 @@ Asks questions, validates answers, and executes the appropriate steps using the 
 import os, sys, shutil
 import readline
 import re
-import traceback
 import time
 import urllib.request
 import json
@@ -1063,12 +1062,14 @@ def main():
                 + setup.config["network"]
                 + ".service"
             )
-        logging.error(f"{str(e)}")
-        print_and_log("Error in Tezos Setup Wizard, exiting.")
-        logfile = "tezos_setup.log"
-        with open(logfile, "a") as f:
-            f.write(traceback.format_exc() + "\n")
-        print("The error has been logged to", os.path.abspath(logfile))
+
+        message = "Error in the Tezos Setup Wizard, exiting."
+        print("\n" + color(message, color_red))
+        logging.error(message)
+
+        log_exception(exception=e, logfile="tezos-setup.log")
+
+        logging.info("Exiting the Tezos Setup Wizard.")
         sys.exit(1)
 
 

--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -600,37 +600,31 @@ class Setup(Setup):
             snapshot_metadata = self.extract_relevant_snapshot(snapshot_array)
 
             if snapshot_metadata is None:
-                message = f"No suitable snapshot found from the {name} provider."
-                print(
-                    color(
-                        message,
-                        color_red,
-                    )
+                print_and_log(
+                    f"No suitable snapshot found from the {name} provider.",
+                    log=logging.warning,
+                    colorcode=color_yellow,
                 )
-                logging.warning(message)
             else:
                 self.config["snapshots"][name] = snapshot_metadata
 
         except urllib.error.URLError:
-            message = f"\nCouldn't collect snapshot metadata from {json_url} due to networking issues.\n"
-            print(
-                color(
-                    message,
-                    color_red,
-                )
+            print_and_log(
+                f"\nCouldn't collect snapshot metadata from {json_url} due to networking issues.\n",
+                log=logging.error,
+                colorcode=color_red,
             )
-            logging.error(message)
         except ValueError:
-            message = f"\nCouldn't collect snapshot metadata from {json_url} due to format mismatch.\n"
-            print(
-                color(
-                    message,
-                    color_red,
-                )
+            print_and_log(
+                f"\nCouldn't collect snapshot metadata from {json_url} due to format mismatch.\n",
+                log=logging.error,
+                colorcode=color_red,
             )
-            logging.error(message)
         except Exception as e:
-            print_and_log(f"\nUnexpected error handling snapshot metadata:\n{e}\n")
+            print_and_log(
+                f"\nUnexpected error handling snapshot metadata:\n{e}\n",
+                log=logging.error,
+            )
 
     def output_snapshot_metadata(self, name):
         from datetime import datetime
@@ -1063,9 +1057,11 @@ def main():
                 + ".service"
             )
 
-        message = "Error in the Tezos Setup Wizard, exiting."
-        print("\n" + color(message, color_red))
-        logging.error(message)
+        print_and_log(
+            "Error in the Tezos Setup Wizard, exiting.",
+            log=logging.error,
+            colorcode=color_red,
+        )
 
         log_exception(exception=e, logfile="tezos-setup.log")
 

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -536,13 +536,13 @@ def main():
         logging.info("Exiting the Tezos Voting Wizard.")
         sys.exit(1)
     except Exception as e:
-        print("Error in Tezos Voting Wizard, exiting.")
-        logging.error(f"{str(e)}")
+        message = "Error in the Tezos Voting Wizard, exiting."
+        print("\n" + color(message, color_red))
+        logging.error(message)
+
+        log_exception(exception=e, logfile="tezos-vote.log")
+
         logging.info("Exiting the Tezos Voting Wizard.")
-        logfile = "tezos_vote.log"
-        with open(logfile, "a") as f:
-            f.write(str(e) + "\n")
-        print("The error has been logged to", os.path.abspath(logfile))
         sys.exit(1)
 
 

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -536,9 +536,12 @@ def main():
         logging.info("Exiting the Tezos Voting Wizard.")
         sys.exit(1)
     except Exception as e:
-        message = "Error in the Tezos Voting Wizard, exiting."
-        print("\n" + color(message, color_red))
-        logging.error(message)
+
+        print_and_log(
+            "Error in the Tezos Voting Wizard, exiting.",
+            log=logging.error,
+            colorcode=color_red,
+        )
 
         log_exception(exception=e, logfile="tezos-vote.log")
 

--- a/baking/src/tezos_baking/util.py
+++ b/baking/src/tezos_baking/util.py
@@ -108,6 +108,7 @@ def color(input, colorcode):
 
 color_red = "\x1b[1;31m"
 color_green = "\x1b[1;32m"
+color_yellow = "\x1b[1;33m"
 
 
 def yes_or_no(prompt, default=None):

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -95,7 +95,7 @@ def search_json_with_default(json_filepath, field, default):
 
 
 def setup_logger(log_file):
-    log_dir = f"{os.getenv('HOME')}/.tezos-logs/"
+    log_dir = f"{os.getenv('HOME')}/.tezos-logs/.debug"
     os.makedirs(log_dir, exist_ok=True)
     log_file = os.path.join(log_dir, log_file)
     logging.basicConfig(
@@ -110,6 +110,33 @@ def setup_logger(log_file):
 def print_and_log(s, log=logging.info):
     print(s)
     log(s)
+
+
+def log_exception(exception, logfile):
+    import traceback
+    from datetime import datetime
+
+    logging.error(f"{str(exception)}")
+
+    error_output = traceback.format_exc()
+
+    print("\nHere are last 10 lines of the error output:")
+    print("\n".join(error_output.splitlines()[-9:]))
+
+    log_dir = f".tezos-logs/"
+
+    with open(os.path.join(os.getenv("HOME"), log_dir, logfile), "a") as f:
+        f.write(datetime.now().strftime("%H:%M:%S %d/%m/%Y:"))
+        f.write("\n")
+        f.write(error_output)
+        f.write("\n")
+
+    print(
+        "\nThe error has been logged to the log file:",
+        os.path.join("~", log_dir, logfile),
+    )
+    print("To see the full log, please run:")
+    print(f"> cat {os.path.join('~', log_dir, logfile)}")
 
 
 class Setup:

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -107,9 +107,9 @@ def setup_logger(log_file):
     )
 
 
-def print_and_log(s, log=logging.info):
-    print(s)
-    log(s)
+def print_and_log(message, log=logging.info, colorcode=None):
+    print(color(message, colorcode) if colorcode else message)
+    log(message)
 
 
 def log_exception(exception, logfile):


### PR DESCRIPTION
## Description

Problem: the location of the log file is unclear from the message given by the wizards. They also don't attempt to show the logs or suggest how to do it.

Solution: Show last 10 lines of the error output. Suggest how to see the full log. Separate log entries in the file by the dates.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #705 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
