### PR TITLE
[#736] Add setup to automatically update binaries

### DIFF
--- a/docker/package/meta.py
+++ b/docker/package/meta.py
@@ -25,16 +25,16 @@ class PackagesMeta:
         self.license_version = license_version
 
 
-tag = os.environ["OCTEZ_VERSION"]
-for (i, c) in enumerate(tag):
+meta_json_contents = json.load(
+    open(f"{os.path.dirname(__file__)}/../../meta.json", "r")
+)
+
+tag = os.environ.get("OCTEZ_VERSION", meta_json_contents["tezos_ref"])
+for i, c in enumerate(tag):
     if c.isdigit():
         digit_index = i
         break
 version = tag[digit_index:]
-
-meta_json_contents = json.load(
-    open(f"{os.path.dirname(__file__)}/../../meta.json", "r")
-)
 packages_meta = PackagesMeta(
     tag=tag,
     version=version,

--- a/docker/package/update-test-binaries-list.py
+++ b/docker/package/update-test-binaries-list.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2023 Oxhead Alpha
+# SPDX-License-Identifier: LicenseRef-MIT-OA
+
+import os
+import json
+from .packages import packages as all_packages
+from .meta import packages_meta
+
+binaries_json_path_suffix = "tests/binaries.json"
+
+
+def update_binaries(binaries, field):
+    binaries_json_path = os.path.join(os.environ["PWD"], binaries_json_path_suffix)
+    with open(binaries_json_path, "r") as file:
+        data = json.load(file)
+
+    data[field] = binaries
+    with open(binaries_json_path, "w") as file:
+        json.dump(data, file, indent=4)
+        file.write("\n")
+
+
+def main():
+    tag = packages_meta.tag
+    binaries = []
+    with open(f"{os.path.dirname(__file__)}/../octez-executables", "r") as f:
+        binaries = [l.strip() for l in f.readlines()]
+    if not binaries:
+        raise Exception(
+            "Exception, while reading binaries list: binaries list is empty"
+        )
+
+    field = "candidates" if "rc" in tag else "released"
+
+    update_binaries(binaries, field)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/tests/binaries.json
+++ b/docker/tests/binaries.json
@@ -1,20 +1,19 @@
 {
     "released": [
-        "tezos-smart-rollup-node",
-        "tezos-smart-rollup-wasm-debugger"
-        "tezos-baking",
-        "tezos-sapling-params",
-        "tezos-accuser-Proxford",
-        "tezos-baker-Proxford",
-        "tezos-accuser-PtNairob",
-        "tezos-baker-PtNairob",
-        "tezos-node",
-        "tezos-dac-node",
-        "tezos-dac-client",
-        "tezos-codec",
-        "tezos-signer",
-        "tezos-admin-client",
-        "tezos-client"
+        "octez-smart-rollup-wasm-debugger",
+        "octez-smart-rollup-node",
+        "octez-dac-client",
+        "octez-dac-node",
+        "octez-signer",
+        "octez-proxy-server",
+        "octez-codec",
+        "octez-client",
+        "octez-admin-client",
+        "octez-node",
+        "octez-accuser-Proxford",
+        "octez-baker-Proxford",
+        "octez-accuser-PtNairob",
+        "octez-baker-PtNairob"
     ],
     "candidates": [
         "tezos-smart-rollup-node",

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -60,6 +60,9 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
       (true; echo "letter_version wasn't reset")
 
     ./scripts/update-release-binaries.py
+    pushd docker
+    python3 -m package.update-test-binaries-list
+    popd
     git commit -a -m "[Chore] Update release binaries for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       (true; echo "lists of binaries and protocols weren't updated")
 


### PR DESCRIPTION

## Description
This PR adds a pipeline setup to update the list of binaries after every successful tag build. The script will create a followup PR with an updated list of binaries. 

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #736 

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
