### PR TITLE
[Chore] Fix ledger use condition

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -980,7 +980,11 @@ block timestamp: {timestamp} ({time_ago})
         print()
         tezos_client_options = self.get_tezos_client_options()
         baker_alias = self.config["baker_alias"]
-        if self.config["key_import_mode"] == "ledger":
+        self.config["baker_key_value"], _ = get_key_address(
+            tezos_client_options, baker_alias
+        )
+
+        if self.check_ledger_use():
             print(
                 color(
                     "Waiting for your response to the prompt on your Ledger Device...",

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -49,13 +49,6 @@ parser.add_argument(
 
 parsed_args = parser.parse_args()
 
-# Regexes
-
-ledger_regex = b"ledger:\/\/[\w\-]+\/[\w\-]+\/[\w']+\/[\w']+"
-protocol_hash_regex = (
-    b"P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}"
-)
-
 
 # Wizard CLI utility
 

--- a/baking/src/tezos_baking/tezos_voting_wizard.py
+++ b/baking/src/tezos_baking/tezos_voting_wizard.py
@@ -194,11 +194,6 @@ def get_key_mode_query(modes):
 
 
 class Setup(Setup):
-
-    # Check whether the baker_alias account is set up to use ledger
-    def check_ledger_use(self):
-        return bool(re.match(ledger_regex.decode(), self.config["baker_key_value"]))
-
     def check_baking_service(self):
         net = self.config["network"]
         try:

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -243,6 +243,10 @@ class Setup:
         )
         return str(json.load(response)["level"])
 
+    # Check whether the baker_alias account is set up to use ledger
+    def check_ledger_use(self, key=None):
+        return bool(re.match(ledger_regex.decode(), self.config["baker_key_value"]))
+
     # Check if an account with the baker_alias alias already exists, and ask the user
     # if it can be overwritten.
     def check_baker_account(self):


### PR DESCRIPTION
## Description

Problem: `key_import_mode` key was used to determine ledger use.
But in some execution paths this key never has a value.

Solution: Check ledger use with `check_ledger_use`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
