### PR TITLE
[Chore] Update "actions/checkout"

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -20,7 +20,7 @@ jobs:
         formula: [tezos-accuser-PtNairob, tezos-accuser-Proxford, tezos-admin-client, tezos-baker-PtNairob, tezos-baker-Proxford, tezos-client, tezos-codec, tezos-node, tezos-signer, tezos-smart-rollup-node, tezos-dac-client, tezos-dac-node, tezos-smart-rollup-wasm-debugger]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install GNU sed
         run: |
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload the bottle to Github Actions
         if: steps.check-built.outcome == 'failure'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: homebrew-bottles-${{ matrix.os }}
           path: '*.bottle.*'
@@ -68,7 +68,7 @@ jobs:
     needs: build-bottles
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install GNU sed
         run: |

--- a/.github/workflows/check-formulas.yml
+++ b/.github/workflows/check-formulas.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check formula syntax
         run: ruby -c ./Formula/*.rb

--- a/.github/workflows/test-binaries.yml
+++ b/.github/workflows/test-binaries.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, nix]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test fedora binaries
         run: nix develop .#buildkite -c ./docker/tests/scripts/test-fedora-binaries.sh


### PR DESCRIPTION
Problem: node16 is now deprecated and github-runner provided by nixpkgs no longer supports this runtime. However, "actions/checkout@v3" uses this runtime.

Solution: Update CI pipeline to use "actions/checkout@v4".

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
