### PR TITLE
[Chore] Supress 'git commit' non-zero exit codes in update-tezos.sh

### DIFF
--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -52,15 +52,16 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
     sed -i "s/version = .*/version = \"$latest_upstream_tag\"/" ./baking/pyproject.toml
     # Commit may fail when release number wasn't updated since the last release
     git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
-      echo "release number wasn't updated"
+      (true; echo "release number wasn't updated")
 
     sed -i 's/letter_version *= *"[a-z]"/letter_version = ""/' ./docker/package/model.py
     # Commit may fail when the letter version wasn't updated since the last release
     git commit -a -m "[Chore] Reset letter_version for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
-      echo "letter_version wasn't reset"
+      (true; echo "letter_version wasn't reset")
 
     ./scripts/update-release-binaries.py
-    git commit -a -m "[Chore] Update release binaries for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io"
+    git commit -a -m "[Chore] Update release binaries for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+      (true; echo "lists of binaries and protocols weren't updated")
 
     git push --set-upstream origin "$branch_name"
 


### PR DESCRIPTION
## Description
Problem: It's possible that release number, 'letter_version', and lists of binaries and protocols aren't going to be updated when creating a PR that introduces the new Octez version. However, 'git commit' return non-zero exit code when one attempts to commit empty diff. As a result, 'update-tezos.sh' may fail in CI.

Solution: Supress 'git commit' non-zero exit code.
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
