### PR TITLE
[OPS-1161] Harden systemd services

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,10 @@
   in pkgs-darwin.lib.recursiveUpdate
   {
       nixosModules = {
-        tezos-node = import ./nix/modules/tezos-node.nix;
-        tezos-accuser = import ./nix/modules/tezos-accuser.nix;
-        tezos-baker = import ./nix/modules/tezos-baker.nix;
-        tezos-signer = import ./nix/modules/tezos-signer.nix;
+        tezos-node = import ./nix/modules/tezos-node.nix { inherit inputs; };
+        tezos-accuser = import ./nix/modules/tezos-accuser.nix { inherit inputs; };
+        tezos-baker = import ./nix/modules/tezos-baker.nix { inherit inputs; };
+        tezos-signer = import ./nix/modules/tezos-signer.nix { inherit inputs; };
       };
 
       devShells."aarch64-darwin".autorelease-macos =

--- a/nix/modules/common.nix
+++ b/nix/modules/common.nix
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
-{ lib, pkgs, ... }:
+{ lib, pkgs, inputs, ... }:
 
 with lib;
-rec {
+let
+  inherit (inputs.serokell-nix.lib.systemd) hardeningProfiles withHardeningProfile;
+in rec {
   sharedOptions = {
 
     logVerbosity = mkOption {
@@ -46,14 +48,14 @@ rec {
     };
   };
 
-  genDaemonConfig = { instancesCfg, service-name, service-pkgs, service-start-script, service-prestart-script ? (_: "")}:
+  genDaemonConfig = { instancesCfg, service-name, service-pkgs, service-start-script, service-prestart-script ? (_: ""), extraServiceConfig ? {}}:
     mkIf (instancesCfg != {}) {
       users = mkMerge (flip mapAttrsToList instancesCfg (node-name: node-cfg: genUsers node-name ));
       systemd = mkMerge (flip mapAttrsToList instancesCfg (node-name: node-cfg:
         let octez-client = "${pkgs.octezPackages.octez-client}/bin/octez-client";
             passwordFilenameArg = if node-cfg.passwordFilename != null then "-f ${node-cfg.passwordFilename}" else "";
         in {
-          services."tezos-${node-name}-octez-${service-name}" = lib.recursiveUpdate (genSystemdService node-name node-cfg service-name) rec {
+          services."tezos-${node-name}-octez-${service-name}" = lib.recursiveUpdate (genSystemdService node-name node-cfg service-name (extraServiceConfig // {Type = "forking";})) rec {
             bindsTo = [ "network.target" "tezos-${node-name}-octez-node.service" ];
             after = bindsTo;
             path = with pkgs; [ curl ];
@@ -77,9 +79,6 @@ rec {
                 fi
               '' + service-prestart-script node-cfg;
             script = service-start-script node-cfg;
-            serviceConfig = {
-              Type = "forking";
-            };
           };
       }));
     };
@@ -89,20 +88,19 @@ rec {
     users."tezos-${node-name}" = { group = "tezos-${node-name}"; isNormalUser = true; };
   };
 
-  genSystemdService = node-name: node-cfg: service-name: {
+  genSystemdService = node-name: node-cfg: service-name: extraServiceConfig: {
     inherit (node-cfg) enable;
     wantedBy = [ "multi-user.target" ];
     description = "Octez ${service-name}";
     environment = {
       OCTEZ_LOG = "* -> ${node-cfg.logVerbosity}";
     };
-    serviceConfig = {
+    serviceConfig = withHardeningProfile hardeningProfiles.backend ({
       User = "tezos-${node-name}";
       Group = "tezos-${node-name}";
       StateDirectory = "tezos-${node-name}";
       Restart = "always";
       RestartSec = "10";
-    };
+    } // extraServiceConfig);
   };
-
 }

--- a/nix/modules/tezos-accuser.nix
+++ b/nix/modules/tezos-accuser.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
+{inputs}:
 {config, lib, pkgs, ...}:
 
 with lib;
@@ -13,7 +14,7 @@ let
       "${pkgs.octezPackages.octez-accuser-Proxford}/bin/octez-accuser-Proxford";
   };
   cfg = config.services.octez-accuser;
-  common = import ./common.nix { inherit lib; inherit pkgs; };
+  common = import ./common.nix { inherit lib pkgs inputs; };
   instanceOptions = types.submodule ( {...} : {
     options = common.daemonOptions // {
 

--- a/nix/modules/tezos-baker.nix
+++ b/nix/modules/tezos-baker.nix
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Oxhead Alpha
 # SPDX-License-Identifier: LicenseRef-MIT-OA
 
+{inputs}:
 {config, lib, pkgs, ...}:
 
 with lib;
@@ -14,7 +15,7 @@ let
   };
   octez-client = "${pkgs.octezPackages.octez-client}/bin/octez-client";
   cfg = config.services.octez-baker;
-  common = import ./common.nix { inherit lib; inherit pkgs; };
+  common = import ./common.nix { inherit lib pkgs inputs; };
   instanceOptions = types.submodule ( {...} : {
     options = common.daemonOptions // {
 
@@ -76,5 +77,8 @@ in {
       service-pkgs = octez-baker-pkgs;
       service-start-script = baker-start-script;
       service-prestart-script = baker-prestart-script;
+      extraServiceConfig = {
+        PrivateDevices = "no";
+      };
     };
 }

--- a/nix/modules/tezos-signer.nix
+++ b/nix/modules/tezos-signer.nix
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
 
+{inputs}:
 {config, lib, pkgs, ...}:
 
 with lib;
 
 let
   octez-signer-launch = "${pkgs.octezPackages.octez-signer}/bin/octez-signer launch";
-  common = import ./common.nix { inherit lib; inherit pkgs; };
+  common = import ./common.nix { inherit lib pkgs inputs; };
   cfg = config.services.octez-signer;
   instanceOptions = types.submodule ( {...} : {
     options = common.sharedOptions // {
@@ -98,7 +99,7 @@ in {
           "${octez-signer-launch} local signer --socket ${node-cfg.unixSocket}";
       };
       in {
-      services."tezos-${node-name}-octez-signer" = common.genSystemdService node-name node-cfg "signer" // {
+      services."tezos-${node-name}-octez-signer" = common.genSystemdService node-name node-cfg "signer" {} // {
         after = [ "network.target" ];
         script = ''
           ${octez-signers.${node-cfg.networkProtocol}}


### PR DESCRIPTION
Problem: We want to harden the security of our systemd services.

Solution: Use the hardening profile defined in serokell.nix.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
