### PR TITLE
[#793] Add support of stake operation

### DIFF
--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -359,7 +359,7 @@ def get_key_mode_query(modes):
         prompt="How do you want to import the baker key?",
         help="To register the baker, its secret key needs to be imported to the data "
         "directory first.\nBy default tezos-baking-<network>.service will use the 'baker' "
-        "alias\nfor the key that will be used for baking and endorsing.\n"
+        "alias\nfor the key that will be used for baking and attesting.\n"
         "If you want to test baking with a faucet file, "
         "make sure you have chosen a test network like " + list(networks.keys())[1],
         options=modes,

--- a/baking/src/tezos_baking/tezos_setup_wizard.py
+++ b/baking/src/tezos_baking/tezos_setup_wizard.py
@@ -826,9 +826,6 @@ block timestamp: {timestamp} ({time_ago})
         print()
         tezos_client_options = self.get_tezos_client_options()
         baker_alias = self.config["baker_alias"]
-        self.config["baker_key_value"], _ = get_key_address(
-            tezos_client_options, baker_alias
-        )
 
         if self.check_ledger_use():
             print(
@@ -902,6 +899,12 @@ block timestamp: {timestamp} ({time_ago})
 
             print()
             try:
+                (
+                    self.config["baker_key_value"],
+                    self.config["baker_key_hash"],
+                ) = get_key_address(
+                    self.get_tezos_client_options(), self.config["baker_alias"]
+                )
                 if not self.baker_registered():
                     print_and_log("Registering the baker")
                     self.register_baker()

--- a/baking/src/tezos_baking/validators.py
+++ b/baking/src/tezos_baking/validators.py
@@ -60,6 +60,21 @@ def required_field(input):
     return input
 
 
+def tez_bigger_than(min):
+    def _validator(input):
+        try:
+            num = float(input)
+        except:
+            raise ValueError("Please input a valid number.")
+        if num < min:
+            raise ValueError(
+                f"Number you entered is less than the minimal stake amount."
+            )
+        return input
+
+    return _validator
+
+
 # The input has to be valid to at least one of the two passed validators.
 def any_of(validator1, validator2):
     def _validator(input):

--- a/baking/src/tezos_baking/wizard_structure.py
+++ b/baking/src/tezos_baking/wizard_structure.py
@@ -308,7 +308,7 @@ class Setup:
                     logging.info("Waiting for funds to arrive")
                     print(
                         f"Before proceeding with baker registration you'll need to provide this address with some XTZ.\n"
-                        f"Note that you need at least 6000 XTZ in order to receive baking and endorsing rights.\n"
+                        f"Note that you need at least 6000 XTZ in order to receive baking and attesting rights.\n"
                         f"You can fill your address using the faucet: https://faucet.{network}.teztnets.com/.\n"
                         f"Waiting for funds to arrive... (Ctrl + C to choose another option)."
                     )

--- a/docs/baking.md
+++ b/docs/baking.md
@@ -151,7 +151,7 @@ sudo -u tezos tezos-client bootstrapped
 ```
 
 By default `tezos-baking-<network>.service` will use the `baker` alias for the
-key that will be used for baking and endorsing.
+key that will be used for baking and attesting.
 
 ### Setting the Liquidity Baking toggle vote option
 
@@ -275,7 +275,7 @@ sudo systemctl stop tezos-baking-custom@voting
 Manually resetting is possible through:
 
 1. Removing the custom chain node directory, `/var/lib/tezos/node-custom@<chain-name>` by default.
-2. Deleting `blocks`, `nonces`, and `endorsements` from the `tezos-client` data directory,
+2. Deleting `blocks`, `nonces`, and `attestations` from the `tezos-client` data directory,
   `/var/lib/tezos/.tezos-client` by default.
 
 ## Quick Start


### PR DESCRIPTION
## Description

Problem: In ParisB protocol, each baker needs to explicitly stake some
balance (minimum 600tz) to receive baking rights. In case of the bakers
that are registered in Oxford or earlier, they are staked automatically,
but this is not the case for new bakers.

Solution: Check if explicit staking is relevant for the user,
ask for a stake amount and perform staking.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #793

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
