### PR TITLE
[Chore] Fix octez tag handling

### DIFF
--- a/.buildkite/pipeline-for-tags.yml
+++ b/.buildkite/pipeline-for-tags.yml
@@ -15,7 +15,7 @@ steps:
 
  - label: Build ubuntu source packages
    key: build-ubuntu-source-packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    commands:
    - eval "$SET_VERSION"
    - nix develop .#docker-tezos-packages -c ./docker/build/ubuntu/build.py --type source
@@ -24,7 +24,7 @@ steps:
 
  - label: Build fedora source packages
    key: build-fedora-source-packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    commands:
    - eval "$SET_VERSION"
    - nix develop .#docker-tezos-packages -c ./docker/build/fedora/build.py --type source
@@ -32,7 +32,7 @@ steps:
      - ./out/*
 
  - label: Sign ubuntu source packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "build-ubuntu-source-packages"
    key: sign-ubuntu-source-packages
@@ -44,7 +44,7 @@ steps:
      - ./out/*
 
  - label: Sign fedora source packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "build-fedora-source-packages"
    key: sign-fedora-source-packages
@@ -56,7 +56,7 @@ steps:
      - ./out/*
 
  - label: Publish ubuntu native packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "sign-ubuntu-source-packages"
    commands:
@@ -65,7 +65,7 @@ steps:
    - nix develop .#buildkite -c ./docker/build/ubuntu/upload.py -d out
 
  - label: Publish fedora native packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "sign-fedora-source-packages"
    commands:
@@ -74,7 +74,7 @@ steps:
    - nix develop .#buildkite -c ./docker/build/fedora/upload.py -d out
 
  - label: build-via-docker
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    key: build-via-docker
    commands:
    - eval "$SET_VERSION"
@@ -85,7 +85,7 @@ steps:
 
  - label: Build source packages from static binaries
    key: build-source-packages-from-static-binaries
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "build-via-docker"
    commands:
@@ -98,7 +98,7 @@ steps:
 
  - label: Sign source packages built from static binaries
    key: sign-source-packages-built-from-static-binaries
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "build-source-packages-from-static-binaries"
    commands:
@@ -109,7 +109,7 @@ steps:
      - ./epel/*
 
  - label: Publish epel packages
-   if: build.tag =~ /^octez-v.*-1/
+   if: build.tag =~ /^v.*-1/
    depends_on:
    - "sign-source-packages-built-from-static-binaries"
    commands:
@@ -120,7 +120,7 @@ steps:
 
  - label: Build Monterey x86_64 bottles
    key: build-bottles-monterey-x86_64
-   if: build.tag =~ /^octez-v.*/
+   if: build.tag =~ /^v.*-1/
    agents:
      queue: "x86_64-rosetta-darwin"
    commands:
@@ -133,7 +133,7 @@ steps:
 
  - label: Build Monterey arm64 bottles
    key: build-bottles-monterey-arm64
-   if: build.tag =~ /^octez-v.*/
+   if: build.tag =~ /^v.*-1/
    agents:
      queue: "arm64-darwin"
    commands:
@@ -151,7 +151,7 @@ steps:
    depends_on:
    - "build-bottles-monterey-arm64"
    - "build-bottles-monterey-x86_64"
-   if: build.tag =~ /^octez-v.*/
+   if: build.tag =~ /^v.*-1/
    commands:
    - mkdir -p "Monterey"
    - nix develop .#buildkite -c gh release download "$BUILDKITE_TAG" -D "Monterey/" -p "*monterey.bottle.tar.gz"

--- a/.buildkite/pipeline-raw.yml
+++ b/.buildkite/pipeline-raw.yml
@@ -212,8 +212,8 @@ steps:
  - label: update stable mirror repository
    if: |
      build.branch == "master" &&
-       ( build.message =~ /^Merge pull request .* from serokell\/auto\/octez-v[0-9]+\.[0-9]+-release/ ||
-         build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-octez-v[.0-9]+-[0-9]+/ )
+       ( build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-release/ ||
+         build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-[0-9]+/ )
    depends_on:
    - "auto-release"
    env:
@@ -225,8 +225,8 @@ steps:
  - label: update RC mirror repository
    if: |
      build.branch == "master" &&
-       (build.message =~ /^Merge pull request .* from serokell\/auto\/octez-v[0-9]+\.[0-9]+-(rc|beta).*-release/ ||
-          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-octez-v[.0-9]+-(rc|beta).*/)
+       (build.message =~ /^Merge pull request .* from serokell\/auto\/v[0-9]+\.[0-9]+-(rc|beta).*-release/ ||
+          build.message =~ /^Merge pull request .* from serokell\/auto\/update-brew-formulae-v[.0-9]+-(rc|beta).*/)
    depends_on:
    - "auto-release"
    env:

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -19,7 +19,7 @@ then
                 os="${BASH_REMATCH[2]}"
                 formula_file="./Formula/$formula_name.rb"
                 if [[ -f $formula_file ]]; then
-                    formula_tag="octez-$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "$formula_file")"
+                    formula_tag="$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "$formula_file")"
                     line="\    sha256 cellar: :any, $os: \"$bottle_hash\""
                     # Update only when formula has the same version as provided current tag
                     if [[ "$formula_tag" == "$2" ]]; then

--- a/scripts/build-all-bottles.sh
+++ b/scripts/build-all-bottles.sh
@@ -32,7 +32,7 @@ for f in "${formulae[@]}"; do
     # build a bottle
     if ./scripts/build-one-bottle.sh "$f"; then
       # upload the bottle to its respective release
-      FORMULA_TAG="octez-$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "./Formula/$f.rb")"
+      FORMULA_TAG="$(sed -n "s/^\s\+version \"\(.*\)\"/\1/p" "./Formula/$f.rb")"
       if ! gh release upload "$FORMULA_TAG" "$f"*.bottle.*; then
         # we want a non-0 exit code if any of the bottles couldn't be uploaded
         retval="1";

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -7,9 +7,9 @@
 
 if [[ -d ./Formula ]]
 then
-    regex="((octez-|)(v.*))-([0-9]+)"
+    regex="(v.*)-[0-9]*"
     if [[ $1 =~ $regex ]]; then
-        tag="${BASH_REMATCH[3]}-${BASH_REMATCH[4]}"
+        tag="${BASH_REMATCH[0]}"
         version="${BASH_REMATCH[1]}"
         find ./Formula -type f \( -name 'tezos-*.rb' ! -name 'tezos-sapling-params.rb' \) \
             -exec sed -i "s/version \"v.*\"/version \"$tag\"/g" {} \; \

--- a/scripts/update-tezos.sh
+++ b/scripts/update-tezos.sh
@@ -26,7 +26,9 @@ cp script-inputs/active_protocol_versions_without_number ../docker/active-protoc
 cd ..
 rm -rf upstream-repo
 
-branch_name="auto/$latest_upstream_tag-release"
+packaging_tag="$([[ "$latest_upstream_tag" =~ octez-(v.*) ]] && echo "${BASH_REMATCH[1]}")"
+
+branch_name="auto/$packaging_tag-release"
 
 our_tezos_tag="$(jq -r '.tezos_ref' meta.json | cut -d'/' -f3)"
 
@@ -38,37 +40,37 @@ if [[ "$latest_upstream_tag" != "$our_tezos_tag" ]]; then
   # wasn't created
   if ! git rev-parse --verify "$branch_name"; then
     git switch -c "$branch_name"
-    echo "Updating Tezos to $latest_upstream_tag"
+    echo "Updating Tezos to $packaging_tag"
 
     ./scripts/update-input.py tezos "$latest_upstream_tag_hash"
     ./scripts/update-input.py opam-repository "$full_opam_repository_tag"
-    git commit -a -m "[Chore] Bump Tezos sources to $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io"
+    git commit -a -m "[Chore] Bump Tezos sources to $packaging_tag" --gpg-sign="tezos-packaging@serokell.io"
 
-    ./scripts/update-brew-formulae.sh "$latest_upstream_tag-1"
-    git commit -a -m "[Chore] Update brew formulae for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io"
+    ./scripts/update-brew-formulae.sh "$packaging_tag-1"
+    git commit -a -m "[Chore] Update brew formulae for $packaging_tag" --gpg-sign="tezos-packaging@serokell.io"
 
     sed -i 's/"release": "[0-9]\+"/"release": "1"/' ./meta.json
     # Update version of tezos-baking package
-    sed -i "s/version = .*/version = \"$latest_upstream_tag\"/" ./baking/pyproject.toml
+    sed -i "s/version = .*/version = \"$packaging_tag\"/" ./baking/pyproject.toml
     # Commit may fail when release number wasn't updated since the last release
-    git commit -a -m "[Chore] Reset release number for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+    git commit -a -m "[Chore] Reset release number for $packaging_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       (true; echo "release number wasn't updated")
 
     sed -i 's/letter_version *= *"[a-z]"/letter_version = ""/' ./docker/package/model.py
     # Commit may fail when the letter version wasn't updated since the last release
-    git commit -a -m "[Chore] Reset letter_version for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+    git commit -a -m "[Chore] Reset letter_version for $packaging_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       (true; echo "letter_version wasn't reset")
 
     ./scripts/update-release-binaries.py
     pushd docker
     python3 -m package.update-test-binaries-list
     popd
-    git commit -a -m "[Chore] Update release binaries for $latest_upstream_tag" --gpg-sign="tezos-packaging@serokell.io" || \
+    git commit -a -m "[Chore] Update release binaries for $packaging_tag" --gpg-sign="tezos-packaging@serokell.io" || \
       (true; echo "lists of binaries and protocols weren't updated")
 
     git push --set-upstream origin "$branch_name"
 
-    gh pr create -B master -t "[Chore] $latest_upstream_tag release" -F .github/release_pull_request_template.md
+    gh pr create -B master -t "[Chore] $packaging_tag release" -F .github/release_pull_request_template.md
   fi
 else
   echo "Our version is the same as the latest tag in the upstream repository"

--- a/tests/bottle-hashes/test-hash-insert.sh
+++ b/tests/bottle-hashes/test-hash-insert.sh
@@ -39,7 +39,7 @@ monterey_bottle="$formula_name-v0.0-0.monterey.bottle.tar.gz"
 dd if=/dev/urandom of=$bottle_dir/$monterey_bottle count=2000 status=none
 
 # Run the hash inserting script
-../../scripts/bottle-hashes.sh "$bottle_dir" "octez-v0.0-1"
+../../scripts/bottle-hashes.sh "$bottle_dir" "v0.0-1"
 
 # Assert the info was inserted correctly
 monterey_hash="$(sha256sum $bottle_dir/$monterey_bottle | cut -d " " -f 1)"


### PR DESCRIPTION

## Description

Problem: new octez releases come with `octez-` prepended to the tag. It doesn't make sense for us to follow this style.

Solution: Strip the prefix and leave only relevant part of tag for us.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
