### PR TITLE
[Chore] Add 'PtParisC' to 'protocol_numbers'

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -33,6 +33,7 @@ protocol_numbers = {
     "PtNairob": "017",
     "Proxford": "018",
     "PtParisB": "019",
+    "PtParisC": "020",
 }
 
 signer_units = [


### PR DESCRIPTION
## Description
Problem: A scheduled job that is supposed to create auto-release on the new Octez release has failed due to an unknown protocol name in 'protocol_numbers'.

Solution: Manually add 'PtParisC' to 'protocol_numbers' with the value '20' (see
https://gitlab.com/tezos/tezos/-/tree/master/src/proto_020_PsParisC).
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
