### PR TITLE
[#759] Handle testnet config unavailability

### DIFF
--- a/tests/systemd/Vagrantfile
+++ b/tests/systemd/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "generic/ubuntu2004"
   config.vm.provision "shell", run: "once", inline: <<-SHELL
     add-apt-repository -y ppa:serokell/tezos && apt-get update
-    apt-get install -y tezos-sapling-params acl python3-pystemd python3-pytest python3-psutil
+    apt-get install -y tezos-sapling-params acl python3-pystemd python3-pytest python3-psutil jq
   SHELL
   config.vm.provision "file", run: "always", source: "#{packagesDirectory}", destination: "$HOME/out"
   config.vm.provision "file", run: "always", source: "services_tests.py", destination: "$HOME/services_tests.py"


### PR DESCRIPTION
## Description

Problem: testnets usually stop working abruptly. Since `tezos-node` installation process depends on the testnet config being available on certain urls, it fails with error if it can't download one.

Solution: Download list of available testnets at first. Create node configuration only if testnet is still available. Fail the install if `teztnets.json` is not avaialable for download.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
