### PR TITLE
[Chore] Add 'PsquebeC' to 'protocol_numbers'

### DIFF
--- a/docker/package/packages.py
+++ b/docker/package/packages.py
@@ -32,6 +32,7 @@ protocol_numbers = {
     "Proxford": "018",
     "PtParisB": "019",
     "PsParisC": "020",
+    "PsquebeC": "021",
 }
 
 signer_units = [


### PR DESCRIPTION
Problem: A scheduled job that is supposed to create auto-release on the new Octez release has failed due to an unknown protocol name in 'protocol_numbers'.

Solution: Manually add 'PsquebeC' to 'protocol_numbers' with value '21' (see https://gitlab.com/tezos/tezos/-/tree/master/src/proto_021_PsquebeC).

- [x] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [x] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
