### PR TITLE
[Chore] Remove unused imports

### DIFF
--- a/docker/package/__init__.py
+++ b/docker/package/__init__.py
@@ -1,6 +1,3 @@
 # SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
 #
 # SPDX-License-Identifier: LicenseRef-MIT-TQ
-
-from .systemd import print_service_file
-from .packages import packages

--- a/gen_systemd_service_file.py
+++ b/gen_systemd_service_file.py
@@ -7,7 +7,8 @@
 # Note: if you modify this file, check if its usage in docs/systemd.md
 # needs to be updated too.
 
-from docker.package import *
+from docker.package.packages import packages
+from docker.package.systemd import print_service_file
 import sys
 
 if len(sys.argv) > 1:


### PR DESCRIPTION
## Description

Problem: `__init__.py` script gets run every time
we run other scripts from that package. It results in error sometimes, since code inside `packages.py` is not ready to run yet.

Solution: Remove unused imports.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
