### PR TITLE
[Chore] Add bottle hashes for v20.3-1

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ { id: macos-12, name: "monterey" } ]
+        os: [ { id: macos-13, name: "ventura" } ]
         # we don't bottle meta-formulas that contain only services
         formula: [tezos-smart-rollup-wasm-debugger, tezos-smart-rollup-node, tezos-dac-client, tezos-dac-node, tezos-dal-node, tezos-signer, tezos-codec, tezos-client, tezos-admin-client, tezos-node, tezos-accuser-PsParisC, tezos-baker-PsParisC, tezos-accuser-PtParisB, tezos-baker-PtParisB, tezos-accuser-Proxford, tezos-baker-Proxford]
     steps:
@@ -54,7 +54,7 @@ jobs:
         if: steps.check-built.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: homebrew-bottles-${{ matrix.os }}
+          name: ${{ matrix.formula }}-${{ github.run_id }}
           path: '*.bottle.*'
 
       - name: Attach the bottle to the release
@@ -64,7 +64,7 @@ jobs:
         run: gh release upload "${{ env.tag }}" *.bottle.*
 
   sync-hashes:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build-bottles
     steps:
       - name: Checkout
@@ -86,12 +86,12 @@ jobs:
 
        # It's possible we have had to rerun the building workflow, skipping some jobs and
        # erasing the previously built bottles, so we use the release to download them all
-      - name: Download Monterey bottles from the release
+      - name: Download Ventura bottles from the release
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh release download "${{ github.ref_name }}" -p "*.monterey.bottle.tar.gz" -D "./Monterey"
+        run: gh release download "${{ github.ref_name }}" -p "*.ventura.bottle.tar.gz" -D "./Ventura"
 
       - name: Add bottle hashes to formulae
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: ./scripts/sync-bottle-hashes.sh "${{ github.ref_name }}" "Monterey"
+        run: ./scripts/sync-bottle-hashes.sh "${{ github.ref_name }}" "Ventura"

--- a/Formula/tezos-accuser-PsParisC.rb
+++ b/Formula/tezos-accuser-PsParisC.rb
@@ -26,6 +26,7 @@ class TezosAccuserPsparisc < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuserPsparisc.version}/"
+    sha256 cellar: :any, ventura: "490aa62c6fa8b5502578f677ee4d0e8993212cc59f34546b50a6b787d15986bd"
   end
 
   def make_deps

--- a/Formula/tezos-accuser-PtParisB.rb
+++ b/Formula/tezos-accuser-PtParisB.rb
@@ -26,6 +26,7 @@ class TezosAccuserPtparisb < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAccuserPtparisb.version}/"
+    sha256 cellar: :any, ventura: "b8f6cb6a21cf2cf703cfdf61cf259414a5c6f7bfa950fc6470ff56c08ff9fe49"
   end
 
   def make_deps

--- a/Formula/tezos-admin-client.rb
+++ b/Formula/tezos-admin-client.rb
@@ -26,6 +26,7 @@ class TezosAdminClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosAdminClient.version}/"
+    sha256 cellar: :any, ventura: "5ba0c3cc55109cbafa9462d5371b6fbb62e57d5df14ef8315cfc584e65aa5c07"
   end
 
   def make_deps

--- a/Formula/tezos-baker-PsParisC.rb
+++ b/Formula/tezos-baker-PsParisC.rb
@@ -26,6 +26,7 @@ class TezosBakerPsparisc < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBakerPsparisc.version}/"
+    sha256 cellar: :any, ventura: "e8b61dc8a01d2de538c89bb6e020df81e6d64f2ede819a62fe5d0230efbc6b33"
   end
 
   def make_deps

--- a/Formula/tezos-baker-PtParisB.rb
+++ b/Formula/tezos-baker-PtParisB.rb
@@ -26,6 +26,7 @@ class TezosBakerPtparisb < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosBakerPtparisb.version}/"
+    sha256 cellar: :any, ventura: "8836c1c1d5f4d7e0c8777b953e1a7e0d028ce686a84e1acd402e09420ba09009"
   end
 
   def make_deps

--- a/Formula/tezos-client.rb
+++ b/Formula/tezos-client.rb
@@ -26,6 +26,7 @@ class TezosClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosClient.version}/"
+    sha256 cellar: :any, ventura: "4efb6f382cecbd3cb51a42f8ec32c94e030212a4339294fb61eff120817b855f"
   end
 
   def make_deps

--- a/Formula/tezos-codec.rb
+++ b/Formula/tezos-codec.rb
@@ -26,6 +26,7 @@ class TezosCodec < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosCodec.version}/"
+    sha256 cellar: :any, ventura: "7332ca78fd2aa4f91694629c278a9be92b381e16d89e49e8c5a2d75ea658446e"
   end
 
   def make_deps

--- a/Formula/tezos-dac-client.rb
+++ b/Formula/tezos-dac-client.rb
@@ -26,6 +26,7 @@ class TezosDacClient < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosDacClient.version}/"
+    sha256 cellar: :any, ventura: "5049f227af507b9e9c1daad5f712b7f557b0034d743952c9f3f0994c2e54541e"
   end
 
   def make_deps

--- a/Formula/tezos-dac-node.rb
+++ b/Formula/tezos-dac-node.rb
@@ -26,6 +26,7 @@ class TezosDacNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosDacNode.version}/"
+    sha256 cellar: :any, ventura: "71efd560049626a0dbb7e0a47d46c8d379d75a0c0eee1d93bf6a0210af267266"
   end
 
   def make_deps

--- a/Formula/tezos-dal-node.rb
+++ b/Formula/tezos-dal-node.rb
@@ -26,6 +26,7 @@ class TezosDalNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosDalNode.version}/"
+    sha256 cellar: :any, ventura: "28e1064941f25d217c1f782aa814f9cfbde6c8ad0fc914dd7a15ee4ab4c08252"
   end
 
   def make_deps

--- a/Formula/tezos-node.rb
+++ b/Formula/tezos-node.rb
@@ -26,6 +26,7 @@ class TezosNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosNode.version}/"
+    sha256 cellar: :any, ventura: "fb0bac1a458ee6821591e180ec8cf9e54afea1927d43070ee1443cf8f5399304"
   end
 
   def make_deps

--- a/Formula/tezos-signer.rb
+++ b/Formula/tezos-signer.rb
@@ -26,6 +26,7 @@ class TezosSigner < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSigner.version}/"
+    sha256 cellar: :any, ventura: "5cc06d5b860d4e8c2084f324d977e38cbee4a8671c5a8470ac41a8ebaafe5aa3"
   end
 
   def make_deps

--- a/Formula/tezos-smart-rollup-node.rb
+++ b/Formula/tezos-smart-rollup-node.rb
@@ -28,6 +28,7 @@ class TezosSmartRollupNode < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSmartRollupNode.version}/"
+    sha256 cellar: :any, ventura: "d063c53cf47ece2ebe64b2221340c05cbca1094e7beaa0dc4ed4d246ab7b0afd"
   end
 
   def make_deps

--- a/Formula/tezos-smart-rollup-wasm-debugger.rb
+++ b/Formula/tezos-smart-rollup-wasm-debugger.rb
@@ -27,6 +27,7 @@ class TezosSmartRollupWasmDebugger < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosSmartRollupWasmDebugger.version}/"
+    sha256 cellar: :any, ventura: "8afc3d417f115d99df4d9790da280b1f92c09864b9be56d07f1cb8533cf36b62"
   end
 
   def make_deps

--- a/docs/support-policy.md
+++ b/docs/support-policy.md
@@ -46,10 +46,4 @@ There are packages for `x86_64` and `aarch64` architectures.
 ## macOS brew formulae
 
 Brew formulae provided by `tezos-packaging` aim to support all maintained macOS versions, currently:
-* macOS 12 (Monterey)
 * macOS 13 (Ventura)
-
-Unfortunately, the ability to provide pre-compiled brew bottles for formulae has
-a hard dependency on the available build infrastructure.
-Thus we currently only provide brew bottles for the following macOS versions:
-* macOS 12 (Monterey) both `x86_64` and `arm64`

--- a/scripts/bottle-hashes.sh
+++ b/scripts/bottle-hashes.sh
@@ -11,7 +11,7 @@ if [[ -d ./Formula ]]
 then
     if [[ -d "$1" ]]
     then
-        regex="(tezos-.*)-v.*\.(monterey|arm64_monterey)\.bottle\.tar\.gz"
+        regex="(tezos-.*)-v.*\.(ventura|arm64_ventura)\.bottle\.tar\.gz"
         for bottle in "$1"/tezos-*.bottle.tar.gz; do
             if [[ $bottle =~ $regex ]]; then
                 bottle_hash=$(sha256sum "$bottle" | cut -d " " -f 1)

--- a/scripts/update-brew-formulae.sh
+++ b/scripts/update-brew-formulae.sh
@@ -12,10 +12,8 @@ then
     find ./Formula -type f \( -name 'tezos-*.rb' ! -name 'tezos-sapling-params.rb' \) \
         -exec sed -i "s/version \"v.*\"/version \"$version\"/g" {} \; \
         -exec sed -i "s/:tag => \".*\"/:tag => \"$tag\"/g" {} \; \
-        -exec sed -i "/catalina/d" {} \; \
-        -exec sed -i "/monterey/d" {} \; \
-        -exec sed -i "/arm64_monterey/d" {} \; \
-        -exec sed -i "/mojave/d" {} \;
+        -exec sed -i "/ventura/d" {} \; \
+        -exec sed -i "/arm64_ventura/d" {} \;
 else
     echo "Please run this script from the base directory (tezos-packaging)."
 fi

--- a/tests/bottle-hashes/test-hash-insert.sh
+++ b/tests/bottle-hashes/test-hash-insert.sh
@@ -33,16 +33,16 @@ class TezosHashTest < Formula
 end
 EOL
 
-monterey_bottle="$formula_name-v0.0-0.monterey.bottle.tar.gz"
+ventura_bottle="$formula_name-v0.0-0.ventura.bottle.tar.gz"
 
 # Generate some dummy bottles
-dd if=/dev/urandom of=$bottle_dir/$monterey_bottle count=2000 status=none
+dd if=/dev/urandom of=$bottle_dir/$ventura_bottle count=2000 status=none
 
 # Run the hash inserting script
 ../../scripts/bottle-hashes.sh "$bottle_dir" "v0.0-1"
 
 # Assert the info was inserted correctly
-monterey_hash="$(sha256sum $bottle_dir/$monterey_bottle | cut -d " " -f 1)"
+ventura_hash="$(sha256sum $bottle_dir/$ventura_bottle | cut -d " " -f 1)"
 
 expected_formula=$(cat << EOF
 class TezosHashTest < Formula
@@ -56,7 +56,7 @@ class TezosHashTest < Formula
 
   bottle do
     root_url "https://github.com/serokell/tezos-packaging/releases/download/#{TezosHashTest.version}/"
-    sha256 cellar: :any, monterey: "$monterey_hash"
+    sha256 cellar: :any, ventura: "$ventura_hash"
   end
 
   def install


### PR DESCRIPTION
## Description

Problem: we have built brew bottles for the new Octez release, but their hashes
aren't in the formulae yet.

Solution: added the hashes.
## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #

#### Related changes (conditional)

- [ ] I checked whether I should update the [README](/serokell/tezos-packaging/tree/master/README.md)

- [ ] I checked whether native packaging works, i.e. native binary packages
  can be successfully built.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
